### PR TITLE
Change `ScriptableObject` to `TopLevel` to avoid churn later.

### DIFF
--- a/examples/src/main/java/Control.java
+++ b/examples/src/main/java/Control.java
@@ -8,6 +8,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Example of controlling the JavaScript execution engine.
@@ -32,7 +33,7 @@ public class Control {
 
             // Initialize the standard objects (Object, Function, etc.)
             // This must be done before scripts can be executed.
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // Now we can evaluate a script. Let's create a new object
             // using the object literal notation.

--- a/examples/src/main/java/CounterTest.java
+++ b/examples/src/main/java/CounterTest.java
@@ -7,6 +7,7 @@
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * An example illustrating how to create a JavaScript object and retrieve properties and call
@@ -62,7 +63,7 @@ public class CounterTest {
     public static void main(String[] args) throws Exception {
         Context cx = Context.enter();
         try {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             ScriptableObject.defineClass(scope, Counter.class);
 
             Scriptable testCounter = cx.newObject(scope, "Counter");

--- a/examples/src/main/java/DynamicScopes.java
+++ b/examples/src/main/java/DynamicScopes.java
@@ -8,7 +8,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /** Example of controlling the JavaScript with multiple scopes and threads. */
 public class DynamicScopes {
@@ -85,7 +85,7 @@ public class DynamicScopes {
         // Initialize the standard objects (Object, Function, etc.)
         // This must be done before scripts can be executed. The call
         // returns a new scope that we will share.
-        ScriptableObject sharedScope = cx.initStandardObjects(null, true);
+        TopLevel sharedScope = cx.initStandardObjects(null, true);
 
         // Now we can execute the precompiled script against the scope
         // to define x variable and f function in the shared scope.

--- a/examples/src/main/java/RunScript.java
+++ b/examples/src/main/java/RunScript.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * RunScript: simplest example of controlling execution of Rhino.
@@ -54,7 +54,7 @@ public class RunScript {
             // Initialize the standard objects (Object, Function, etc.)
             // This must be done before scripts can be executed. Returns
             // a scope object that we use in later calls.
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // Collect the arguments into a single string.
             String s = "";

--- a/examples/src/main/java/RunScript2.java
+++ b/examples/src/main/java/RunScript2.java
@@ -5,8 +5,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * RunScript2: Like RunScript, but reflects the System.out into JavaScript.
@@ -53,7 +53,7 @@ public class RunScript2 {
     public static void main(String args[]) {
         Context cx = Context.enter();
         try {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // Add a global variable "out" that is a JavaScript reflection
             // of System.out

--- a/examples/src/main/java/RunScript3.java
+++ b/examples/src/main/java/RunScript3.java
@@ -7,6 +7,7 @@
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * RunScript3: Example of using JavaScript objects
@@ -69,7 +70,7 @@ public class RunScript3 {
     public static void main(String args[]) {
         Context cx = Context.enter();
         try {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // Collect the arguments into a single string.
             String s = "";

--- a/examples/src/main/java/RunScript4.java
+++ b/examples/src/main/java/RunScript4.java
@@ -7,6 +7,7 @@
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * RunScript4: Execute scripts in an environment that includes the example Counter class.
@@ -69,7 +70,7 @@ public class RunScript4 {
     public static void main(String args[]) throws Exception {
         Context cx = Context.enter();
         try {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // Use the Counter class to define a Counter constructor
             // and prototype in JavaScript.

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 /**
@@ -29,20 +30,21 @@ public class Builtins {
 
     private Writer stdout;
 
-    void register(Context cx, ScriptableObject scope, ScriptContext sc) {
+    void register(Context cx, TopLevel scope, ScriptContext sc) {
         if (sc.getWriter() == null) {
             stdout = new OutputStreamWriter(System.out, StandardCharsets.UTF_8);
         } else {
             stdout = sc.getWriter();
         }
 
-        scope.defineProperty(
-                scope,
-                "print",
-                0,
-                Builtins::print,
-                ScriptableObject.PERMANENT | ScriptableObject.DONTENUM,
-                ScriptableObject.DONTENUM | ScriptableObject.READONLY);
+        scope.getGlobalThis()
+                .defineProperty(
+                        scope,
+                        "print",
+                        0,
+                        Builtins::print,
+                        ScriptableObject.PERMANENT | ScriptableObject.DONTENUM,
+                        ScriptableObject.DONTENUM | ScriptableObject.READONLY);
     }
 
     private static Object print(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {

--- a/rhino-xml/src/test/java/org/mozilla/javascript/tests/XMLSecureParserTest.java
+++ b/rhino-xml/src/test/java/org/mozilla/javascript/tests/XMLSecureParserTest.java
@@ -12,7 +12,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Test for secure xml parsing
@@ -121,7 +121,7 @@ public class XMLSecureParserTest {
     }
 
     private void executeXML(Context cx) {
-        Scriptable scope = cx.initStandardObjects();
+        TopLevel scope = cx.initStandardObjects();
         cx.evaluateString(scope, "new XML('<a></a>').toXMLString();", "source", 1, null);
     }
 

--- a/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/XmlNonResettableDocumentBuilderTest.java
+++ b/rhino-xml/src/test/java/org/mozilla/javascript/xmlimpl/tests/XmlNonResettableDocumentBuilderTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 public class XmlNonResettableDocumentBuilderTest {
     private static final String XML_PROPERTY = "javax.xml.parsers.DocumentBuilderFactory";
@@ -29,7 +29,7 @@ public class XmlNonResettableDocumentBuilderTest {
     @Test
     public void nonResettableDocumentBuilder() {
         try (Context cx = new ContextFactory().enterContext()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             Object result =
                     cx.evaluateString(
                             scope,

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1075,7 +1075,7 @@ public class Context implements Closeable {
      *
      * @return the initialized scope
      */
-    public final ScriptableObject initSafeStandardObjects() {
+    public final TopLevel initSafeStandardObjects() {
         return initSafeStandardObjects(null, false);
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
@@ -80,7 +80,7 @@ public class DebuggerTest {
         MockDebugger debugger = new MockDebugger();
         MockDebugFrame frame = MockDebugger.getFrame();
         Context cx = Context.enter();
-        Scriptable scope = cx.initSafeStandardObjects();
+        TopLevel scope = cx.initSafeStandardObjects();
         try {
             cx.setDebugger(debugger, cx);
             cx.setGeneratingSource(true);

--- a/rhino/src/test/java/org/mozilla/javascript/EqualObjectGraphsTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/EqualObjectGraphsTest.java
@@ -82,7 +82,7 @@ public class EqualObjectGraphsTest {
     public void heterogenousScriptables() {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_DEFAULT);
-            ScriptableObject top = cx.initStandardObjects();
+            TopLevel top = cx.initStandardObjects();
             ScriptRuntime.doTopCall(
                     (Callable)
                             (c, scope, thisObj, args) -> {
@@ -105,7 +105,7 @@ public class EqualObjectGraphsTest {
     }
 
     private static Object makeHeterogenousScriptable(Context cx, String discriminator) {
-        ScriptableObject global = cx.initStandardObjects();
+        TopLevel global = cx.initStandardObjects();
         ScriptableObject s = (ScriptableObject) cx.newObject(global);
         s.put(0, s, "i0");
         s.put(1, s, "i1");

--- a/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/HoistingTest.java
@@ -202,7 +202,7 @@ public class HoistingTest {
                     int languageVersion = cx.getLanguageVersion();
                     try {
                         cx.setLanguageVersion(Context.VERSION_ES6);
-                        Scriptable scope = cx.initStandardObjects();
+                        TopLevel scope = cx.initStandardObjects();
                         String script =
                                 ""
                                         + "var arr_obj = [];\n"

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
@@ -24,7 +24,7 @@ public class ScriptRuntimeEvalSpecialTest {
     private static void canUseEvalSpecialWithThisSetTo(Object thisArg) {
         Utils.runWithAllModes(
                 cx -> {
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     Object o =
                             ScriptRuntime.evalSpecial(
                                     cx, scope, thisArg, new Object[] {"true"}, "", 0);

--- a/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SuperTest.java
@@ -1160,7 +1160,7 @@ class SuperTest {
 
             try (Context cx = Context.enter()) {
                 cx.setLanguageVersion(Context.VERSION_ES6);
-                ScriptableObject scope = cx.initStandardObjects();
+                TopLevel scope = cx.initStandardObjects();
 
                 cx.setInterpretedMode(true);
                 cx.evaluateString(scope, script, "test", 1, null);

--- a/rhino/src/test/java/org/mozilla/javascript/ThreadSafeScriptableObjectTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ThreadSafeScriptableObjectTest.java
@@ -13,7 +13,7 @@ public class ThreadSafeScriptableObjectTest {
                         Utils.contextFactoryWithFeatures(Context.FEATURE_THREAD_SAFE_OBJECTS));
 
         try (Context cx = Context.enter()) {
-            ScriptableObject global = cx.initStandardObjects();
+            TopLevel global = cx.initStandardObjects();
             global.sealObject();
 
             // Registered by NativeJavaTopPackage

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ApplyOnPrimitiveNumberTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ApplyOnPrimitiveNumberTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -26,7 +26,7 @@ public class ApplyOnPrimitiveNumberTest {
 
         Utils.runWithAllModes(
                 _cx -> {
-                    final ScriptableObject scope = _cx.initStandardObjects();
+                    TopLevel scope = _cx.initStandardObjects();
                     final Object result = _cx.evaluateString(scope, script, "test script", 0, null);
                     assertEquals("object", ScriptRuntime.typeof(result));
                     assertEquals("1", Context.toString(result));

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AssignSubclassTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class AssignSubclassTest {
@@ -13,7 +14,7 @@ public class AssignSubclassTest {
     public void basicOperations() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         ScriptableObject.defineClass(scope, MySubclass.class);
                     } catch (Exception e) {
@@ -45,7 +46,7 @@ public class AssignSubclassTest {
     public void assign() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         ScriptableObject.defineClass(scope, MySubclass.class);
                     } catch (Exception e) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/AvoidObjectDetectionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/AvoidObjectDetectionTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /** There is some special handling for document.all */
 public class AvoidObjectDetectionTest {
@@ -50,7 +51,7 @@ public class AvoidObjectDetectionTest {
         final ContextFactory factory = new ContextFactory();
 
         try (Context cx = factory.enterContext()) {
-            final ScriptableObject topScope = cx.initStandardObjects();
+            TopLevel topScope = cx.initStandardObjects();
             ScriptableObject.defineClass(topScope, Foo.class);
             ScriptableObject.defineClass(topScope, Avoid.class);
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug448816Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug448816Test.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=448816
@@ -37,7 +37,7 @@ public class Bug448816Test {
         reference.put(Integer.valueOf(1), Integer.valueOf(42));
         // get a js object as map
         try (Context context = Context.enter()) {
-            ScriptableObject scope = context.initStandardObjects();
+            TopLevel scope = context.initStandardObjects();
             map =
                     (Map<Object, Object>)
                             context.evaluateString(

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug466207Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug466207Test.java
@@ -20,7 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * See https://bugzilla.mozilla.org/show_bug.cgi?id=466207
@@ -44,7 +44,7 @@ public class Bug466207Test {
         // get a js object as map
 
         try (Context context = Context.enter()) {
-            ScriptableObject scope = context.initStandardObjects();
+            TopLevel scope = context.initStandardObjects();
             list =
                     (List<Object>)
                             context.evaluateString(
@@ -190,7 +190,7 @@ public class Bug466207Test {
 
     private void listPop() {
         try (Context context = Context.enter()) {
-            ScriptableObject scope = context.initStandardObjects();
+            TopLevel scope = context.initStandardObjects();
             scope.put("list", scope, list);
             context.evaluateString(scope, "list.pop()", "testsrc", 1, null);
         }
@@ -199,7 +199,7 @@ public class Bug466207Test {
     @Test
     public void bigList() {
         try (Context context = Context.enter()) {
-            ScriptableObject scope = context.initStandardObjects();
+            TopLevel scope = context.initStandardObjects();
             NativeArray array =
                     (NativeArray)
                             context.evaluateString(

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug467396Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug467396Test.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;
 
 /**
@@ -24,7 +24,7 @@ public class Bug467396Test {
     @Test
     public void overloadedVarargs() {
         try (Context cx = ContextFactory.getGlobal().enterContext()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             Object result =
                     unwrap(
                             cx.evaluateString(

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug482203Test.java
@@ -11,8 +11,8 @@ import org.junit.Test;
 import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 public class Bug482203Test {
 
@@ -23,7 +23,7 @@ public class Bug482203Test {
             InputStreamReader in =
                     new InputStreamReader(Bug482203Test.class.getResourceAsStream("Bug482203.js"));
             Script script = cx.compileReader(in, "", 1, null);
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             script.exec(cx, scope, scope);
             int counter = 0;
             for (; ; ) {
@@ -46,7 +46,7 @@ public class Bug482203Test {
             InputStreamReader in =
                     new InputStreamReader(Bug482203Test.class.getResourceAsStream("Bug482203.js"));
             Script script = cx.compileReader(in, "", 1, null);
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             cx.executeScriptWithContinuations(script, scope);
             int counter = 0;
             for (; ; ) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug685403Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug685403Test.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * @author André Bargull
@@ -23,7 +24,7 @@ import org.mozilla.javascript.ScriptableObject;
 public class Bug685403Test {
 
     private Context cx;
-    private ScriptableObject scope;
+    private TopLevel scope;
 
     @Before
     public void setUp() {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug782363Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug782363Test.java
@@ -25,7 +25,7 @@ import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSDescriptor;
 import org.mozilla.javascript.Parser;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -154,7 +154,7 @@ public class Bug782363Test {
         }
         sb.append("}; F()");
 
-        ScriptableObject scope = cx.initStandardObjects();
+        TopLevel scope = cx.initStandardObjects();
         Object ret = cx.evaluateString(scope, sb.toString(), "<eval>", 1, null);
         assertTrue(ret instanceof Number);
         assertEquals(expected, ((Number) ret).doubleValue(), 0);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Bug783797Test.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
 /**
@@ -21,7 +20,7 @@ import org.mozilla.javascript.TopLevel;
 public class Bug783797Test {
 
     private interface Action {
-        void run(Context cx, ScriptableObject scope1, ScriptableObject scope2);
+        void run(Context cx, TopLevel scope1, TopLevel scope2);
     }
 
     private static ContextAction<Void> action(final String fn, final Action a) {
@@ -57,8 +56,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope1, "String.prototype.foo = 'scope1'");
                                 eval(cx, scope2, "String.prototype.foo = 'scope2'");
 
@@ -81,8 +79,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope1, "String.prototype.foo = 'scope1'");
                                 eval(cx, scope2, "String.prototype.foo = 'scope2'");
 
@@ -105,8 +102,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope1, "String.prototype.foo = 'scope1'");
 
                                 assertFALSE(eval(cx, scope2, "test()"));
@@ -126,8 +122,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope2, "String.prototype.foo = 'scope2'");
 
                                 assertTRUE(eval(cx, scope2, "test()"));
@@ -147,8 +142,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code +=
@@ -177,8 +171,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code +=
@@ -207,8 +200,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code +=
@@ -237,8 +229,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code +=
@@ -267,8 +258,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code +=
@@ -297,8 +287,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code += "String.prototype.d = 0;";
@@ -331,8 +320,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 String code = "";
                                 code += "String.prototype.c = 0;";
                                 code += "String.prototype.d = 0;";
@@ -365,8 +353,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope1, "String.prototype.foo = 'scope1'");
                                 eval(cx, scope2, "String.prototype.foo = 'scope2'");
 
@@ -389,8 +376,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(
                                         cx,
                                         scope1,
@@ -419,8 +405,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(
                                         cx,
                                         scope1,
@@ -450,8 +435,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope1, "String.prototype.foo = 'scope1'");
 
                                 assertFALSE(eval(cx, scope2, "test()"));
@@ -472,8 +456,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 eval(cx, scope2, "String.prototype.foo = 'scope1'");
 
                                 assertTRUE(eval(cx, scope2, "test()"));
@@ -493,8 +476,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertSame(scope2, eval(cx, scope2, "test.__parent__"));
                                 assertSame(scope2, eval(cx, scope1, "scope2.test.__parent__"));
                                 assertSame(
@@ -512,8 +494,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 var globalThis1 = ((TopLevel) scope1).getGlobalThis();
                                 var globalThis2 = ((TopLevel) scope2).getGlobalThis();
                                 assertSame(globalThis2, eval(cx, scope2, "test()"));
@@ -536,8 +517,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 var globalThis = ((TopLevel) scope2).getGlobalThis();
                                 assertSame(globalThis, eval(cx, scope2, "test()"));
                                 assertSame(globalThis, eval(cx, scope2, "test.call(null)"));
@@ -559,8 +539,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 var globalThis1 = ((TopLevel) scope1).getGlobalThis();
                                 var globalThis2 = ((TopLevel) scope2).getGlobalThis();
                                 assertSame(globalThis2, eval(cx, scope2, "test()"));
@@ -597,8 +576,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));
@@ -630,8 +608,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));
@@ -663,8 +640,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));
@@ -696,8 +672,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));
@@ -729,8 +704,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));
@@ -762,8 +736,7 @@ public class Bug783797Test {
                         fn,
                         new Action() {
                             @Override
-                            public void run(
-                                    Context cx, ScriptableObject scope1, ScriptableObject scope2) {
+                            public void run(Context cx, TopLevel scope1, TopLevel scope2) {
                                 assertTRUE(eval(cx, scope2, "String.prototype === test()"));
                                 assertTRUE(
                                         eval(cx, scope2, "String.prototype === test.call(null)"));

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CatchTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CatchTest.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 public class CatchTest {
     public static class Foo extends ScriptableObject {
@@ -54,7 +55,7 @@ public class CatchTest {
                     if (shutter != null) {
                         context.setClassShutter(shutter);
                     }
-                    final Scriptable scope = context.initStandardObjects();
+                    TopLevel scope = context.initStandardObjects();
 
                     try {
                         ScriptableObject.defineClass(scope, Foo.class);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ClassShutterExceptionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ClassShutterExceptionTest.java
@@ -12,7 +12,7 @@ import org.mozilla.javascript.ClassShutter;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * @author Norris Boyd
@@ -32,7 +32,7 @@ public class ClassShutterExceptionTest {
         try (Context cx = Context.enter()) {
             Context.ClassShutterSetter setter = cx.getClassShutterSetter();
             try {
-                Scriptable globalScope = cx.initStandardObjects();
+                TopLevel globalScope = cx.initStandardObjects();
                 if (setter == null) {
                     setter = classShutterSetter;
                 } else {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
@@ -10,7 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.JSScript;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.optimizer.OptJSCode;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -96,7 +96,7 @@ public class CodegenTest {
 
         Utils.runWithAllModes(
                 _cx -> {
-                    final Scriptable scope = _cx.initStandardObjects();
+                    TopLevel scope = _cx.initStandardObjects();
                     Assert.assertEquals(
                             1000d,
                             (double)

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ConsStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ConsStringTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mozilla.javascript.ConsString;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.annotations.JSFunction;
 
 public class ConsStringTest {
@@ -57,7 +58,7 @@ public class ConsStringTest {
     @Test
     public void doNotLeakConsStringIntoSetter() throws Exception {
         try (Context cx = Context.enter()) {
-            final ScriptableObject topScope = cx.initStandardObjects();
+            TopLevel topScope = cx.initStandardObjects();
             final MyHostObject myHostObject = new MyHostObject();
 
             // define custom getter method
@@ -79,7 +80,7 @@ public class ConsStringTest {
     @Test
     public void doNotLeakConsStringIntoFunction() throws Exception {
         try (Context cx = Context.enter()) {
-            final ScriptableObject topScope = cx.initStandardObjects();
+            TopLevel topScope = cx.initStandardObjects();
             ScriptableObject.defineClass(topScope, MyHostObject.class);
 
             final String script = "var a = 'Rhino'; new MyHostObject().test('#' + a);";

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CustomSetterAcceptNullScriptableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CustomSetterAcceptNullScriptableTest.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Takes care that it's possible to set <code>null</code> value when using custom setter for a
@@ -47,7 +48,7 @@ public class CustomSetterAcceptNullScriptableTest {
         final ContextFactory factory = new ContextFactory();
 
         try (Context cx = factory.enterContext()) {
-            final ScriptableObject topScope = cx.initStandardObjects();
+            TopLevel topScope = cx.initStandardObjects();
             final Foo foo = new Foo();
 
             // define custom setter method

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DefineClassMapInheritance.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DefineClassMapInheritance.java
@@ -10,6 +10,7 @@ import java.lang.reflect.InvocationTargetException;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 @SuppressWarnings("serial")
 public class DefineClassMapInheritance {
@@ -29,7 +30,7 @@ public class DefineClassMapInheritance {
     public void test()
             throws IllegalAccessException, InstantiationException, InvocationTargetException {
         try (Context cx = Context.enter()) {
-            ScriptableObject scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             // define two classes that share a parent prototype
             ScriptableObject.defineClass(scope, Fruit.class, false, true);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/DynamicScopeTest.java
@@ -66,7 +66,7 @@ public class DynamicScopeTest {
         try {
             // Used to fail with org.mozilla.javascript.EvaluatorException: Cannot modify a property
             // of a sealed object: iterator.
-            final ScriptableObject scope = cx.initStandardObjects(new TopLevel(), true);
+            TopLevel scope = cx.initStandardObjects(new TopLevel(), true);
 
             Object result = cx.evaluateString(scope, "42", "source", 1, null);
             assertEquals(42, result);
@@ -81,7 +81,7 @@ public class DynamicScopeTest {
         try {
             // Used to fail with org.mozilla.javascript.EvaluatorException: Cannot modify a property
             // of a sealed object: iterator.
-            final ScriptableObject scope = cx.initStandardObjects(new TopLevel(), true);
+            TopLevel scope = cx.initStandardObjects(new TopLevel(), true);
 
             Object result = cx.evaluateString(scope, "23", "source", 1, null);
             assertEquals(23, result);
@@ -99,7 +99,7 @@ public class DynamicScopeTest {
 
             // Used to fail with org.mozilla.javascript.EvaluatorException: Cannot modify a property
             // of a sealed object: iterator.
-            final TopLevel someScope = cx.initStandardObjects();
+            TopLevel someScope = cx.initStandardObjects();
 
             Scriptable someObj =
                     (Scriptable)

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorHandlingTest.java
@@ -13,7 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.JavaScriptException;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.WrappedException;
 import org.mozilla.javascript.testutils.Utils;
@@ -149,7 +149,7 @@ public class ErrorHandlingTest {
         Utils.runWithAllModes(
                 cx -> {
                     try {
-                        final ScriptableObject scope = cx.initStandardObjects();
+                        TopLevel scope = cx.initStandardObjects();
                         cx.evaluateString(scope, script, "myScript.js", 1, null);
                         Assert.fail("No error was thrown");
                     } catch (final Throwable t) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ErrorPropertiesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ErrorPropertiesTest.java
@@ -7,7 +7,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -79,7 +79,7 @@ public class ErrorPropertiesTest {
         Utils.runWithAllModes(
                 cx -> {
                     try {
-                        final ScriptableObject scope = cx.initStandardObjects();
+                        TopLevel scope = cx.initStandardObjects();
                         final Object o = cx.evaluateString(scope, script, "myScript.js", 1, null);
                         Assert.assertEquals(expected, o);
                         return o;

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ForEachForOfTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ForEachForOfTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -73,7 +73,7 @@ public class ForEachForOfTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Dto dto = new Dto();
                     dto.setData("foo");
@@ -90,7 +90,7 @@ public class ForEachForOfTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Dto dto = new Dto();
                     dto.setData("foo");
@@ -107,7 +107,7 @@ public class ForEachForOfTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Dto dto = new Dto();
                     dto.setData("foo");
@@ -125,7 +125,7 @@ public class ForEachForOfTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Dto dto = new Dto();
                     dto.setData("foo");

--- a/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/GeneratedMethodNameTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Takes care that the name of the method generated for a function "looks like" the original
@@ -96,7 +96,7 @@ public class GeneratedMethodNameTest {
         // these tests in that case.
         Assume.assumeThat("Skipping test for Java 21", isJava21(), CoreMatchers.is(false));
         try (Context cx = ContextFactory.getGlobal().enterContext()) {
-            Scriptable topScope = cx.initStandardObjects();
+            TopLevel topScope = cx.initStandardObjects();
             topScope.put("javaNameGetter", topScope, new JavaNameGetter());
             Script script = cx.compileString(scriptCode, "myScript", 1, null);
             script.exec(cx, topScope, topScope);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/InitializationTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/InitializationTest.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 public class InitializationTest {
     private static final String BASIC_SCRIPT = "'Hello, ' + 'World!';";
@@ -15,7 +15,7 @@ public class InitializationTest {
     @Test
     public void standard() {
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initStandardObjects();
+            TopLevel root = cx.initStandardObjects();
             Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
             assertEquals("Hello, World!", result);
         }
@@ -25,7 +25,7 @@ public class InitializationTest {
     public void standardES6() {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            ScriptableObject root = cx.initStandardObjects();
+            TopLevel root = cx.initStandardObjects();
             Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
             assertEquals("Hello, World!", result);
         }
@@ -34,7 +34,7 @@ public class InitializationTest {
     @Test
     public void safeStandard() {
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
             assertEquals("Hello, World!", result);
         }
@@ -51,7 +51,7 @@ public class InitializationTest {
                         + "res;";
 
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             root.put("str", root, "Rhino");
             Object result = cx.evaluateString(root, code, "test", 1, null);
             assertEquals("R5 Rhino", result);
@@ -71,7 +71,7 @@ public class InitializationTest {
                         + "res;";
 
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             root.put("arr", root, new String[] {"a", "b", "d"});
             Object result = cx.evaluateString(root, code, "test", 1, null);
             assertEquals("a3 abd abd", result);
@@ -91,7 +91,7 @@ public class InitializationTest {
                         + "res;";
 
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             root.put("lst", root, List.of("a", "b", "c"));
             Object result = cx.evaluateString(root, code, "test", 1, null);
             assertEquals("a3 abc abc", result);
@@ -103,7 +103,7 @@ public class InitializationTest {
         String code = "let res = '';\n" + "for (let elem of mp) { res += elem; }\n" + "res;";
 
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             root.put("mp", root, Map.of("k0", "v0"));
             Object result = cx.evaluateString(root, code, "test", 1, null);
             assertEquals("k0,v0", result);
@@ -115,7 +115,7 @@ public class InitializationTest {
         String code = "let res = '';\n" + "for (let elem of mp) { res += elem; }\n" + "res;";
 
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initSafeStandardObjects();
+            TopLevel root = cx.initSafeStandardObjects();
             root.put("mp", root, Set.of("v0"));
             Object result = cx.evaluateString(root, code, "test", 1, null);
             assertEquals("v0", result);
@@ -125,7 +125,7 @@ public class InitializationTest {
     @Test
     public void standardSealed() {
         try (Context cx = Context.enter()) {
-            ScriptableObject root = cx.initStandardObjects(null, true);
+            TopLevel root = cx.initStandardObjects(null, true);
             Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
             assertEquals("Hello, World!", result);
         }
@@ -135,7 +135,7 @@ public class InitializationTest {
     public void standardSealedES6() {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            ScriptableObject root = cx.initStandardObjects(null, true);
+            TopLevel root = cx.initStandardObjects(null, true);
             Object result = cx.evaluateString(root, BASIC_SCRIPT, "basic", 1, null);
             assertEquals("Hello, World!", result);
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/InterfaceAdapterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/InterfaceAdapterTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Wrapper;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -30,7 +30,7 @@ public class InterfaceAdapterTest {
     private void testIt(String js, Object expected) {
         Utils.runWithAllModes(
                 cx -> {
-                    final ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     scope.put("list", scope, createList());
                     Object o = cx.evaluateString(scope, js, "testNativeFunction.js", 1, null);
                     if (o instanceof Wrapper) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Issue1041Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Issue1041Test.java
@@ -7,13 +7,13 @@ package org.mozilla.javascript.tests;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 public class Issue1041Test {
     @Test
     public void quantifierWithMax0() {
         try (Context cx = Context.enter()) {
-            ScriptableObject scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             Boolean result =
                     (Boolean) cx.evaluateString(scope, "/ab{0}c/.test('abc')", "<eval>", 1, null);
             Assert.assertFalse(result);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Issue1206Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Issue1206Test.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Tests the ConsString class to ensure it properly supports String, StringBuffer and StringBuilder.
@@ -18,7 +18,7 @@ public class Issue1206Test {
     @Test
     public void consStringUsingString() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects(null);
+            TopLevel scope = cx.initStandardObjects(null);
             scope.put("var1", scope, "hello");
             Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
             assertEquals("hello world", result);
@@ -28,7 +28,7 @@ public class Issue1206Test {
     @Test
     public void consStringUsingStringBuffer() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects(null);
+            TopLevel scope = cx.initStandardObjects(null);
             scope.put("var1", scope, new StringBuffer("hello"));
             Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
             assertEquals("hello world", result);
@@ -38,7 +38,7 @@ public class Issue1206Test {
     @Test
     public void consStringUsingStringBuilder() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects(null);
+            TopLevel scope = cx.initStandardObjects(null);
             scope.put("var1", scope, new StringBuilder("hello"));
             Object result = cx.evaluateString(scope, "var1 = var1 + ' world'", "test", 1, null);
             assertEquals("hello world", result);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/JavaIterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/JavaIterableTest.java
@@ -21,6 +21,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 public class JavaIterableTest {
 
@@ -144,7 +145,7 @@ public class JavaIterableTest {
                 .call(
                         context -> {
                             context.setLanguageVersion(Context.VERSION_ES6);
-                            Scriptable global = context.initStandardObjects();
+                            TopLevel global = context.initStandardObjects();
                             Scriptable scope = context.newObject(global);
                             scope.put("value", scope, Context.javaToJS(value, scope));
                             return context.evaluateString(scope, scriptSourceText, "", 1, null);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/LookupSetterTest.java
@@ -9,7 +9,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
@@ -110,7 +109,7 @@ public class LookupSetterTest {
                     @Override
                     public String run(final Context cx) {
                         try {
-                            final Scriptable scope = cx.initStandardObjects(new TopScope());
+                            TopLevel scope = cx.initStandardObjects(new TopScope());
                             ScriptableObject.defineClass(scope, Foo.class);
                             cx.evaluateString(scope, defineSetterAndGetterX, "initX", 1, null);
                             Object result =

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayBufferTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayBufferTest.java
@@ -7,7 +7,7 @@ package org.mozilla.javascript.tests;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 public class NativeArrayBufferTest {
@@ -21,7 +21,7 @@ public class NativeArrayBufferTest {
     public void test() throws Exception {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            Scriptable global = cx.initStandardObjects();
+            TopLevel global = cx.initStandardObjects();
             Object result = cx.evaluateString(global, "(new ArrayBuffer(5)).isView", "", 1, null);
             Assert.assertEquals(Undefined.instance, result);
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeArrayTest.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -136,7 +135,7 @@ public class NativeArrayTest {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
 
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             String result = cx.evaluateString(scope, source, "source", 1, null).toString();
             Assert.assertEquals("0,1,0,1", result);
         }
@@ -161,7 +160,7 @@ public class NativeArrayTest {
         var contextFactory = Utils.contextFactoryWithFeatures(Context.FEATURE_THREAD_SAFE_OBJECTS);
         try (Context cx = contextFactory.enterContext()) {
             cx.setLanguageVersion(Context.VERSION_ECMASCRIPT);
-            Scriptable scope = cx.initSafeStandardObjects(new TopLevel());
+            TopLevel scope = cx.initSafeStandardObjects(new TopLevel());
 
             assertNotNull(cx.evaluateString(scope, script, "test", 1, null));
         }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeJavaObjectTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeJavaObjectTest.java
@@ -13,7 +13,7 @@ import java.math.BigInteger;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeJavaObject;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 public class NativeJavaObjectTest {
 
@@ -22,7 +22,7 @@ public class NativeJavaObjectTest {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
 
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             {
                 String source = "java.util.Collections.singletonList('123').get(0)";
                 Object result = cx.evaluateString(scope, source, "source", 1, null);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeJsonTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeJsonTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * @author Ronald Brill
@@ -22,7 +22,7 @@ public class NativeJsonTest {
                 "function f(){ return JSON.stringify({property1:\"hello\", array1:[{subobject:1}]}); } f();";
 
         try (Context cx = Context.enter()) {
-            Scriptable jsScope = cx.initStandardObjects();
+            TopLevel jsScope = cx.initStandardObjects();
             Object result = cx.evaluateString(jsScope, jsScript, "myscript.js", 1, null);
             assertEquals("{\"property1\":\"hello\",\"array1\":[{\"subobject\":1}]}", result);
             assertEquals("java.lang.String", result.getClass().getName());

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeRegExpTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.fail;
 import java.util.function.BiFunction;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.regexp.NativeRegExp;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -22,7 +22,7 @@ public class NativeRegExpTest {
         final String script = "/0{0/";
         Utils.runWithAllModes(
                 _cx -> {
-                    final ScriptableObject scope = _cx.initStandardObjects();
+                    TopLevel scope = _cx.initStandardObjects();
                     final Object result = _cx.evaluateString(scope, script, "test script", 0, null);
                     assertEquals(script, Context.toString(result));
                     return null;
@@ -563,7 +563,7 @@ public class NativeRegExpTest {
         final String regexp = "/(a{3,6})(?=\\1)/g";
         Utils.runWithAllModes(
                 _cx -> {
-                    final ScriptableObject scope = _cx.initStandardObjects();
+                    TopLevel scope = _cx.initStandardObjects();
                     final Object result = _cx.evaluateString(scope, regexp, "test script", 0, null);
                     assertTrue(result instanceof NativeRegExp);
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/NativeStringTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -38,7 +38,7 @@ public class NativeStringTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("en"));
 
@@ -49,7 +49,7 @@ public class NativeStringTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("tr"));
 
@@ -65,7 +65,7 @@ public class NativeStringTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("en"));
 
@@ -76,7 +76,7 @@ public class NativeStringTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("tr"));
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/OverloadTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/OverloadTest.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 import java.util.Map;
 import org.junit.Test;
 import org.mozilla.javascript.EvaluatorException;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class OverloadTest {
@@ -53,7 +53,7 @@ public class OverloadTest {
     private static void assertEvaluates(final Object expected, final String source) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     final Object rep = cx.evaluateString(scope, source, "test.js", 0, null);
                     assertEquals(expected, rep);
                     return null;
@@ -64,7 +64,7 @@ public class OverloadTest {
             final Class<? extends Exception> exceptionClass, final String source) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         cx.evaluateString(scope, source, "test.js", 0, null);
                         fail("Did not throw exception");

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ScriptRuntimeEquivalentValuesTest.java
@@ -19,7 +19,7 @@ public class ScriptRuntimeEquivalentValuesTest {
     public void equivalentValuesUndefined() throws Exception {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    final TopLevel scope = cx.initStandardObjects();
                     try {
                         ScriptableObject.defineClass(scope, EquivalentTesterObject.class);
                     } catch (Exception e) {
@@ -43,7 +43,7 @@ public class ScriptRuntimeEquivalentValuesTest {
     public void equivalentValuesNull() throws Exception {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         ScriptableObject.defineClass(scope, EquivalentTesterObject.class);
                     } catch (Exception e) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ToNumberLegacyConversionsTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ToNumberLegacyConversionsTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Test cases for a legacy ToNumber conversion applied to a String type.
@@ -121,7 +122,7 @@ public class ToNumberLegacyConversionsTest {
     }
 
     public Context cx;
-    public Scriptable scope;
+    public TopLevel scope;
 
     @Before
     public void setup() {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/TypeOfTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -73,7 +74,7 @@ public class TypeOfTest {
     private static void doTest(String expected, final String script, final Scriptable obj) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     scope.put("myObj", scope, obj);
 
                     String res =

--- a/tests/src/test/java/org/mozilla/javascript/drivers/JsTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/JsTestsBase.java
@@ -13,6 +13,7 @@ import org.junit.BeforeClass;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public abstract class JsTestsBase {
@@ -48,7 +49,7 @@ public abstract class JsTestsBase {
     public void runJsTests(File[] tests) throws IOException {
         try (Context cx = threadSafeFactory.enterContext()) {
             cx.setInterpretedMode(this.interpretedMode);
-            Scriptable shared = cx.initStandardObjects();
+            TopLevel shared = cx.initStandardObjects();
             for (File f : tests) {
                 int length = (int) f.length(); // don't worry about very long
                 // files

--- a/tests/src/test/java/org/mozilla/javascript/tests/ContinuationComparisonTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ContinuationComparisonTest.java
@@ -17,6 +17,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Interpreter;
 import org.mozilla.javascript.NativeContinuation;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 public class ContinuationComparisonTest {
 
@@ -33,7 +34,7 @@ public class ContinuationComparisonTest {
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_DEFAULT);
             cx.setInterpretedMode(true); // interpreter for continuations
-            ScriptableObject global = cx.initStandardObjects();
+            TopLevel global = cx.initStandardObjects();
             final AtomicReference<NativeContinuation> captured = new AtomicReference<>();
             ScriptableObject.putProperty(
                     global,

--- a/tests/src/test/java/org/mozilla/javascript/tests/Evaluator.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Evaluator.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 public class Evaluator {
 
@@ -35,7 +36,7 @@ public class Evaluator {
     }
 
     public static Object eval(Context cx, String source, Map<String, Scriptable> bindings) {
-        Scriptable scope = cx.initStandardObjects();
+        TopLevel scope = cx.initStandardObjects();
         if (bindings != null) {
             for (Map.Entry<String, Scriptable> entry : bindings.entrySet()) {
                 final Scriptable object = entry.getValue();

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorStackTraceTest.java
@@ -22,7 +22,7 @@ public class GeneratorStackTraceTest {
     private static void runWithExpectedStackTrace(final String _source, final String expected) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         cx.evaluateString(scope, _source, "test.js", 0, null);
                     } catch (final JavaScriptException e) {
@@ -53,7 +53,7 @@ public class GeneratorStackTraceTest {
         Utils.runWithAllModes(
                 context -> {
                     try {
-                        final Scriptable scope = context.initStandardObjects();
+                        TopLevel scope = context.initStandardObjects();
                         context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
                         Assert.fail("Expected exception from nested generator not thrown.");
                     } catch (JavaScriptException e) {
@@ -93,7 +93,7 @@ public class GeneratorStackTraceTest {
         Utils.runWithAllModes(
                 context -> {
                     try {
-                        final Scriptable scope = context.initStandardObjects();
+                        TopLevel scope = context.initStandardObjects();
                         context.evaluateString(scope, jsCode, "nestedGeneratorTest.js", 1, null);
                         Assert.fail("Expected exception from nested generator not thrown.");
                     } catch (JavaScriptException e) {
@@ -118,7 +118,7 @@ public class GeneratorStackTraceTest {
     public void testJavaCallbackThrowsFromGenerator() {
         Utils.runWithAllModes(
                 context -> {
-                    Scriptable scope = context.initStandardObjects();
+                    TopLevel scope = context.initStandardObjects();
                     LambdaFunction f =
                             new LambdaFunction(
                                     scope,

--- a/tests/src/test/java/org/mozilla/javascript/tests/GeneratorsYieldStarReturnTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/GeneratorsYieldStarReturnTest.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -53,7 +54,7 @@ public class GeneratorsYieldStarReturnTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.evaluateString(scope, script, "test", 1, null);
 
                     Object result = scope.get("result", scope);
@@ -111,7 +112,7 @@ public class GeneratorsYieldStarReturnTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.evaluateString(scope, script, "test", 1, null);
 
                     Object result = scope.get("result", scope);
@@ -161,7 +162,7 @@ public class GeneratorsYieldStarReturnTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.evaluateString(scope, script, "test", 1, null);
 
                     Object result = scope.get("result", scope);
@@ -215,7 +216,7 @@ public class GeneratorsYieldStarReturnTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.evaluateString(scope, script, "test", 1, null);
 
                     Object result = scope.get("result", scope);

--- a/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/InterpreterFunctionPeelingTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContinuationPending;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 // Tests that continuations work across arrow function, bound function, and apply/call invocations.
 public class InterpreterFunctionPeelingTest {
@@ -20,7 +20,7 @@ public class InterpreterFunctionPeelingTest {
         try (var cx = Context.enter()) {
             cx.setInterpretedMode(true);
             Script s = cx.compileString(script, "unknown source", 0, null);
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             scope.put("c", scope, Context.javaToJS(CAPTURER, scope));
             Assert.assertThrows(
                     ContinuationPending.class,

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -18,7 +19,7 @@ public class LambdaAccessorSlotTest {
     public void testGetterProperty() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -43,7 +44,7 @@ public class LambdaAccessorSlotTest {
     public void testThrowIfNeitherGetterOrSetterAreDefined() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     var error =
                             assertThrows(
                                     EcmaError.class,
@@ -62,7 +63,7 @@ public class LambdaAccessorSlotTest {
     public void testCanUpdateValueUsingSetter() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -93,7 +94,7 @@ public class LambdaAccessorSlotTest {
     public void testOnlyGetterCanBeAccessed() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);
@@ -122,7 +123,7 @@ public class LambdaAccessorSlotTest {
     public void testRedefineExistingProperty() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     var sh = new StatusHolder("PENDING");
 
                     sh.defineProperty("value", "oldValueOfValue", DONTENUM);
@@ -153,7 +154,7 @@ public class LambdaAccessorSlotTest {
     public void testWhenNoSetterDefined_InStrictMode_WillThrowException() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);
@@ -188,7 +189,7 @@ public class LambdaAccessorSlotTest {
     public void testWhenNoSetterDefined_InNormalMode_NoErrorButValueIsNotChanged() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);
@@ -218,7 +219,7 @@ public class LambdaAccessorSlotTest {
     public void testSetterOnly_WillModifyUnderlyingValue() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -245,7 +246,7 @@ public class LambdaAccessorSlotTest {
     public void testGetterUsing_getOwnPropertyDescriptor() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);
@@ -268,7 +269,7 @@ public class LambdaAccessorSlotTest {
     public void testSetterOnlyUsing_getOwnPropertyDescriptor() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -297,7 +298,7 @@ public class LambdaAccessorSlotTest {
     public void testSetterOnlyUsing_getOwnPropertyDescriptor_missingValue() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -326,7 +327,7 @@ public class LambdaAccessorSlotTest {
     public void testSetValueUsing_getOwnPropertyDescriptor() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -354,7 +355,7 @@ public class LambdaAccessorSlotTest {
     public void testSetterOnlyUsing_getOwnPropertyDescriptor_ErrorOnGet() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -385,7 +386,7 @@ public class LambdaAccessorSlotTest {
     public void testRedefineExistingProperty_ChangingConfigurableAttr_ShouldFailValidation() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     var sh = new StatusHolder("PENDING");
                     ScriptableObject existingDesc = (ScriptableObject) cx.newObject(scope);
 
@@ -421,7 +422,7 @@ public class LambdaAccessorSlotTest {
             testRedefineExistingProperty_ModifyingNotConfigurableProperty_ShouldFailValidation() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     var sh = new StatusHolder("PENDING");
                     ScriptableObject existingDesc = (ScriptableObject) cx.newObject(scope);
 
@@ -460,7 +461,7 @@ public class LambdaAccessorSlotTest {
     public void testSetterOnlyUsing_getOwnPropertyDescriptor_InStrictMode_ErrorOnGet() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx,
@@ -492,7 +493,7 @@ public class LambdaAccessorSlotTest {
     public void testGetterOnlyUsing_getOwnPropertyDescriptor_ErrorOnSet() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);
@@ -520,7 +521,7 @@ public class LambdaAccessorSlotTest {
     public void testGetterOnlyUsing_getOwnPropertyDescriptor_InStrictMode_ErrorOnSet() {
         Utils.runWithAllModes(
                 cx -> {
-                    Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     StatusHolder.init(scope)
                             .definePrototypeProperty(
                                     cx, "status", (thisObj) -> self(thisObj).getStatus(), DONTENUM);

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -18,9 +18,9 @@ import org.mozilla.javascript.NativeConsole;
 import org.mozilla.javascript.NativeConsole.Level;
 import org.mozilla.javascript.ScriptStackElement;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SecurityUtilities;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 
 /** Test NativeConsole */
@@ -227,7 +227,7 @@ public class NativeConsoleTest {
     @Test
     public void formatObject() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             Scriptable emptyObject = cx.newObject(scope);
             assertFormat(new Object[] {"%o", emptyObject}, "{}");
@@ -270,7 +270,7 @@ public class NativeConsoleTest {
     @Test
     public void formatValueOnly() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             assertFormat(new Object[] {"param1", "param2"}, "param1 param2");
             assertFormat(new Object[] {1, 2, 7}, "1 2 7");
@@ -304,7 +304,7 @@ public class NativeConsoleTest {
     @Test
     public void formatMissingPlaceholder() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             assertFormat(
                     new Object[] {"string: %s;", "param1", "param2"}, "string: param1; param2");
@@ -563,7 +563,7 @@ public class NativeConsoleTest {
 
     private static void assertFormat(Object[] args, String expected) {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             assertEquals(expected, NativeConsole.format(cx, scope, args));
         }
     }
@@ -572,7 +572,7 @@ public class NativeConsoleTest {
         DummyConsolePrinter printer = new DummyConsolePrinter();
 
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             NativeConsole.init(scope, false, printer);
             cx.evaluateString(scope, source, "source", 1, null);
             printer.assertCalls(expectedCalls);
@@ -584,7 +584,7 @@ public class NativeConsoleTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_DEFAULT);
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             NativeConsole.init(scope, false, printer);
             cx.evaluateString(scope, source, "source", 1, null);
             printer.assertMsf(expectedMsg);
@@ -596,7 +596,7 @@ public class NativeConsoleTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_DEFAULT);
-            ScriptableObject scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             NativeConsole.init(scope, false, printer);
             return cx.evaluateString(scope, js, "source", 1, null);
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeObjectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeObjectTest.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class NativeObjectTest {
@@ -69,7 +69,7 @@ public class NativeObjectTest {
     @Test
     public void nativeJavaObject_hasOwnProperty() {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             ScriptableObject.putProperty(scope, "javaObj", Context.javaToJS(new JavaObj(), scope));
             Object result =
                     cx.evaluateString(

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -25,7 +26,7 @@ import org.mozilla.javascript.tools.shell.Global;
 public class NativeWrappedArrayTest {
 
     private Context cx;
-    private Scriptable global;
+    private TopLevel global;
 
     @Before
     public void init() {
@@ -84,7 +85,7 @@ public class NativeWrappedArrayTest {
 
     @Test
     public void customArray() throws IOException {
-        ((ScriptableObject) global)
+        global.getGlobalThis()
                 .defineFunctionProperties(
                         global, new String[] {"makeCustomArray"}, NativeWrappedArrayTest.class, 0);
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ObserveInstructionCountTest.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -82,7 +83,7 @@ public class ObserveInstructionCountTest {
                 cx -> {
                     assertTrue(cx instanceof MyContext);
                     try {
-                        Scriptable globalScope = cx.initStandardObjects();
+                        TopLevel globalScope = cx.initStandardObjects();
                         cx.evaluateString(globalScope, source, "test source", 1, null);
                         fail();
                     } catch (QuotaExceededException e) {
@@ -140,7 +141,7 @@ public class ObserveInstructionCountTest {
                     assertTrue(cx instanceof MyContext);
                     cx.setInstructionObserverThreshold(0);
                     try {
-                        Scriptable globalScope = cx.initStandardObjects();
+                        TopLevel globalScope = cx.initStandardObjects();
                         cx.evaluateString(
                                 globalScope, "/(.*)ab/.test(\"1234\");", "test source", 1, null);
                         assertFalse(((MyContext) cx).wasObserved());

--- a/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/OptionalChainingOperatorTest.java
@@ -5,7 +5,6 @@ import static org.mozilla.javascript.Context.FEATURE_E4X;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.testutils.Utils;
@@ -219,7 +218,7 @@ public class OptionalChainingOperatorTest {
     @Test
     public void canParseOptionalChainingEvenWithoutXml() {
         try (Context cx = Utils.contextFactoryWithFeatureDisabled(FEATURE_E4X).enterContext()) {
-            Scriptable scope = cx.initStandardObjects(new TopLevel());
+            TopLevel scope = cx.initStandardObjects(new TopLevel());
             String source = "o = {a: true}; o?.['a']\n";
             Object result = cx.evaluateString(scope, source, "test", 1, null);
             assertEquals(Boolean.TRUE, result);

--- a/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/SecurityControllerTest.java
@@ -19,8 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mozilla.javascript.ClassShutter;
 import org.mozilla.javascript.EcmaError;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.SecurityController;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.JavaPolicySecurity;
@@ -132,7 +132,7 @@ public class SecurityControllerTest {
         Utils.runWithAllModes(
                 context -> {
                     context.setClassShutter(new PolicyClassShutter());
-                    Scriptable scope = context.initStandardObjects(global);
+                    TopLevel scope = context.initStandardObjects(global);
 
                     return context.evaluateString(scope, scriptSourceText, "", 1, pd);
                 });

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceTest.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.JavaScriptException;
 import org.mozilla.javascript.RhinoException;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.StackStyle;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -122,7 +122,7 @@ public class StackTraceTest {
             final String _source, final String _expectedStackTrace) {
         Utils.runWithMode(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         cx.evaluateString(scope, _source, "test.js", 0, null);
                     } catch (final JavaScriptException e) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StrictModeApiTest.java
@@ -44,7 +44,7 @@ public class StrictModeApiTest {
                 Utils.contextFactoryWithFeatures(Context.FEATURE_STRICT_MODE),
                 cx -> {
                     try {
-                        Scriptable scope = cx.initSafeStandardObjects();
+                        TopLevel scope = cx.initSafeStandardObjects();
                         final MyHostObject prototype = new MyHostObject();
                         ScriptableObject.defineClass(scope, MyHostObject.class);
                         final Method readMethod = MyHostObject.class.getMethod("jsxGet_x");

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -261,7 +261,7 @@ public class Test262SuiteTest {
 
         public static $262 createRealm(
                 Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-            ScriptableObject realm = (ScriptableObject) cx.initSafeStandardObjects(new TopLevel());
+            TopLevel realm = cx.initSafeStandardObjects(new TopLevel());
             return install(realm, thisObj.getPrototype());
         }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/WriteReadOnlyPropertyTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 
 /**
  * Test that read-only properties can be... set when needed. This was the standard behavior in Rhino
@@ -64,7 +65,7 @@ public class WriteReadOnlyPropertyTest {
                 };
         contextFactory.call(
                 cx -> {
-                    final ScriptableObject top = cx.initStandardObjects();
+                    TopLevel top = cx.initStandardObjects();
                     final Foo foo = new Foo("hello");
                     foo.defineProperty(
                             top, "myProp", null, readMethod, null, ScriptableObject.EMPTY);

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireJarTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireJarTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.commonjs.module.Require;
 import org.mozilla.javascript.commonjs.module.provider.StrongCachingModuleScriptProvider;
 import org.mozilla.javascript.commonjs.module.provider.UrlModuleSourceProvider;
@@ -50,7 +51,7 @@ public class RequireJarTest extends RequireTest {
     @Override
     public void nonSandboxed() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             final String jsFile = getClass().getResource("testNonSandboxed.js").toExternalForm();
             ScriptableObject.putProperty(scope, "moduleUri", jsFile);
@@ -68,7 +69,7 @@ public class RequireJarTest extends RequireTest {
     @Override
     public void relativeId() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             require.install(scope);
             cx.evaluateReader(scope, getReader("testRelativeId.js"), "testRelativeId.js", 1, null);
@@ -79,7 +80,7 @@ public class RequireJarTest extends RequireTest {
     @Override
     public void setMainForAlreadyLoadedModule() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             require.install(scope);
             cx.evaluateReader(

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/RequireTest.java
@@ -54,7 +54,7 @@ public class RequireTest {
     @Test
     public void nonSandboxed() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             final String jsFile = getClass().getResource("testNonSandboxed.js").toExternalForm();
             ScriptableObject.putProperty(scope, "moduleUri", jsFile);
@@ -76,7 +76,7 @@ public class RequireTest {
     @Test
     public void customGlobal() throws Exception {
         try (Context cx = createContext()) {
-            final TopLevel scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             ScriptableObject.defineClass(scope, CustomGlobal.class);
 
             var obj = cx.newObject(scope, "CustomGlobal", null);
@@ -115,7 +115,7 @@ public class RequireTest {
     @Test
     public void relativeId() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             require.install(scope);
             cx.evaluateReader(scope, getReader("testRelativeId.js"), "testRelativeId.js", 1, null);
@@ -125,7 +125,7 @@ public class RequireTest {
     @Test
     public void setMainForAlreadyLoadedModule() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             require.install(scope);
             cx.evaluateReader(
@@ -148,7 +148,7 @@ public class RequireTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setGeneratingDebug(false);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         final Require require = getSandboxedRequire(cx, scope, false);
                         require.install(scope);
@@ -172,7 +172,7 @@ public class RequireTest {
     @Test
     public void thisScopeGlobalThis() throws Exception {
         try (Context cx = createContext()) {
-            final Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             final Require require = getSandboxedRequire(cx, scope, false);
             require.requireMain(cx, "thisScopeGlobalThisMain");
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectGetOwnPropertyDescriptorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/ObjectGetOwnPropertyDescriptorTest.java
@@ -13,8 +13,8 @@ import static org.mozilla.javascript.tests.Evaluator.eval;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeObject;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSGetter;
 import org.mozilla.javascript.annotations.JSSetter;
@@ -49,7 +49,7 @@ public class ObjectGetOwnPropertyDescriptorTest {
     @Test
     public void callPropertyDescriptorSetterWithConsString() throws Exception {
         try (Context cx = Context.enter()) {
-            Scriptable scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
             ScriptableObject.defineClass(scope, AnnotatedHostObject.class);
 
             final String script =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es5/TypedArrayJavaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es5/TypedArrayJavaTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 
 /** Test for TypedArrays. */
 public class TypedArrayJavaTest {
@@ -29,7 +29,7 @@ public class TypedArrayJavaTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_1_8);
-            Scriptable global = cx.initStandardObjects();
+            TopLevel global = cx.initStandardObjects();
 
             for (String type : allNativeTypes) {
                 String script =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ArrayDestructuringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ArrayDestructuringTest.java
@@ -5,6 +5,7 @@
 package org.mozilla.javascript.tests.es6;
 
 import org.junit.Test;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class ArrayDestructuringTest {
@@ -33,7 +34,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "assert = { sameValue(a, b, e) { if (a !== b) throw e; } };\n"
@@ -59,7 +60,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "assert = { sameValue(a, b, e) { if (a !== b) throw e; } };\n"
@@ -81,7 +82,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "assert = { sameValue(a, b, e) { if (a !== b) throw e; } };\n"
@@ -102,7 +103,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "assert = { sameValue(a, b, e) { if (a !== b) throw e; } };\n"
@@ -128,7 +129,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var callCount = 0;\n"
@@ -150,7 +151,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var errorThrown = false;\n"
@@ -177,7 +178,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "function f([x = 1, y = 2] = {x: 100, y: 200,\n"
@@ -201,7 +202,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "function Test262Error() {}\n"
@@ -231,7 +232,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "function a() {}\n"
@@ -256,7 +257,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var doneCallCount = 0;\n"
@@ -292,7 +293,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "Array.prototype[1] = 'y';\n"
@@ -314,7 +315,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var a, b, rest;\n"
@@ -340,7 +341,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     // Shadow Symbol with a plain object - should cause iterator access to fail
                     String script =
@@ -376,7 +377,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var iterable = {\n"
@@ -411,7 +412,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(180);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var f = function([a, b, c]) { return a + b + c; };\n"
@@ -432,7 +433,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(180);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     // In pre-ES6, only index-based access should work
                     // This verifies we don't call Symbol.iterator in version 180
@@ -453,7 +454,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(180);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var f = function([a = 5, b = 10]) { return a + b; };\n"
@@ -476,7 +477,7 @@ public class ArrayDestructuringTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(org.mozilla.javascript.Context.VERSION_ES6);
-                    org.mozilla.javascript.ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     String script =
                             "var obj = {\n"

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/DeadlockReproTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.NativeObject;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class DeadlockReproTest {
@@ -17,7 +17,7 @@ public class DeadlockReproTest {
 
         try (Context cx = factory.enterContext()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            ScriptableObject scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             scope.put("o", scope, new NativeObject());
             final String script =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/FunctionNullSetTest.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextAction;
 import org.mozilla.javascript.Function;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -30,7 +30,7 @@ public class FunctionNullSetTest {
                     @Override
                     public Object run(final Context cx) {
                         try {
-                            final Scriptable scope = cx.initSafeStandardObjects();
+                            final TopLevel scope = cx.initSafeStandardObjects();
                             final MyHostObject prototype = new MyHostObject();
                             ScriptableObject.defineClass(scope, MyHostObject.class);
                             final Method getterMethod =

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeDateTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeDateTest.java
@@ -15,7 +15,7 @@ import java.util.TimeZone;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EcmaError;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /** Test for NativeDate. */
@@ -420,7 +420,7 @@ public class NativeDateTest {
     private static void ctorDateTimeString(final String expected, final String js) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone("GMT"));
 
@@ -434,7 +434,7 @@ public class NativeDateTest {
             final Class<T> expectedThrowable, final String expectedMessage, final String js) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone("GMT"));
 
@@ -480,7 +480,7 @@ public class NativeDateTest {
 
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone("Europe/Berlin"));
 
@@ -509,7 +509,7 @@ public class NativeDateTest {
         final String js = "new Date('2021-12-18T22:23').toISOString()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 
@@ -558,7 +558,7 @@ public class NativeDateTest {
         final String js = "new Date('2021-12-18').toISOString()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 
@@ -631,7 +631,7 @@ public class NativeDateTest {
     private static void toLocale(final String expected, final String js) {
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone("GMT"));
 
@@ -703,7 +703,7 @@ public class NativeDateTest {
         final String js = "new Date('Sat, 18 Dec 2021 22:23:00 UTC').toDateString()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 
@@ -757,7 +757,7 @@ public class NativeDateTest {
         final String js = "new Date('Sat, 18 Dec 2021 22:23:00 UTC').toTimeString()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 
@@ -806,7 +806,7 @@ public class NativeDateTest {
         final String js = "new Date('Sat, 18 Dec 2021 22:23:00 UTC').toUTCString()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 
@@ -855,7 +855,7 @@ public class NativeDateTest {
         final String js = "new Date(0).getTimezoneOffset()";
         Utils.runWithAllModes(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setTimeZone(TimeZone.getTimeZone(tz));
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeFunctionTest.java
@@ -8,8 +8,8 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSFunction;
 import org.mozilla.javascript.testutils.Utils;
@@ -137,7 +137,7 @@ public class NativeFunctionTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     try {
                         ScriptableObject.defineClass(scope, HelperObject.class);
                     } catch (Exception e) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeObjectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeObjectTest.java
@@ -13,8 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /** Test for NativeObject. */
@@ -376,9 +375,9 @@ public class NativeObjectTest {
             Utils.runWithAllModes(
                     cx -> {
                         cx.setLanguageVersion(Context.VERSION_ES6);
-                        ScriptableObject scope = cx.initStandardObjects();
+                        TopLevel scope = cx.initStandardObjects();
 
-                        Scriptable realm = cx.initStandardObjects();
+                        TopLevel realm = cx.initStandardObjects();
                         scope.put("realm", scope, realm);
 
                         Object result = cx.evaluateString(scope, prefix + script, "test", 1, null);
@@ -416,9 +415,9 @@ public class NativeObjectTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
-                    Scriptable realm = cx.initStandardObjects();
+                    TopLevel realm = cx.initStandardObjects();
                     scope.put("realm", scope, realm);
 
                     Object result = cx.evaluateString(scope, script, "test", 1, null);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NumericSeparatorTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class NumericSeparatorTest {
@@ -25,7 +25,7 @@ public class NumericSeparatorTest {
         Utils.runWithMode(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Object result = cx.evaluateString(scope, "1234", "test", 1, null);
                     assertEquals(1234.0, result);
@@ -38,7 +38,7 @@ public class NumericSeparatorTest {
         Utils.runWithMode(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     Object result = cx.evaluateString(scope, "1234", "test", 1, null);
                     assertEquals(1234, result);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/PropertyTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 public class PropertyTest {
@@ -16,7 +17,7 @@ public class PropertyTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     final String expected = "undefined - true - true | function - function";
 
@@ -52,7 +53,7 @@ public class PropertyTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     final String expected = "undefined - true - true | function - function";
 
@@ -89,7 +90,7 @@ public class PropertyTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     final String expected = "undefined - true - true | function - function";
 
@@ -129,7 +130,7 @@ public class PropertyTest {
 
         try (Context cx = factory.enterContext()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            ScriptableObject scope = cx.initStandardObjects();
+            TopLevel scope = cx.initStandardObjects();
 
             final String expected = "undefined - true - true | function - function";
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/StrictPropagationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/StrictPropagationTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.LambdaFunction;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.SerializableCallable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
@@ -21,7 +20,7 @@ public class StrictPropagationTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects(new TopLevel());
+                    TopLevel scope = cx.initStandardObjects(new TopLevel());
 
                     SerializableCallable includeDynamic =
                             (cx2, scope2, thisObj, args) ->

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/Symbol3Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/Symbol3Test.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /** Tests for Symbol support. */
@@ -83,7 +84,7 @@ public class Symbol3Test {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     final String script =
                             "var sym = Object.getOwnPropertySymbols(MyHostObject);"

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/TypedArrayJavaTest.java
@@ -4,7 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /** Test for TypedArrays. */
@@ -115,7 +115,7 @@ public class TypedArrayJavaTest {
         Utils.runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     for (String type : allNativeTypes) {
                         String scr = script.replace("§§type§§", type);

--- a/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayJavaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/harmony/TypedArrayJavaTest.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.ListIterator;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
 import org.mozilla.javascript.typedarrays.NativeFloat32Array;
 import org.mozilla.javascript.typedarrays.NativeFloat64Array;
@@ -293,7 +293,7 @@ public class TypedArrayJavaTest {
 
         try (Context cx = Context.enter()) {
             cx.setLanguageVersion(Context.VERSION_ES6);
-            Scriptable global = cx.initStandardObjects();
+            TopLevel global = cx.initStandardObjects();
 
             for (String type : allNativeTypes) {
                 ScriptableObject obj =

--- a/tests/src/test/java/org/mozilla/javascript/tests/intl402/NativeStringTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/intl402/NativeStringTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Locale;
 import org.junit.Test;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
@@ -25,7 +25,7 @@ public class NativeStringTest {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("en"));
 
@@ -37,7 +37,7 @@ public class NativeStringTest {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("tr"));
 
@@ -77,7 +77,7 @@ public class NativeStringTest {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("en"));
 
@@ -89,7 +89,7 @@ public class NativeStringTest {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLanguageVersion(Context.VERSION_ES6);
                     cx.setLocale(new Locale("tr"));
 

--- a/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
+++ b/testutils/src/main/java/org/mozilla/javascript/testutils/Utils.java
@@ -14,8 +14,6 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EcmaError;
 import org.mozilla.javascript.EvaluatorException;
 import org.mozilla.javascript.JavaScriptException;
-import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 
 /**
@@ -66,7 +64,7 @@ public class Utils {
     public static void executeScript(String script, boolean interpreted) {
         Utils.runWithMode(
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     return cx.evaluateString(scope, script, "myScript.js", 1, null);
                 },
                 interpreted);
@@ -169,7 +167,7 @@ public class Utils {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     final Object res = cx.evaluateString(scope, script, "test.js", 0, null);
                     assertEquals(expected, res);
@@ -191,7 +189,7 @@ public class Utils {
         Utils.runWithAllModes(
                 Utils.contextFactoryWithFeatures(Context.FEATURE_INTL_402),
                 cx -> {
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     cx.setLocale(locale);
 
                     final Object res = cx.evaluateString(scope, script, "test.js", 0, null);
@@ -293,7 +291,7 @@ public class Utils {
                     if (languageVersion > -1) {
                         cx.setLanguageVersion(languageVersion);
                     }
-                    final Scriptable scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
                     final Object res = cx.evaluateString(scope, script, "test.js", 1, null);
 
                     if (expected instanceof Integer && res instanceof Double) {
@@ -330,7 +328,7 @@ public class Utils {
         runWithAllModes(
                 cx -> {
                     cx.setLanguageVersion(Context.VERSION_ES6);
-                    Scriptable scope = cx.initStandardObjects(new TopLevel());
+                    TopLevel scope = cx.initStandardObjects(new TopLevel());
                     final Object res = cx.evaluateString(scope, script, "test.js", 1, null);
 
                     assertEquals(expected, res);
@@ -487,7 +485,7 @@ public class Utils {
                     if (languageVersion > -1) {
                         cx.setLanguageVersion(languageVersion);
                     }
-                    ScriptableObject scope = cx.initStandardObjects();
+                    TopLevel scope = cx.initStandardObjects();
 
                     T e =
                             assertThrows(


### PR DESCRIPTION
This is the first step in introducing `VarScope` as a subtype of `Scriptable`. Breaking it out into its own PR as it is an almost entirely mechanical change which can be reviewed on its own.