### PR TITLE
Change `Scriptable` inheritance and add type param in preparation for scopes.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -7,14 +7,14 @@ import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
  * using Java and JavaScript functions. Unlike LambdaSlot, the fact that these values are accessed
  * and mutated by functions is visible via the slot's property descriptor.
  */
-public class AccessorSlot extends Slot {
+public class AccessorSlot extends Slot<Scriptable> {
     private static final long serialVersionUID = 1677840254177335827L;
 
     AccessorSlot(Object name, int index) {
         super(name, index, 0);
     }
 
-    AccessorSlot(Slot oldSlot) {
+    AccessorSlot(Slot<Scriptable> oldSlot) {
         super(oldSlot);
     }
 
@@ -106,19 +106,19 @@ public class AccessorSlot extends Slot {
     }
 
     @Override
-    Function getSetterFunction(String name, Scriptable scope) {
+    Function getSetterFunction(String name, Scriptable start) {
         if (setter == null) {
             return null;
         }
-        return setter.asSetterFunction(name, scope);
+        return setter.asSetterFunction(name, start);
     }
 
     @Override
-    Function getGetterFunction(String name, Scriptable scope) {
+    Function getGetterFunction(String name, Scriptable start) {
         if (getter == null) {
             return null;
         }
-        return getter.asGetterFunction(name, scope);
+        return getter.asGetterFunction(name, start);
     }
 
     @Override
@@ -146,7 +146,7 @@ public class AccessorSlot extends Slot {
     interface Getter {
         Object getValue(Scriptable start);
 
-        Function asGetterFunction(final String name, final Scriptable scope);
+        Function asGetterFunction(String name, Scriptable start);
 
         boolean isSameGetterFunction(Object getter);
     }
@@ -168,7 +168,7 @@ public class AccessorSlot extends Slot {
         }
 
         @Override
-        public Function asGetterFunction(String name, Scriptable scope) {
+        public Function asGetterFunction(String name, Scriptable start) {
             return member.asGetterFunction(name);
         }
 
@@ -198,7 +198,7 @@ public class AccessorSlot extends Slot {
         }
 
         @Override
-        public Function asGetterFunction(String name, Scriptable scope) {
+        public Function asGetterFunction(String name, Scriptable start) {
             return target instanceof Function ? (Function) target : null;
         }
 
@@ -212,7 +212,7 @@ public class AccessorSlot extends Slot {
     interface Setter {
         boolean setValue(Object value, Scriptable owner, Scriptable start);
 
-        Function asSetterFunction(final String name, final Scriptable scope);
+        Function asSetterFunction(String name, Scriptable scope);
 
         boolean isSameSetterFunction(Object getter);
     }
@@ -234,7 +234,7 @@ public class AccessorSlot extends Slot {
             var valueType = pTypes[pTypes.length - 1];
             boolean isNullable = member.getArgNullability().isNullable(pTypes.length - 1);
             int tag = FunctionObject.getTypeTag(valueType);
-            Object actualArg = FunctionObject.convertArg(cx, start, value, tag, isNullable);
+            Object actualArg = FunctionObject.convertArg(cx, member.scope, value, tag, isNullable);
 
             if (member.delegateTo == null) {
                 member.invoke(start, new Object[] {actualArg});
@@ -245,7 +245,7 @@ public class AccessorSlot extends Slot {
         }
 
         @Override
-        public Function asSetterFunction(String name, Scriptable scope) {
+        public Function asSetterFunction(String name, Scriptable start) {
             return member.asSetterFunction(name);
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -205,7 +205,8 @@ class Arguments extends ScriptableObject {
     }
 
     @Override
-    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
+    Object[] getIds(
+            CompoundOperationMap<Scriptable> map, boolean getNonEnumerable, boolean getSymbols) {
         Object[] ids = super.getIds(map, getNonEnumerable, getSymbols);
         if (args.length != 0) {
             boolean[] present = new boolean[args.length];

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -252,7 +252,7 @@ public class BaseFunction extends ScriptableObject implements Function {
         }
     }
 
-    protected void createPrototypeProperty(CompoundOperationMap compoundOp) {
+    protected void createPrototypeProperty(CompoundOperationMap<Scriptable> compoundOp) {
         compoundOp.compute(
                 this,
                 compoundOp,

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -22,24 +22,24 @@ import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
  * map from which a slot was fetched. We store it in the slot's value field as this is not used for
  * any real value storage on a built in slot.
  */
-public class BuiltInSlot<T extends ScriptableObject> extends Slot {
+public class BuiltInSlot<T extends ScriptableObject> extends Slot<Scriptable> {
 
-    public interface Getter<U extends ScriptableObject> extends Serializable {
-        Object apply(U builtIn, Scriptable start);
+    public interface Getter<T extends ScriptableObject> extends Serializable {
+        Object apply(T builtIn, Scriptable start);
     }
 
-    public interface Setter<U extends ScriptableObject> extends Serializable {
-        boolean apply(U builtIn, Object value, Scriptable owner, Scriptable start, boolean isThrow);
+    public interface Setter<T extends ScriptableObject> extends Serializable {
+        boolean apply(T builtIn, Object value, Scriptable owner, Scriptable start, boolean isThrow);
     }
 
     public interface AttributeSetter<U extends ScriptableObject> extends Serializable {
         void apply(U builtIn, int attributes);
     }
 
-    public interface PropDescriptionSetter<U extends ScriptableObject> extends Serializable {
+    public interface PropDescriptionSetter<T extends ScriptableObject> extends Serializable {
         boolean apply(
-                U builtIn,
-                BuiltInSlot<U> current,
+                T builtIn,
+                BuiltInSlot<T> current,
                 Object id,
                 DescriptorInfo info,
                 boolean checkValid,
@@ -121,7 +121,7 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
     }
 
     @Override
-    Slot copySlot() {
+    Slot<Scriptable> copySlot() {
         var res = new BuiltInSlot<T>(this);
         res.next = null;
         res.orderedNext = null;
@@ -166,7 +166,7 @@ public class BuiltInSlot<T extends ScriptableObject> extends Slot {
 
     @Override
     @SuppressWarnings("unchecked")
-    DescriptorInfo getPropertyDescriptor(Context cx, Scriptable scope) {
+    DescriptorInfo getPropertyDescriptor(Context cx, Scriptable start) {
         return ScriptableObject.buildDataDescriptor(getValue((T) this.value), getAttributes());
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/CompoundOperationMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompoundOperationMap.java
@@ -8,12 +8,12 @@ import java.util.Iterator;
  * has been mutated as part of the operation to allow the underlying map to delegate operations as
  * required.
  */
-public class CompoundOperationMap implements SlotMap, AutoCloseable {
-    protected final SlotMapOwner owner;
-    protected SlotMap map;
+public class CompoundOperationMap<T extends PropHolder<T>> implements SlotMap<T>, AutoCloseable {
+    protected final SlotMapOwner<T> owner;
+    protected SlotMap<T> map;
     boolean touched = false;
 
-    public CompoundOperationMap(SlotMapOwner owner) {
+    public CompoundOperationMap(SlotMapOwner<T> owner) {
         this.owner = owner;
         this.map = owner.getMap();
     }
@@ -30,14 +30,14 @@ public class CompoundOperationMap implements SlotMap, AutoCloseable {
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
         map.add(owner, newSlot);
         touched = true;
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner, Object key, int index, SlotComputer<S, T> compute) {
         updateMap(true);
         var res = map.compute(owner, this, key, index, compute);
         touched = true;
@@ -45,12 +45,12 @@ public class CompoundOperationMap implements SlotMap, AutoCloseable {
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> compute) {
+            SlotComputer<S, T> compute) {
         assert (compoundOp == this);
         updateMap(true);
         var res = map.compute(owner, this, key, index, compute);
@@ -71,7 +71,7 @@ public class CompoundOperationMap implements SlotMap, AutoCloseable {
     }
 
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         updateMap(true);
         var res = map.modify(owner, key, index, attributes);
         touched = true;
@@ -79,7 +79,7 @@ public class CompoundOperationMap implements SlotMap, AutoCloseable {
     }
 
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         updateMap(false);
         return map.query(key, index);
     }
@@ -91,7 +91,7 @@ public class CompoundOperationMap implements SlotMap, AutoCloseable {
     }
 
     @Override
-    public Iterator<Slot> iterator() {
+    public Iterator<Slot<T>> iterator() {
         updateMap(false);
         return map.iterator();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ConstProperties.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ConstProperties.java
@@ -8,7 +8,7 @@
 
 package org.mozilla.javascript;
 
-public interface ConstProperties {
+public interface ConstProperties<T extends PropHolder<T>> {
     /**
      * Sets a named const property in this object.
      *
@@ -55,7 +55,7 @@ public interface ConstProperties {
      * @see org.mozilla.javascript.ScriptableObject#putProperty(Scriptable, String, Object)
      * @see org.mozilla.javascript.Context#toObject(Object, Scriptable)
      */
-    public void putConst(String name, Scriptable start, Object value);
+    public void putConst(String name, T start, Object value);
 
     /**
      * Reserves a definition spot for a const. This will set up a definition of the const property,
@@ -65,7 +65,7 @@ public interface ConstProperties {
      * @param name The name of the property.
      * @param start The object whose property is being reserved.
      */
-    public void defineConst(String name, Scriptable start);
+    public void defineConst(String name, T start);
 
     /**
      * Returns true if the named property is defined as a const on this object.

--- a/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EmbeddedSlotMap.java
@@ -17,13 +17,13 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-public class EmbeddedSlotMap implements SlotMap {
+public class EmbeddedSlotMap<T extends PropHolder<T>> implements SlotMap<T> {
 
-    private Slot[] slots;
+    private Slot<T>[] slots;
 
     // gateways into the definition-order linked list of slots
-    private Slot firstAdded;
-    private Slot lastAdded;
+    private Slot<T> firstAdded;
+    private Slot<T> lastAdded;
 
     private int count;
     private boolean hasIndex = false;
@@ -31,10 +31,10 @@ public class EmbeddedSlotMap implements SlotMap {
     // initial slot array size, must be a power of 2
     private static final int INITIAL_SLOT_SIZE = 4;
 
-    private static final class Iter implements Iterator<Slot> {
-        private Slot next;
+    private static final class Iter<T extends PropHolder<T>> implements Iterator<Slot<T>> {
+        private Slot<T> next;
 
-        Iter(Slot slot) {
+        Iter(Slot<T> slot) {
             next = slot;
         }
 
@@ -44,8 +44,8 @@ public class EmbeddedSlotMap implements SlotMap {
         }
 
         @Override
-        public Slot next() {
-            Slot ret = next;
+        public Slot<T> next() {
+            Slot<T> ret = next;
             if (ret == null) {
                 throw new NoSuchElementException();
             }
@@ -56,6 +56,7 @@ public class EmbeddedSlotMap implements SlotMap {
 
     public EmbeddedSlotMap() {}
 
+    @SuppressWarnings("unchecked")
     public EmbeddedSlotMap(int capacity) {
         int n = -1 >>> Integer.numberOfLeadingZeros(capacity - 1);
         n = (n < 0) ? 1 : n + 1;
@@ -73,20 +74,20 @@ public class EmbeddedSlotMap implements SlotMap {
     }
 
     @Override
-    public Iterator<Slot> iterator() {
-        return new Iter(firstAdded);
+    public Iterator<Slot<T>> iterator() {
+        return new Iter<T>(firstAdded);
     }
 
     /** Locate the slot with the given name or index. */
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         if (slots == null || (key == null && !hasIndex)) {
             return null;
         }
 
         int indexOrHash = (key != null ? key.hashCode() : index);
         int slotIndex = getSlotIndex(slots.length, indexOrHash);
-        for (Slot slot = slots[slotIndex]; slot != null; slot = slot.next) {
+        for (Slot<T> slot = slots[slotIndex]; slot != null; slot = slot.next) {
             if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
                 return slot;
             }
@@ -101,9 +102,9 @@ public class EmbeddedSlotMap implements SlotMap {
      * @param index index or 0 if slot holds property name.
      */
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         final int indexOrHash = (key != null ? key.hashCode() : index);
-        Slot slot;
+        Slot<T> slot;
 
         if (slots != null) {
             final int slotIndex = getSlotIndex(slots.length, indexOrHash);
@@ -117,12 +118,13 @@ public class EmbeddedSlotMap implements SlotMap {
             }
         }
 
-        Slot newSlot = new Slot(key, index, attributes);
+        Slot<T> newSlot = new Slot<T>(key, index, attributes);
         createNewSlot(owner, newSlot);
         return newSlot;
     }
 
-    private void createNewSlot(SlotMapOwner owner, Slot newSlot) {
+    @SuppressWarnings("unchecked")
+    private void createNewSlot(SlotMapOwner<T> owner, Slot<T> newSlot) {
         if (count == 0 && slots == null) {
             // Always throw away old slots if any on empty insert.
             slots = new Slot[INITIAL_SLOT_SIZE];
@@ -135,7 +137,7 @@ public class EmbeddedSlotMap implements SlotMap {
                 promoteMap(owner, newSlot);
                 return;
             }
-            Slot[] newSlots = new Slot[slots.length * 2];
+            Slot<T>[] newSlots = new Slot[slots.length * 2];
             copyTable(slots, newSlots);
             slots = newSlots;
         }
@@ -143,24 +145,24 @@ public class EmbeddedSlotMap implements SlotMap {
         insertNewSlot(newSlot);
     }
 
-    protected void promoteMap(SlotMapOwner owner, Slot newSlot) {
-        var newMap = new HashSlotMap(this, newSlot);
+    protected void promoteMap(SlotMapOwner<T> owner, Slot<T> newSlot) {
+        var newMap = new HashSlotMap<T>(this, newSlot);
         owner.setMap(newMap);
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> c) {
+            SlotComputer<S, T> c) {
         final int indexOrHash = (key != null ? key.hashCode() : index);
 
         if (slots != null) {
-            Slot slot;
+            Slot<T> slot;
             final int slotIndex = getSlotIndex(slots.length, indexOrHash);
-            Slot prev = slots[slotIndex];
+            Slot<T> prev = slots[slotIndex];
             for (slot = prev; slot != null; slot = slot.next) {
                 if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
                     break;
@@ -174,12 +176,12 @@ public class EmbeddedSlotMap implements SlotMap {
         return computeNew(owner, compoundOp, key, index, c);
     }
 
-    private <S extends Slot> S computeNew(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    private <S extends Slot<T>> S computeNew(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> c) {
+            SlotComputer<S, T> c) {
         S newSlot = c.compute(key, index, null, compoundOp, owner);
         if (newSlot != null) {
             if (!compoundOp.touched) {
@@ -191,14 +193,14 @@ public class EmbeddedSlotMap implements SlotMap {
         return newSlot;
     }
 
-    private <S extends Slot> S computeExisting(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    private <S extends Slot<T>> S computeExisting(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> c,
-            Slot slot,
-            Slot prev,
+            SlotComputer<S, T> c,
+            Slot<T> slot,
+            Slot<T> prev,
             int slotIndex) {
         // Modify or remove existing slot
         S newSlot = c.compute(key, index, slot, compoundOp, owner);
@@ -218,7 +220,7 @@ public class EmbeddedSlotMap implements SlotMap {
                 if (slot == firstAdded) {
                     firstAdded = newSlot;
                 } else {
-                    Slot ps = firstAdded;
+                    Slot<T> ps = firstAdded;
                     while ((ps != null) && (ps.orderedNext != slot)) {
                         ps = ps.orderedNext;
                     }
@@ -239,14 +241,15 @@ public class EmbeddedSlotMap implements SlotMap {
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
+    @SuppressWarnings("unchecked")
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
         if (slots == null) {
             slots = new Slot[INITIAL_SLOT_SIZE];
         }
         createNewSlot(owner, newSlot);
     }
 
-    private void insertNewSlot(Slot newSlot) {
+    private void insertNewSlot(Slot<T> newSlot) {
         ++count;
         // add new slot to linked list
         if (lastAdded != null) {
@@ -260,7 +263,7 @@ public class EmbeddedSlotMap implements SlotMap {
         addKnownAbsentSlot(slots, newSlot);
     }
 
-    private void removeSlot(Slot slot, Slot prev, int ix, Object key) {
+    private void removeSlot(Slot<T> slot, Slot<T> prev, int ix, Object key) {
         count--;
         // remove slot from hash table
         if (prev == slot) {
@@ -289,10 +292,11 @@ public class EmbeddedSlotMap implements SlotMap {
         }
     }
 
-    private static void copyTable(Slot[] oldSlots, Slot[] newSlots) {
-        for (Slot slot : oldSlots) {
+    private static <T extends PropHolder<T>> void copyTable(
+            Slot<T>[] oldSlots, Slot<T>[] newSlots) {
+        for (Slot<T> slot : oldSlots) {
             while (slot != null) {
-                Slot nextSlot = slot.next;
+                Slot<T> nextSlot = slot.next;
                 addKnownAbsentSlot(newSlots, slot);
                 slot = nextSlot;
             }
@@ -303,7 +307,8 @@ public class EmbeddedSlotMap implements SlotMap {
      * Add slot with keys that are known to absent from the table. This is an optimization to use
      * when inserting into empty table, after table growth or during deserialization.
      */
-    private static void addKnownAbsentSlot(Slot[] addSlots, Slot slot) {
+    private static <T extends PropHolder<T>> void addKnownAbsentSlot(
+            Slot<T>[] addSlots, Slot<T> slot) {
         final int insertPos = getSlotIndex(addSlots.length, slot.indexOrHash);
         slot.next = addSlots[insertPos];
         addSlots[insertPos] = slot;

--- a/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/HashSlotMap.java
@@ -15,9 +15,9 @@ import java.util.LinkedHashMap;
  * object. However it is much more resistant to large number of hash collisions than EmbeddedSlotMap
  * and therefore we use this implementation when an object gains a large number of properties.
  */
-public class HashSlotMap implements SlotMap {
+public class HashSlotMap<T extends PropHolder<T>> implements SlotMap<T> {
 
-    private final LinkedHashMap<Object, Slot> map;
+    private final LinkedHashMap<Object, Slot<T>> map;
 
     public HashSlotMap() {
         map = new LinkedHashMap<>();
@@ -27,16 +27,16 @@ public class HashSlotMap implements SlotMap {
         map = new LinkedHashMap<>(capacity);
     }
 
-    public HashSlotMap(SlotMap oldMap) {
+    public HashSlotMap(SlotMap<T> oldMap) {
         map = new LinkedHashMap<>(oldMap.size());
-        for (Slot n : oldMap) {
+        for (Slot<T> n : oldMap) {
             add(null, n.copySlot());
         }
     }
 
-    public HashSlotMap(SlotMap oldMap, Slot newSlot) {
+    public HashSlotMap(SlotMap<T> oldMap, Slot<T> newSlot) {
         map = new LinkedHashMap<>(oldMap.dirtySize() + 1);
-        for (Slot n : oldMap) {
+        for (Slot<T> n : oldMap) {
             add(null, n.copySlot());
         }
         add(null, newSlot);
@@ -53,40 +53,40 @@ public class HashSlotMap implements SlotMap {
     }
 
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         Object name = makeKey(key, index);
         return map.get(name);
     }
 
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         Object name = makeKey(key, index);
-        return map.computeIfAbsent(name, n -> new Slot(key, index, attributes));
+        return map.computeIfAbsent(name, n -> new Slot<T>(key, index, attributes));
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> c) {
+            SlotComputer<S, T> c) {
         Object name = makeKey(key, index);
-        Slot ret =
+        Slot<T> ret =
                 map.compute(
                         name, (n, existing) -> c.compute(key, index, existing, compoundOp, owner));
         return (S) ret;
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
         Object name = makeKey(newSlot);
         map.put(name, newSlot);
     }
 
     @Override
-    public Iterator<Slot> iterator() {
+    public Iterator<Slot<T>> iterator() {
         return map.values().iterator();
     }
 
@@ -94,7 +94,7 @@ public class HashSlotMap implements SlotMap {
         return name == null ? String.valueOf(index) : name;
     }
 
-    private Object makeKey(Slot slot) {
+    private Object makeKey(Slot<T> slot) {
         return slot.name == null ? String.valueOf(slot.indexOrHash) : slot.name;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -597,7 +597,8 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     @Override
-    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
+    Object[] getIds(
+            CompoundOperationMap<Scriptable> map, boolean getNonEnumerable, boolean getSymbols) {
         Object[] result = super.getIds(map, getNonEnumerable, getSymbols);
 
         if (prototypeValues != null) {

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -13,7 +13,7 @@ import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
  * implementing properties that behave like standard JavaScript properties, but are implemented with
  * native functionality without the need for reflection.
  */
-public class LambdaAccessorSlot extends Slot {
+public class LambdaAccessorSlot extends Slot<Scriptable> {
     private ScriptableObject.LambdaGetterFunction getter;
     private ScriptableObject.LambdaSetterFunction setter;
     private LambdaFunction getterFunction;
@@ -23,7 +23,7 @@ public class LambdaAccessorSlot extends Slot {
         super(name, index, 0);
     }
 
-    LambdaAccessorSlot(Slot oldSlot) {
+    LambdaAccessorSlot(Slot<Scriptable> oldSlot) {
         super(oldSlot);
     }
 
@@ -137,7 +137,7 @@ public class LambdaAccessorSlot extends Slot {
                             scope,
                             "get " + super.name,
                             0,
-                            (cx1, scope1, thisObj, args) -> getter.apply(thisObj),
+                            (cx1, scope1, thisObj, args) -> getter.apply((Scriptable) thisObj),
                             false);
         }
     }
@@ -152,7 +152,8 @@ public class LambdaAccessorSlot extends Slot {
                             1,
                             (cx1, scope1, thisObj, args) -> {
                                 setter.accept(
-                                        thisObj, args.length > 0 ? args[0] : Undefined.instance);
+                                        (Scriptable) thisObj,
+                                        args.length > 0 ? args[0] : Undefined.instance);
                                 return Undefined.instance;
                             },
                             false);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
@@ -12,14 +12,14 @@ import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
  * implementing properties that behave like any other JavaScript property but which are implemented
  * using some native functionality without using reflection.
  */
-public class LambdaSlot extends Slot {
+public class LambdaSlot extends Slot<Scriptable> {
     private static final long serialVersionUID = -3046681698806493052L;
 
     LambdaSlot(Object name, int index) {
         super(name, index, 0);
     }
 
-    LambdaSlot(Slot oldSlot) {
+    LambdaSlot(Slot<Scriptable> oldSlot) {
         super(oldSlot);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazyLoadSlot.java
@@ -4,18 +4,18 @@ package org.mozilla.javascript;
  * This is a specialization of Slot to store values that are retrieved via calls to script
  * functions. It's used to load built-in objects more efficiently.
  */
-public class LazyLoadSlot extends Slot {
+public class LazyLoadSlot<T extends PropHolder<T>> extends Slot<T> {
     LazyLoadSlot(Object name, int index) {
         super(name, index, 0);
     }
 
-    LazyLoadSlot(Slot oldSlot) {
+    LazyLoadSlot(Slot<T> oldSlot) {
         super(oldSlot);
     }
 
     @Override
-    LazyLoadSlot copySlot() {
-        var newSlot = new LazyLoadSlot(this);
+    LazyLoadSlot<T> copySlot() {
+        var newSlot = new LazyLoadSlot<T>(this);
         newSlot.value = value;
         newSlot.next = null;
         newSlot.orderedNext = null;
@@ -23,7 +23,7 @@ public class LazyLoadSlot extends Slot {
     }
 
     @Override
-    public Object getValue(Scriptable start) {
+    public Object getValue(T start) {
         Object val = this.value;
         if (val instanceof LazilyLoadedCtor) {
             LazilyLoadedCtor initializer = (LazilyLoadedCtor) val;

--- a/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LockAwareSlotMap.java
@@ -5,7 +5,7 @@ package org.mozilla.javascript;
  * should only be used internally by implementation, or by other {@link SlotMap}s which share the
  * same lock.
  */
-interface LockAwareSlotMap extends SlotMap {
+interface LockAwareSlotMap<T extends PropHolder<T>> extends SlotMap<T> {
     /** The equivalent of {@link SlotMap#size()}. */
     int sizeWithLock();
 
@@ -13,24 +13,24 @@ interface LockAwareSlotMap extends SlotMap {
     boolean isEmptyWithLock();
 
     /** The equivalent of {@link SlotMap#modify(SlotMapOwner, Object, int, int)}. */
-    Slot modifyWithLock(SlotMapOwner owner, Object key, int index, int attributes);
+    Slot<T> modifyWithLock(SlotMapOwner<T> owner, Object key, int index, int attributes);
 
     /** The equivalent of {@link SlotMap#query(Object, int)}. */
-    Slot queryWithLock(Object key, int index);
+    Slot<T> queryWithLock(Object key, int index);
 
     /**
      * The equivalent of {@link SlotMap#compute(SlotMapOwner, Object, int,
      * org.mozilla.javascript.SlotMap.SlotComputer)}.
      */
-    <S extends Slot> S computeWithLock(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    <S extends Slot<T>> S computeWithLock(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> compute);
+            SlotComputer<S, T> compute);
 
     /** The equivalent of {@link SlotMap#add(SlotMapOwner, Slot)}. */
-    void addWithLock(SlotMapOwner owner, Slot newSlot);
+    void addWithLock(SlotMapOwner<T> owner, Slot<T> newSlot);
 
     long getReadLock();
 
@@ -39,8 +39,8 @@ interface LockAwareSlotMap extends SlotMap {
     void releaseLock(long lock);
 
     @Override
-    default CompoundOperationMap startCompoundOp(SlotMapOwner owner, boolean forWriting) {
+    default CompoundOperationMap<T> startCompoundOp(SlotMapOwner<T> owner, boolean forWriting) {
         long stamp = forWriting ? getWriteLock() : getReadLock();
-        return new ThreadSafeCompoundOperationMap(owner, this, stamp);
+        return new ThreadSafeCompoundOperationMap<T>(owner, this, stamp);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -36,7 +36,7 @@ final class MemberBox implements Serializable {
     transient Function asSetterFunction;
     transient Object delegateTo;
 
-    private final Scriptable scope;
+    final Scriptable scope;
 
     private static final NullabilityDetector nullDetector =
             ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -363,11 +363,11 @@ public class NativeArray extends ScriptableObject implements List {
         }
     }
 
-    public void deleteInternal(CompoundOperationMap compoundOp, String id) {
+    public void deleteInternal(CompoundOperationMap<Scriptable> compoundOp, String id) {
         compoundOp.compute(this, id, 0, ScriptableObject::checkSlotRemoval);
     }
 
-    public void deleteInternal(CompoundOperationMap compoundOp, int index) {
+    public void deleteInternal(CompoundOperationMap<Scriptable> compoundOp, int index) {
         var slot = denseOnly ? null : compoundOp.query(null, index);
         if (dense != null
                 && 0 <= index
@@ -381,7 +381,8 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     @Override
-    public Object[] getIds(CompoundOperationMap map, boolean nonEnumerable, boolean getSymbols) {
+    public Object[] getIds(
+            CompoundOperationMap<Scriptable> map, boolean nonEnumerable, boolean getSymbols) {
         Object[] superIds = super.getIds(map, nonEnumerable, getSymbols);
         if (dense == null) {
             return superIds;
@@ -544,13 +545,13 @@ public class NativeArray extends ScriptableObject implements List {
         builtIn.lengthAttr = attrs;
     }
 
-    private static Slot lengthDescSetValue(
+    private static Slot<Scriptable> lengthDescSetValue(
             ScriptableObject owner,
             DescriptorInfo info,
             Object key,
-            Slot existing,
-            CompoundOperationMap map,
-            Slot slot) {
+            Slot<Scriptable> existing,
+            CompoundOperationMap<Scriptable> map,
+            Slot<Scriptable> slot) {
         ((NativeArray) owner).setLength(map, (Double) info.value);
         return slot;
     }
@@ -743,7 +744,7 @@ public class NativeArray extends ScriptableObject implements List {
         return denseOnly;
     }
 
-    private boolean setLength(CompoundOperationMap compoundOp, double d) {
+    private boolean setLength(CompoundOperationMap<Scriptable> compoundOp, double d) {
         /* XXX do we satisfy this?
          * 15.4.5.1 [[Put]](P, V):
          * 1. Call the [[CanPut]] method of A with name P.
@@ -875,7 +876,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     /* This version explicitly checks whether the target is  sealed. The other implementation which does not take a compound op does not do so explicitly, but it does rely on the underlying `delete` implementation doing that check. */
     private static void deleteElem(
-            CompoundOperationMap compoundOp, NativeArray target, long index) {
+            CompoundOperationMap<Scriptable> compoundOp, NativeArray target, long index) {
         int i = (int) index;
         if (i == index) {
             checkNotSealed(target, null, i);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -546,7 +546,8 @@ final class NativeString extends ScriptableObject {
     }
 
     @Override
-    protected Object[] getIds(CompoundOperationMap map, boolean nonEnumerable, boolean getSymbols) {
+    protected Object[] getIds(
+            CompoundOperationMap<Scriptable> map, boolean nonEnumerable, boolean getSymbols) {
         // In ES6, Strings have entries in the property map for each character.
         Context cx = Context.getCurrentContext();
         if ((cx != null) && (cx.getLanguageVersion() >= Context.VERSION_ES6)) {

--- a/rhino/src/main/java/org/mozilla/javascript/PropHolder.java
+++ b/rhino/src/main/java/org/mozilla/javascript/PropHolder.java
@@ -1,0 +1,49 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// API class
+
+package org.mozilla.javascript;
+
+/**
+ * Interface the common route of JS objects and environment records, i.e. a thing that has
+ * properties and some form of ancestor. Although environment records do not hold user accessible
+ * keys which are symbols or numbers, it is useful to include these as it makes the concrete map
+ * implementations simpler and they may be useful for internally maintained vbalues.
+ */
+public interface PropHolder<T extends PropHolder<T>> {
+
+    public Object get(Symbol key, T start);
+
+    public Object get(String name, T start);
+
+    public Object get(int index, T start);
+
+    public boolean has(Symbol name, T start);
+
+    public boolean has(String name, T start);
+
+    public boolean has(int index, T start);
+
+    public void put(Symbol name, T start, Object value);
+
+    public void put(String name, T start, Object value);
+
+    public void put(int index, T start, Object value);
+
+    public void delete(Symbol name);
+
+    public void delete(String name);
+
+    public void delete(int index);
+
+    /**
+     * Get the parent scope of the object.
+     *
+     * @return the parent scope
+     */
+    public T getAncestor();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -92,12 +92,12 @@ public class ScriptRuntime {
             preventExtensions();
         }
 
-        private static Slot removeWithoutChecking(
+        private static <T extends PropHolder<T>> Slot<T> removeWithoutChecking(
                 Object key,
                 int index,
                 Slot slot,
-                CompoundOperationMap compoundOp,
-                SlotMapOwner owner) {
+                CompoundOperationMap<T> compoundOp,
+                SlotMapOwner<T> owner) {
             return null;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
@@ -23,7 +23,7 @@ package org.mozilla.javascript;
  * @author Nick Thompson
  * @author Brendan Eich
  */
-public interface Scriptable {
+public interface Scriptable extends PropHolder<Scriptable> {
 
     /**
      * Get the name of the set of objects implemented by this Java class. This corresponds to the
@@ -76,6 +76,7 @@ public interface Scriptable {
      * @return the value of the property (may be null), or NOT_FOUND
      * @see org.mozilla.javascript.Context#getUndefinedValue
      */
+    @Override
     public Object get(String name, Scriptable start);
 
     /**
@@ -89,7 +90,13 @@ public interface Scriptable {
      * @return the value of the property (may be null), or NOT_FOUND
      * @see org.mozilla.javascript.Scriptable#get(String,Scriptable)
      */
+    @Override
     public Object get(int index, Scriptable start);
+
+    @Override
+    default Object get(Symbol key, Scriptable start) {
+        return ScriptableObject.NOT_FOUND;
+    }
 
     /**
      * Indicates whether or not a named property is defined in an object.
@@ -104,6 +111,7 @@ public interface Scriptable {
      * @see org.mozilla.javascript.Scriptable#get(String, Scriptable)
      * @see org.mozilla.javascript.ScriptableObject#getProperty(Scriptable, String)
      */
+    @Override
     public boolean has(String name, Scriptable start);
 
     /**
@@ -119,7 +127,13 @@ public interface Scriptable {
      * @see org.mozilla.javascript.Scriptable#get(int, Scriptable)
      * @see org.mozilla.javascript.ScriptableObject#getProperty(Scriptable, int)
      */
+    @Override
     public boolean has(int index, Scriptable start);
+
+    @Override
+    default boolean has(Symbol key, Scriptable start) {
+        return false;
+    }
 
     /**
      * Sets a named property in this object.
@@ -167,6 +181,7 @@ public interface Scriptable {
      * @see org.mozilla.javascript.ScriptableObject#putProperty(Scriptable, String, Object)
      * @see org.mozilla.javascript.Context#toObject(Object, Scriptable)
      */
+    @Override
     public void put(String name, Scriptable start, Object value);
 
     /**
@@ -185,7 +200,11 @@ public interface Scriptable {
      * @see org.mozilla.javascript.ScriptableObject#putProperty(Scriptable, int, Object)
      * @see org.mozilla.javascript.Context#toObject(Object, Scriptable)
      */
+    @Override
     public void put(int index, Scriptable start, Object value);
+
+    @Override
+    default void put(Symbol key, Scriptable start, Object value) {}
 
     /**
      * Removes a property from this object. This operation corresponds to the ECMA [[Delete]] except
@@ -204,6 +223,7 @@ public interface Scriptable {
      * @see org.mozilla.javascript.Scriptable#get(String, Scriptable)
      * @see org.mozilla.javascript.ScriptableObject#deleteProperty(Scriptable, String)
      */
+    @Override
     public void delete(String name);
 
     /**
@@ -220,7 +240,11 @@ public interface Scriptable {
      * @see org.mozilla.javascript.Scriptable#get(int, Scriptable)
      * @see org.mozilla.javascript.ScriptableObject#deleteProperty(Scriptable, int)
      */
+    @Override
     public void delete(int index);
+
+    @Override
+    default void delete(Symbol key) {}
 
     /**
      * Get the prototype of the object.
@@ -228,6 +252,11 @@ public interface Scriptable {
      * @return the prototype
      */
     public Scriptable getPrototype();
+
+    @Override
+    default Scriptable getAncestor() {
+        return getPrototype();
+    }
 
     /**
      * Set the prototype of the object.

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -50,8 +50,12 @@ import org.mozilla.javascript.debug.DebuggableObject;
  * @see org.mozilla.javascript.Scriptable
  * @author Norris Boyd
  */
-public abstract class ScriptableObject extends SlotMapOwner
-        implements Scriptable, SymbolScriptable, Serializable, DebuggableObject, ConstProperties {
+public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
+        implements Scriptable,
+                SymbolScriptable,
+                Serializable,
+                DebuggableObject,
+                ConstProperties<Scriptable> {
 
     private static final long serialVersionUID = 2829861078851942586L;
 
@@ -188,6 +192,10 @@ public abstract class ScriptableObject extends SlotMapOwner
         return null != getMap().query(name, 0);
     }
 
+    public ScriptableObject getThis() {
+        return this;
+    }
+
     /**
      * Returns true if the property index is defined.
      *
@@ -220,7 +228,7 @@ public abstract class ScriptableObject extends SlotMapOwner
      */
     @Override
     public Object get(String name, Scriptable start) {
-        Slot slot = getMap().query(name, 0);
+        var slot = getMap().query(name, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -243,7 +251,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             return Scriptable.NOT_FOUND;
         }
 
-        Slot slot = getMap().query(null, index);
+        var slot = getMap().query(null, index);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -253,7 +261,7 @@ public abstract class ScriptableObject extends SlotMapOwner
     /** Another version of Get that supports Symbol keyed properties. */
     @Override
     public Object get(Symbol key, Scriptable start) {
-        Slot slot = getMap().query(key, 0);
+        var slot = getMap().query(key, 0);
         if (slot == null) {
             return Scriptable.NOT_FOUND;
         }
@@ -387,8 +395,12 @@ public abstract class ScriptableObject extends SlotMapOwner
         getMap().compute(this, key, 0, ScriptableObject::checkSlotRemoval);
     }
 
-    protected static Slot checkSlotRemoval(
-            Object key, int index, Slot slot, CompoundOperationMap compoundOp, SlotMapOwner owner) {
+    protected static <T extends PropHolder<T>> Slot<T> checkSlotRemoval(
+            Object key,
+            int index,
+            Slot<T> slot,
+            CompoundOperationMap<T> compoundOp,
+            SlotMapOwner<T> owner) {
         if ((slot != null) && ((slot.getAttributes() & ScriptableObject.PERMANENT) != 0)) {
             Context cx = Context.getContext();
             if (cx.isStrictMode()) {
@@ -418,9 +430,11 @@ public abstract class ScriptableObject extends SlotMapOwner
         if (putConstImpl(name, 0, start, value, READONLY)) return;
 
         if (start == this) throw Kit.codeBug();
-        if (start instanceof ConstProperties)
-            ((ConstProperties) start).putConst(name, start, value);
-        else start.put(name, start, value);
+        if (start instanceof ConstProperties) {
+            @SuppressWarnings("unchecked")
+            var cstart = ((ConstProperties<Scriptable>) start);
+            cstart.putConst(name, start, value);
+        } else start.put(name, start, value);
     }
 
     @Override
@@ -428,7 +442,11 @@ public abstract class ScriptableObject extends SlotMapOwner
         if (putConstImpl(name, 0, start, Undefined.instance, UNINITIALIZED_CONST)) return;
 
         if (start == this) throw Kit.codeBug();
-        if (start instanceof ConstProperties) ((ConstProperties) start).defineConst(name, start);
+        if (start instanceof ConstProperties) {
+            @SuppressWarnings("unchecked")
+            var cstart = ((ConstProperties<Scriptable>) start);
+            cstart.defineConst(name, start);
+        }
     }
 
     /**
@@ -439,7 +457,7 @@ public abstract class ScriptableObject extends SlotMapOwner
      */
     @Override
     public boolean isConst(String name) {
-        Slot slot = getMap().query(name, 0);
+        var slot = getMap().query(name, 0);
         if (slot == null) {
             return false;
         }
@@ -580,7 +598,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             // Create a new AccessorSlot, or cast it if it's already set
             aSlot = getMap().compute(this, name, index, ScriptableObject::ensureAccessorSlot);
         } else {
-            Slot slot = getMap().query(name, index);
+            var slot = getMap().query(name, index);
             if (slot instanceof AccessorSlot) {
                 aSlot = (AccessorSlot) slot;
             } else {
@@ -626,7 +644,7 @@ public abstract class ScriptableObject extends SlotMapOwner
      */
     public Object getGetterOrSetter(String name, int index, Scriptable scope, boolean isSetter) {
         if (name != null && index != 0) throw new IllegalArgumentException(name);
-        Slot slot = getMap().query(name, index);
+        var slot = getMap().query(name, index);
         if (slot == null) return null;
         Function getterOrSetter =
                 isSetter
@@ -669,7 +687,7 @@ public abstract class ScriptableObject extends SlotMapOwner
 
     protected boolean isGetterOrSetter(
             CompoundOperationMap map, String name, int index, boolean setter) {
-        Slot slot = map.query(name, index);
+        var slot = map.query(name, index);
         return (slot != null && slot.isSetterSlot());
     }
 
@@ -732,6 +750,11 @@ public abstract class ScriptableObject extends SlotMapOwner
     /** Returns the prototype of the object. */
     @Override
     public Scriptable getPrototype() {
+        return prototypeObject;
+    }
+
+    @Override
+    public Scriptable getAncestor() {
         return prototypeObject;
     }
 
@@ -1448,7 +1471,8 @@ public abstract class ScriptableObject extends SlotMapOwner
      */
     public static void defineConstProperty(Scriptable destination, String propertyName) {
         if (destination instanceof ConstProperties) {
-            ConstProperties cp = (ConstProperties) destination;
+            @SuppressWarnings("unchecked")
+            var cp = (ConstProperties<Scriptable>) destination;
             cp.defineConst(propertyName, destination);
         } else defineProperty(destination, propertyName, Undefined.instance, CONST);
     }
@@ -1701,7 +1725,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             }
         }
 
-        Slot aSlot = getMap().query(key, index);
+        var aSlot = getMap().query(key, index);
 
         if (aSlot instanceof BuiltInSlot) {
             // 10.4.2.4 ArrayLengthSet requires we check that any new
@@ -1862,7 +1886,7 @@ public abstract class ScriptableObject extends SlotMapOwner
     static boolean defineOrdinaryProperty(
             PropDescValueSetter descValueSetter,
             ScriptableObject owner,
-            CompoundOperationMap compoundOp,
+            CompoundOperationMap<Scriptable> compoundOp,
             Object id,
             DescriptorInfo info,
             boolean checkValid,
@@ -1880,11 +1904,11 @@ public abstract class ScriptableObject extends SlotMapOwner
                         owner.checkPropertyChangeForSlot(id, existing, info);
                     }
 
-                    Slot slot;
+                    Slot<Scriptable> slot;
                     int attributes;
 
                     if (existing == null) {
-                        slot = new Slot(k, ix, 0);
+                        slot = new Slot<>(k, ix, 0);
                         attributes =
                                 applyDescriptorToAttributeBitset(
                                         DONTENUM | READONLY | PERMANENT,
@@ -1911,22 +1935,22 @@ public abstract class ScriptableObject extends SlotMapOwner
     }
 
     interface PropDescValueSetter {
-        Slot execute(
+        Slot<Scriptable> execute(
                 ScriptableObject owner,
                 DescriptorInfo info,
                 Object key,
-                Slot existing,
-                CompoundOperationMap map,
-                Slot slot);
+                Slot<Scriptable> existing,
+                CompoundOperationMap<Scriptable> map,
+                Slot<Scriptable> slot);
     }
 
-    static Slot setSlotValue(
+    static Slot<Scriptable> setSlotValue(
             ScriptableObject owner,
             DescriptorInfo info,
             Object key,
-            Slot existing,
-            CompoundOperationMap map,
-            Slot slot) {
+            Slot<Scriptable> existing,
+            CompoundOperationMap<Scriptable> map,
+            Slot<Scriptable> slot) {
         if (info.accessorDescriptor) {
             AccessorSlot fslot;
             if (slot instanceof AccessorSlot) {
@@ -1955,7 +1979,7 @@ public abstract class ScriptableObject extends SlotMapOwner
         } else {
             if (!slot.isValueSlot() && info.isDataDescriptor()) {
                 // Replace a non-base slot with a regular slot
-                slot = new Slot(slot);
+                slot = new Slot<>(slot);
             }
 
             if (info.value != NOT_FOUND) {
@@ -1985,7 +2009,7 @@ public abstract class ScriptableObject extends SlotMapOwner
      */
     public void defineProperty(
             String name, Supplier<Object> getter, Consumer<Object> setter, int attributes) {
-        LambdaSlot slot = getMap().compute(this, name, 0, ScriptableObject::ensureLambdaSlot);
+        var slot = getMap().compute(this, name, 0, ScriptableObject::ensureLambdaSlot);
         slot.setAttributes(attributes);
         slot.getter = getter;
         slot.setter = setter;
@@ -2084,7 +2108,7 @@ public abstract class ScriptableObject extends SlotMapOwner
     }
 
     private LambdaAccessorSlot replaceExistingLambdaSlot(
-            Context cx, Object key, Slot existing, LambdaAccessorSlot newSlot) {
+            Context cx, Object key, Slot<Scriptable> existing, LambdaAccessorSlot newSlot) {
         LambdaAccessorSlot replacedSlot;
         if (existing instanceof LambdaAccessorSlot) {
             replacedSlot = (LambdaAccessorSlot) existing;
@@ -2454,9 +2478,9 @@ public abstract class ScriptableObject extends SlotMapOwner
         // to try to acquire a write lock while holding the read lock... and deadlock.
         // We do this in a loop because an initialization could add _other_ stuff to initialize.
 
-        List<Slot> toInitialize = new ArrayList<>();
+        List<Slot<Scriptable>> toInitialize = new ArrayList<>();
         while (!isSealed) {
-            for (Slot slot : toInitialize) {
+            for (var slot : toInitialize) {
                 // Need to check the type again, because initializing one slot _could_ have
                 // initialized another one
                 Object value = slot.value;
@@ -2472,7 +2496,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             toInitialize.clear();
 
             try (var map = startCompoundOp(false)) {
-                for (Slot slot : map) {
+                for (var slot : map) {
                     Object value = slot.value;
                     if (value instanceof LazilyLoadedCtor) {
                         toInitialize.add(slot);
@@ -2760,7 +2784,11 @@ public abstract class ScriptableObject extends SlotMapOwner
     public static void putConstProperty(Scriptable obj, String name, Object value) {
         Scriptable base = getBase(obj, name);
         if (base == null) base = obj;
-        if (base instanceof ConstProperties) ((ConstProperties) base).putConst(name, obj, value);
+        if (base instanceof ConstProperties) {
+            @SuppressWarnings("unchecked")
+            var cbase = ((ConstProperties<Scriptable>) base);
+            cbase.putConst(name, obj, value);
+        }
     }
 
     /**
@@ -3017,7 +3045,7 @@ public abstract class ScriptableObject extends SlotMapOwner
             Object key, int index, Scriptable start, Object value, boolean isThrow) {
         // This method is very hot (basically called on each assignment),
         // so we inline the extensible/sealed checks below.
-        Slot slot;
+        Slot<Scriptable> slot;
         if (this != start) {
             slot = getMap().query(key, index);
             if (!isExtensible
@@ -3069,7 +3097,7 @@ public abstract class ScriptableObject extends SlotMapOwner
                 throw ScriptRuntime.typeErrorById("msg.not.extensible");
             }
         }
-        Slot slot;
+        Slot<Scriptable> slot;
         if (this != start) {
             slot = getMap().query(name, index);
             if (slot == null) {
@@ -3098,8 +3126,8 @@ public abstract class ScriptableObject extends SlotMapOwner
         return slot.setValue(value, this, start);
     }
 
-    private Slot getAttributeSlot(String name, int index) {
-        Slot slot = getMap().query(name, index);
+    private Slot<Scriptable> getAttributeSlot(String name, int index) {
+        var slot = getMap().query(name, index);
         if (slot == null) {
             String str = (name != null ? name : Integer.toString(index));
             throw Context.reportRuntimeErrorById("msg.prop.not.found", str);
@@ -3107,15 +3135,16 @@ public abstract class ScriptableObject extends SlotMapOwner
         return slot;
     }
 
-    private Slot getAttributeSlot(Symbol key) {
-        Slot slot = getMap().query(key, 0);
+    private Slot<Scriptable> getAttributeSlot(Symbol key) {
+        var slot = getMap().query(key, 0);
         if (slot == null) {
             throw Context.reportRuntimeErrorById("msg.prop.not.found", key);
         }
         return slot;
     }
 
-    Object[] getIds(CompoundOperationMap map, boolean getNonEnumerable, boolean getSymbols) {
+    Object[] getIds(
+            CompoundOperationMap<Scriptable> map, boolean getNonEnumerable, boolean getSymbols) {
         Object[] a;
         int externalLen = (externalData == null ? 0 : externalData.getArrayLength());
 
@@ -3132,7 +3161,7 @@ public abstract class ScriptableObject extends SlotMapOwner
         }
 
         int c = externalLen;
-        for (Slot slot : map) {
+        for (var slot : map) {
             if ((getNonEnumerable || (slot.getAttributes() & DONTENUM) == 0)
                     && (getSymbols || !(slot.name instanceof Symbol))) {
                 if (c == externalLen) {
@@ -3168,7 +3197,11 @@ public abstract class ScriptableObject extends SlotMapOwner
      * These are handy for changing slot types in one "compute" operation.
      */
     private static AccessorSlot ensureAccessorSlot(
-            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
+            Object name,
+            int index,
+            Slot<Scriptable> existing,
+            SlotMap<Scriptable> compoundOp,
+            SlotMapOwner<Scriptable> owner) {
         if (existing == null) {
             return new AccessorSlot(name, index);
         } else if (existing instanceof AccessorSlot) {
@@ -3178,19 +3211,27 @@ public abstract class ScriptableObject extends SlotMapOwner
         }
     }
 
-    private static LazyLoadSlot ensureLazySlot(
-            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
+    static <T extends PropHolder<T>> LazyLoadSlot<T> ensureLazySlot(
+            Object name,
+            int index,
+            Slot<T> existing,
+            SlotMap<T> compoundOp,
+            SlotMapOwner<T> owner) {
         if (existing == null) {
-            return new LazyLoadSlot(name, index);
+            return new LazyLoadSlot<T>(name, index);
         } else if (existing instanceof LazyLoadSlot) {
-            return (LazyLoadSlot) existing;
+            return (LazyLoadSlot<T>) existing;
         } else {
-            return new LazyLoadSlot(existing);
+            return new LazyLoadSlot<>(existing);
         }
     }
 
     private static LambdaSlot ensureLambdaSlot(
-            Object name, int index, Slot existing, SlotMap compoundOp, SlotMapOwner owner) {
+            Object name,
+            int index,
+            Slot<Scriptable> existing,
+            SlotMap<Scriptable> compoundOp,
+            SlotMapOwner<Scriptable> owner) {
         if (existing == null) {
             return new LambdaSlot(name, index);
         } else if (existing instanceof LambdaSlot) {
@@ -3221,18 +3262,19 @@ public abstract class ScriptableObject extends SlotMapOwner
         int tableSize = in.readInt();
         setMap(createSlotMap(tableSize));
         for (int i = 0; i < tableSize; i++) {
-            Slot slot = (Slot) in.readObject();
+            @SuppressWarnings("unchecked")
+            var slot = (Slot<Scriptable>) in.readObject();
             getMap().add(this, slot);
         }
     }
 
     protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
-        Slot slot = querySlot(cx, id);
+        var slot = querySlot(cx, id);
         if (slot == null) return null;
         return slot.getPropertyDescriptor(cx, this);
     }
 
-    protected final Slot querySlot(Context cx, Object id) {
+    protected final Slot<Scriptable> querySlot(Context cx, Object id) {
         if (id instanceof Symbol) {
             return getMap().query(id, 0);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * A Slot is the base class for all properties stored in the ScriptableObject class. There are a
@@ -10,14 +11,14 @@ import java.io.Serializable;
  * primitive type or another object. Separate classes are used to represent properties that have
  * various types of getter and setter methods.
  */
-public class Slot implements Serializable {
+public class Slot<T extends PropHolder<T>> implements Serializable {
     private static final long serialVersionUID = -6090581677123995491L;
     Object name; // This can change due to caching
     int indexOrHash;
     private short attributes;
     Object value;
-    transient Slot next; // next in hash table bucket
-    transient Slot orderedNext; // next in linked list
+    transient Slot<T> next; // next in hash table bucket
+    transient Slot<T> orderedNext; // next in linked list
 
     Slot(Object name, int index, int attributes) {
         this.name = name;
@@ -25,8 +26,8 @@ public class Slot implements Serializable {
         this.attributes = (short) attributes;
     }
 
-    Slot copySlot() {
-        var newSlot = new Slot(this);
+    Slot<T> copySlot() {
+        var newSlot = new Slot<T>(this);
         newSlot.next = null;
         newSlot.orderedNext = null;
         return newSlot;
@@ -47,7 +48,7 @@ public class Slot implements Serializable {
         return false;
     }
 
-    protected Slot(Slot oldSlot) {
+    protected Slot(Slot<T> oldSlot) {
         name = oldSlot.name;
         indexOrHash = oldSlot.indexOrHash;
         attributes = oldSlot.attributes;
@@ -63,11 +64,11 @@ public class Slot implements Serializable {
         }
     }
 
-    public final boolean setValue(Object value, Scriptable owner, Scriptable start) {
+    public final boolean setValue(Object value, T owner, T start) {
         return setValue(value, owner, start, Context.isCurrentContextStrict());
     }
 
-    public boolean setValue(Object value, Scriptable owner, Scriptable start, boolean isThrow) {
+    public boolean setValue(Object value, T owner, T start, boolean isThrow) {
         if ((attributes & ScriptableObject.READONLY) != 0) {
             if (isThrow) {
                 throw ScriptRuntime.typeErrorById("msg.modify.readonly", name);
@@ -81,7 +82,7 @@ public class Slot implements Serializable {
         return false;
     }
 
-    public Object getValue(Scriptable start) {
+    public Object getValue(T start) {
         return value;
     }
 
@@ -94,11 +95,11 @@ public class Slot implements Serializable {
         attributes = (short) value;
     }
 
-    ScriptableObject.DescriptorInfo getPropertyDescriptor(Context cx, Scriptable scope) {
+    DescriptorInfo getPropertyDescriptor(Context cx, T scope) {
         return ScriptableObject.buildDataDescriptor(value, attributes);
     }
 
-    protected void throwNoSetterException(Scriptable start, Object newValue) {
+    protected void throwNoSetterException(T start, Object newValue) {
         Context cx = Context.getContext();
         if (cx.isStrictMode()
                 ||
@@ -108,7 +109,7 @@ public class Slot implements Serializable {
 
             String prop = "";
             if (name != null) {
-                prop = "[" + start.getClassName() + "]." + name;
+                prop = "[" + ((Scriptable) start).getClassName() + "]." + name;
             }
             throw ScriptRuntime.typeErrorById(
                     "msg.set.prop.no.setter", prop, Context.toString(newValue));
@@ -119,12 +120,12 @@ public class Slot implements Serializable {
      * Return a JavaScript function that represents the "setter". This is used by some legacy
      * functionality. Return null if there is no setter.
      */
-    Function getSetterFunction(String name, Scriptable scope) {
+    Function getSetterFunction(String name, T scope) {
         return null;
     }
 
     /** Same for the "getter." */
-    Function getGetterFunction(String name, Scriptable scope) {
+    Function getGetterFunction(String name, T scope) {
         return null;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMap.java
@@ -15,18 +15,18 @@ package org.mozilla.javascript;
  * ScriptableObject are complex. Many attempts to make this interface more elegant have resulted in
  * substantial performance regressions so we are doing the best that we can.
  */
-public interface SlotMap extends Iterable<Slot> {
+public interface SlotMap<T extends PropHolder<T>> extends Iterable<Slot<T>> {
 
     @SuppressWarnings("AndroidJdkLibsChecker")
     // https://developer.android.com/reference/java/lang/FunctionalInterface added in API level 24
     @FunctionalInterface
-    public interface SlotComputer<S extends Slot> {
+    public interface SlotComputer<S extends Slot<T>, T extends PropHolder<T>> {
         S compute(
                 Object key,
                 int index,
-                Slot existing,
-                CompoundOperationMap mutableMap,
-                SlotMapOwner owner);
+                Slot<T> existing,
+                CompoundOperationMap<T> mutableMap,
+                SlotMapOwner<T> owner);
     }
 
     /** Return the size of the map. */
@@ -45,7 +45,7 @@ public interface SlotMap extends Iterable<Slot> {
      *     slots will not be modified.
      * @return a Slot, which will be created anew if no such slot exists.
      */
-    Slot modify(SlotMapOwner owner, Object key, int index, int attributes);
+    Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes);
 
     /**
      * Retrieve the slot at EITHER key or index, or return null if the slot cannot be found.
@@ -54,7 +54,7 @@ public interface SlotMap extends Iterable<Slot> {
      * @param index if key is zero, then this will be used as the key instead.
      * @return either the Slot that matched the key and index, or null
      */
-    Slot query(Object key, int index);
+    Slot<T> query(Object key, int index);
 
     /**
      * Replace the value of key with the slot computed by the "compute" method. If "compute" throws
@@ -64,31 +64,31 @@ public interface SlotMap extends Iterable<Slot> {
      * code and is more efficient than making multiple calls to this interface. In order to allow
      * use of multiple Slot subclasses, this function is templatized.
      */
-    default <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+    default <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner, Object key, int index, SlotComputer<S, T> compute) {
         try (var mutableMap = owner.startCompoundOp(true)) {
             return mutableMap.compute(owner, mutableMap, key, index, compute);
         }
     }
 
-    <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+    <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> mutableMap,
             Object key,
             int index,
-            SlotComputer<S> compute);
+            SlotComputer<S, T> compute);
 
     /**
      * Insert a new slot to the map. Both "name" and "indexOrHash" must be populated. Note that
      * ScriptableObject generally adds slots via the "modify" method.
      */
-    void add(SlotMapOwner owner, Slot newSlot);
+    void add(SlotMapOwner<T> owner, Slot<T> newSlot);
 
     default int dirtySize() {
         return size();
     }
 
-    default CompoundOperationMap startCompoundOp(SlotMapOwner owner, boolean forWriting) {
-        return new CompoundOperationMap(owner);
+    default CompoundOperationMap<T> startCompoundOp(SlotMapOwner<T> owner, boolean forWriting) {
+        return new CompoundOperationMap<T>(owner);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SlotMapOwner.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
-public abstract class SlotMapOwner {
+public abstract class SlotMapOwner<T extends PropHolder<T>> implements PropHolder<T> {
     private static final long serialVersionUID = 1L;
 
     /**
@@ -17,9 +17,9 @@ public abstract class SlotMapOwner {
      */
     static final int LARGE_HASH_SIZE = (1 << 10) + (1 << 9);
 
-    static final SlotMap EMPTY_SLOT_MAP = new EmptySlotMap();
+    static final SlotMap<?> EMPTY_SLOT_MAP = new EmptySlotMap<>();
 
-    static final SlotMap THREAD_SAFE_EMPTY_SLOT_MAP = new ThreadSafeEmptySlotMap();
+    static final SlotMap<?> THREAD_SAFE_EMPTY_SLOT_MAP = new ThreadSafeEmptySlotMap<>();
 
     @SuppressWarnings("AndroidJdkLibsChecker")
     // https://developer.android.com/reference/java/lang/invoke/VarHandle added in API level 33
@@ -37,15 +37,16 @@ public abstract class SlotMapOwner {
             }
         }
 
-        static SlotMap checkAndReplaceMap(SlotMapOwner owner, SlotMap oldMap, SlotMap newMap) {
-            return (SlotMap) SLOT_MAP.compareAndExchange(owner, oldMap, newMap);
+        static <T extends PropHolder<T>> SlotMap<T> checkAndReplaceMap(
+                SlotMapOwner<T> owner, SlotMap<T> oldMap, SlotMap<T> newMap) {
+            return (SlotMap<T>) SLOT_MAP.compareAndExchange(owner, oldMap, newMap);
         }
     }
 
-    private static class EmptySlotMap implements SlotMap {
+    private static class EmptySlotMap<T extends PropHolder<T>> implements SlotMap<T> {
 
         @Override
-        public Iterator<Slot> iterator() {
+        public Iterator<Slot<T>> iterator() {
             return Collections.emptyIterator();
         }
 
@@ -60,37 +61,37 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
-            var newSlot = new Slot(key, index, attributes);
-            var map = new SingleEntrySlotMap(newSlot);
+        public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
+            var newSlot = new Slot<T>(key, index, attributes);
+            var map = new SingleEntrySlotMap<T>(newSlot);
             owner.setMap(map);
             return newSlot;
         }
 
         @Override
-        public Slot query(Object key, int index) {
+        public Slot<T> query(Object key, int index) {
             return null;
         }
 
         @Override
-        public void add(SlotMapOwner owner, Slot newSlot) {
+        public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
             if (newSlot != null) {
-                var map = new SingleEntrySlotMap(newSlot);
+                var map = new SingleEntrySlotMap<T>(newSlot);
                 owner.setMap(map);
             }
         }
 
         @Override
-        public <S extends Slot> S compute(
-                SlotMapOwner owner,
-                CompoundOperationMap compoundOp,
+        public <S extends Slot<T>> S compute(
+                SlotMapOwner<T> owner,
+                CompoundOperationMap<T> compoundOp,
                 Object key,
                 int index,
-                SlotComputer<S> c) {
+                SlotComputer<S, T> c) {
             var newSlot = c.compute(key, index, null, compoundOp, owner);
             if (newSlot != null) {
                 if (!compoundOp.isTouched()) {
-                    var map = new SingleEntrySlotMap(newSlot);
+                    var map = new SingleEntrySlotMap<T>(newSlot);
                     owner.setMap(map);
                 } else {
                     // The map has been touched so delegate the add (can't do
@@ -102,11 +103,12 @@ public abstract class SlotMapOwner {
         }
     }
 
-    private static final class ThreadSafeEmptySlotMap extends EmptySlotMap {
+    private static final class ThreadSafeEmptySlotMap<T extends PropHolder<T>>
+            extends EmptySlotMap<T> {
 
         @Override
-        public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
-            var newSlot = new Slot(key, index, attributes);
+        public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
+            var newSlot = new Slot<T>(key, index, attributes);
             var currentMap = replaceMapAndAddSlot(owner, newSlot);
             if (currentMap != this) {
                 return currentMap.modify(owner, key, index, attributes);
@@ -115,7 +117,7 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public void add(SlotMapOwner owner, Slot newSlot) {
+        public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
             if (newSlot != null) {
                 var currentMap = replaceMapAndAddSlot(owner, newSlot);
                 if (currentMap != this) {
@@ -125,12 +127,12 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public <S extends Slot> S compute(
-                SlotMapOwner owner,
-                CompoundOperationMap compoundOp,
+        public <S extends Slot<T>> S compute(
+                SlotMapOwner<T> owner,
+                CompoundOperationMap<T> compoundOp,
                 Object key,
                 int index,
-                SlotComputer<S> c) {
+                SlotComputer<S, T> c) {
             var newSlot = c.compute(key, index, null, compoundOp, owner);
             if (newSlot != null) {
                 var currentMap = replaceMapAndAddSlot(owner, newSlot);
@@ -141,23 +143,23 @@ public abstract class SlotMapOwner {
             return newSlot;
         }
 
-        private SlotMap replaceMapAndAddSlot(SlotMapOwner owner, Slot newSlot) {
-            var map = new ThreadSafeSingleEntrySlotMap(newSlot);
+        private SlotMap<T> replaceMapAndAddSlot(SlotMapOwner<T> owner, Slot<T> newSlot) {
+            var map = new ThreadSafeSingleEntrySlotMap<T>(newSlot);
             return ThreadedAccess.checkAndReplaceMap(owner, this, map);
         }
 
         @Override
-        public CompoundOperationMap startCompoundOp(SlotMapOwner owner, boolean forWriting) {
-            var map = new ThreadSafeEmbeddedSlotMap();
+        public CompoundOperationMap<T> startCompoundOp(SlotMapOwner<T> owner, boolean forWriting) {
+            var map = new ThreadSafeEmbeddedSlotMap<T>();
             return ThreadedAccess.checkAndReplaceMap(owner, this, map)
                     .startCompoundOp(owner, forWriting);
         }
     }
 
-    private static final class Iter implements Iterator<Slot> {
-        private Slot next;
+    private static final class Iter<T extends PropHolder<T>> implements Iterator<Slot<T>> {
+        private Slot<T> next;
 
-        Iter(Slot slot) {
+        Iter(Slot<T> slot) {
             next = slot;
         }
 
@@ -167,8 +169,8 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public Slot next() {
-            Slot ret = next;
+        public Slot<T> next() {
+            Slot<T> ret = next;
             if (ret == null) {
                 throw new NoSuchElementException();
             }
@@ -177,18 +179,18 @@ public abstract class SlotMapOwner {
         }
     }
 
-    static class SingleEntrySlotMap implements SlotMap {
+    static class SingleEntrySlotMap<T extends PropHolder<T>> implements SlotMap<T> {
 
-        SingleEntrySlotMap(Slot slot) {
+        SingleEntrySlotMap(Slot<T> slot) {
             assert (slot != null);
             this.slot = slot;
         }
 
-        protected final Slot slot;
+        protected final Slot<T> slot;
 
         @Override
-        public Iterator<Slot> iterator() {
-            return new Iter(slot);
+        public Iterator<Slot<T>> iterator() {
+            return new Iter<T>(slot);
         }
 
         @Override
@@ -202,19 +204,19 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+        public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
             final int indexOrHash = (key != null ? key.hashCode() : index);
 
             if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
                 return slot;
             }
-            Slot newSlot = new Slot(key, index, attributes);
+            Slot<T> newSlot = new Slot<T>(key, index, attributes);
             add(owner, newSlot);
             return newSlot;
         }
 
         @Override
-        public Slot query(Object key, int index) {
+        public Slot<T> query(Object key, int index) {
             final int indexOrHash = (key != null ? key.hashCode() : index);
 
             if (indexOrHash == slot.indexOrHash && Objects.equals(slot.name, key)) {
@@ -224,11 +226,11 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public void add(SlotMapOwner owner, Slot newSlot) {
+        public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
             if (owner == null) {
                 throw new IllegalStateException();
             } else {
-                var newMap = new EmbeddedSlotMap();
+                var newMap = new EmbeddedSlotMap<T>();
                 owner.setMap(newMap);
                 newMap.add(owner, slot);
                 newMap.add(owner, newSlot);
@@ -236,31 +238,32 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public <S extends Slot> S compute(
-                SlotMapOwner owner,
-                CompoundOperationMap compoundOp,
+        public <S extends Slot<T>> S compute(
+                SlotMapOwner<T> owner,
+                CompoundOperationMap<T> compoundOp,
                 Object key,
                 int index,
-                SlotComputer<S> c) {
-            var newMap = new EmbeddedSlotMap();
+                SlotComputer<S, T> c) {
+            var newMap = new EmbeddedSlotMap<T>();
             owner.setMap(newMap);
             newMap.add(owner, slot);
             return newMap.compute(owner, compoundOp, key, index, c);
         }
     }
 
-    static final class ThreadSafeSingleEntrySlotMap extends SingleEntrySlotMap {
+    static final class ThreadSafeSingleEntrySlotMap<T extends PropHolder<T>>
+            extends SingleEntrySlotMap<T> {
 
-        ThreadSafeSingleEntrySlotMap(Slot slot) {
+        ThreadSafeSingleEntrySlotMap(Slot<T> slot) {
             super(slot);
         }
 
         @Override
-        public void add(SlotMapOwner owner, Slot newSlot) {
+        public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
             if (owner == null) {
                 throw new IllegalStateException();
             } else {
-                var newMap = new ThreadSafeEmbeddedSlotMap(2);
+                var newMap = new ThreadSafeEmbeddedSlotMap<T>(2);
                 newMap.add(null, slot);
                 var currentMap = ThreadedAccess.checkAndReplaceMap(owner, this, newMap);
                 if (currentMap == this) {
@@ -272,23 +275,23 @@ public abstract class SlotMapOwner {
         }
 
         @Override
-        public <S extends Slot> S compute(
-                SlotMapOwner owner,
-                CompoundOperationMap compoundOp,
+        public <S extends Slot<T>> S compute(
+                SlotMapOwner<T> owner,
+                CompoundOperationMap<T> compoundOp,
                 Object key,
                 int index,
-                SlotComputer<S> c) {
+                SlotComputer<S, T> c) {
             var currentMap = checkAndReplaceMap(owner);
             return currentMap.compute(owner, compoundOp, key, index, c);
         }
 
         @Override
-        public CompoundOperationMap startCompoundOp(SlotMapOwner owner, boolean forWriting) {
+        public CompoundOperationMap<T> startCompoundOp(SlotMapOwner<T> owner, boolean forWriting) {
             return checkAndReplaceMap(owner).startCompoundOp(owner, forWriting);
         }
 
-        private SlotMap checkAndReplaceMap(SlotMapOwner owner) {
-            var newMap = new ThreadSafeEmbeddedSlotMap(2);
+        private SlotMap<T> checkAndReplaceMap(SlotMapOwner<T> owner) {
+            var newMap = new ThreadSafeEmbeddedSlotMap<T>(2);
             newMap.add(null, slot);
             var currentMap = ThreadedAccess.checkAndReplaceMap(owner, this, newMap);
             return currentMap;
@@ -299,7 +302,7 @@ public abstract class SlotMapOwner {
      * This holds all the slots. It may or may not be thread-safe, and may expand itself to a
      * different data structure depending on the size of the object.
      */
-    private SlotMap slotMap;
+    private SlotMap<T> slotMap;
 
     protected SlotMapOwner() {
         slotMap = createSlotMap(0);
@@ -309,34 +312,38 @@ public abstract class SlotMapOwner {
         slotMap = createSlotMap(capacity);
     }
 
-    protected SlotMapOwner(SlotMap map) {
+    protected SlotMapOwner(SlotMap<T> map) {
         slotMap = map;
     }
 
-    protected static SlotMap createSlotMap(int initialSize) {
+    protected static <T extends PropHolder<T>> SlotMap<T> createSlotMap(int initialSize) {
         Context cx = Context.getCurrentContext();
         if ((cx != null) && cx.hasFeature(Context.FEATURE_THREAD_SAFE_OBJECTS)) {
             if (initialSize == 0) {
-                return THREAD_SAFE_EMPTY_SLOT_MAP;
+                @SuppressWarnings("unchecked")
+                var res = (SlotMap<T>) THREAD_SAFE_EMPTY_SLOT_MAP;
+                return res;
             } else if (initialSize > LARGE_HASH_SIZE) {
-                return new ThreadSafeHashSlotMap(initialSize);
+                return new ThreadSafeHashSlotMap<>(initialSize);
             } else {
-                return new ThreadSafeEmbeddedSlotMap();
+                return new ThreadSafeEmbeddedSlotMap<>();
             }
         } else if (initialSize == 0) {
-            return EMPTY_SLOT_MAP;
+            @SuppressWarnings("unchecked")
+            var res = (SlotMap<T>) EMPTY_SLOT_MAP;
+            return res;
         } else if (initialSize > LARGE_HASH_SIZE) {
-            return new HashSlotMap();
+            return new HashSlotMap<>();
         } else {
-            return new EmbeddedSlotMap();
+            return new EmbeddedSlotMap<>();
         }
     }
 
-    SlotMap getMap() {
+    SlotMap<T> getMap() {
         return slotMap;
     }
 
-    final void setMap(SlotMap newMap) {
+    final void setMap(SlotMap<T> newMap) {
         slotMap = newMap;
     }
 
@@ -369,7 +376,7 @@ public abstract class SlotMapOwner {
      *     deadlocks or other semantic issues.
      * @return the {@link CompoundOperationMap} which can be used for the operation.
      */
-    final CompoundOperationMap startCompoundOp(boolean forWriting) {
+    final CompoundOperationMap<T> startCompoundOp(boolean forWriting) {
         return slotMap.startCompoundOp(this, forWriting);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeCompoundOperationMap.java
@@ -8,42 +8,42 @@ import java.util.Iterator;
  * threads. This means that the instance fields do not need to be volatile as we are only
  * considering access from this thread.
  */
-class ThreadSafeCompoundOperationMap extends CompoundOperationMap {
+class ThreadSafeCompoundOperationMap<T extends PropHolder<T>> extends CompoundOperationMap<T> {
     private boolean closed = false;
     private long lockStamp = 0;
 
     public ThreadSafeCompoundOperationMap(
-            SlotMapOwner owner, LockAwareSlotMap map, long lockStamp) {
+            SlotMapOwner<T> owner, LockAwareSlotMap<T> map, long lockStamp) {
         super(owner);
         this.map = map;
         this.lockStamp = lockStamp;
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
-        ((LockAwareSlotMap) map).addWithLock(owner, newSlot);
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
+        ((LockAwareSlotMap<T>) map).addWithLock(owner, newSlot);
         touched = true;
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner, Object key, int index, SlotComputer<S> compute) {
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner, Object key, int index, SlotComputer<S, T> compute) {
         updateMap(true);
-        S res = ((LockAwareSlotMap) map).computeWithLock(owner, this, key, index, compute);
+        S res = ((LockAwareSlotMap<T>) map).computeWithLock(owner, this, key, index, compute);
         touched = true;
         return res;
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap compoundOp,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> compoundOp,
             Object key,
             int index,
-            SlotComputer<S> compute) {
+            SlotComputer<S, T> compute) {
         assert (compoundOp == this);
         updateMap(true);
-        S res = ((LockAwareSlotMap) map).computeWithLock(owner, this, key, index, compute);
+        S res = ((LockAwareSlotMap<T>) map).computeWithLock(owner, this, key, index, compute);
         touched = true;
         return res;
     }
@@ -51,47 +51,47 @@ class ThreadSafeCompoundOperationMap extends CompoundOperationMap {
     @Override
     public boolean isEmpty() {
         updateMap(false);
-        return ((LockAwareSlotMap) map).isEmptyWithLock();
+        return ((LockAwareSlotMap<T>) map).isEmptyWithLock();
     }
 
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         updateMap(true);
-        Slot res = ((LockAwareSlotMap) map).modifyWithLock(owner, key, index, attributes);
+        Slot<T> res = ((LockAwareSlotMap<T>) map).modifyWithLock(owner, key, index, attributes);
         touched = true;
         return res;
     }
 
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         updateMap(false);
-        return ((LockAwareSlotMap) map).queryWithLock(key, index);
+        return ((LockAwareSlotMap<T>) map).queryWithLock(key, index);
     }
 
     @Override
     public int size() {
         updateMap(false);
-        return ((LockAwareSlotMap) map).sizeWithLock();
+        return ((LockAwareSlotMap<T>) map).sizeWithLock();
     }
 
     @Override
-    public Iterator<Slot> iterator() {
+    public Iterator<Slot<T>> iterator() {
         updateMap(false);
-        return new Iter(map.iterator());
+        return new Iter<>(map.iterator());
     }
 
     @Override
     public void close() {
         if (!closed) {
-            ((LockAwareSlotMap) owner.getMap()).releaseLock(lockStamp);
+            ((LockAwareSlotMap<T>) owner.getMap()).releaseLock(lockStamp);
             closed = true;
         }
     }
 
-    private static class Iter implements Iterator<Slot> {
-        private final Iterator<Slot> mapIterator;
+    private static class Iter<T extends PropHolder<T>> implements Iterator<Slot<T>> {
+        private final Iterator<Slot<T>> mapIterator;
 
-        private Iter(Iterator<Slot> mapIterator) {
+        private Iter(Iterator<Slot<T>> mapIterator) {
             this.mapIterator = mapIterator;
         }
 
@@ -101,7 +101,7 @@ class ThreadSafeCompoundOperationMap extends CompoundOperationMap {
         }
 
         @Override
-        public Slot next() {
+        public Slot<T> next() {
             return mapIterator.next();
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeEmbeddedSlotMap.java
@@ -3,10 +3,11 @@ package org.mozilla.javascript;
 import java.util.concurrent.locks.StampedLock;
 
 @SuppressWarnings("AndroidJdkLibsChecker")
-class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlotMap {
+class ThreadSafeEmbeddedSlotMap<T extends PropHolder<T>> extends EmbeddedSlotMap<T>
+        implements LockAwareSlotMap<T> {
 
     private final StampedLock lock = new StampedLock();
-    private volatile LockAwareSlotMap current = this;
+    private volatile LockAwareSlotMap<T> current = this;
 
     public ThreadSafeEmbeddedSlotMap() {
         super();
@@ -55,7 +56,7 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         final long stamp = lock.writeLock();
         try {
             return current.modifyWithLock(owner, key, index, attributes);
@@ -65,19 +66,19 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> mutableMap,
             Object key,
             int index,
-            SlotComputer<S> c) {
+            SlotComputer<S, T> c) {
         return current.computeWithLock(owner, mutableMap, key, index, c);
     }
 
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         long stamp = lock.tryOptimisticRead();
-        Slot s = current.queryWithLock(key, index);
+        Slot<T> s = current.queryWithLock(key, index);
         if (lock.validate(stamp)) {
             return s;
         }
@@ -91,7 +92,7 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
         final long stamp = lock.writeLock();
         try {
             current.addWithLock(owner, newSlot);
@@ -101,17 +102,17 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public void addWithLock(SlotMapOwner owner, Slot newSlot) {
+    public void addWithLock(SlotMapOwner<T> owner, Slot<T> newSlot) {
         super.add(owner, newSlot);
     }
 
     @Override
-    public <S extends Slot> S computeWithLock(
-            SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+    public <S extends Slot<T>> S computeWithLock(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> mutableMap,
             Object key,
             int index,
-            SlotComputer<S> compute) {
+            SlotComputer<S, T> compute) {
         return super.compute(owner, mutableMap, key, index, compute);
     }
 
@@ -121,12 +122,12 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    public Slot modifyWithLock(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modifyWithLock(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         return super.modify(owner, key, index, attributes);
     }
 
     @Override
-    public Slot queryWithLock(Object key, int index) {
+    public Slot<T> queryWithLock(Object key, int index) {
         return super.query(key, index);
     }
 
@@ -151,11 +152,11 @@ class ThreadSafeEmbeddedSlotMap extends EmbeddedSlotMap implements LockAwareSlot
     }
 
     @Override
-    protected void promoteMap(SlotMapOwner owner, Slot newSlot) {
+    protected void promoteMap(SlotMapOwner<T> owner, Slot<T> newSlot) {
         // We can use `setMap` here as this promotion can only be done
         // by the lock holder and the operation will be being done on
         // the "current" map.
-        var newMap = new ThreadSafeHashSlotMap(lock, this, newSlot);
+        var newMap = new ThreadSafeHashSlotMap<>(lock, this, newSlot);
         owner.setMap(newMap);
         current = newMap;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ThreadSafeHashSlotMap.java
@@ -5,7 +5,8 @@ import java.util.concurrent.locks.StampedLock;
 @SuppressWarnings("AndroidJdkLibsChecker")
 // https://developer.android.com/reference/java/util/concurrent/locks/StampedLock added in API level
 // 24
-class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
+class ThreadSafeHashSlotMap<T extends PropHolder<T>> extends HashSlotMap<T>
+        implements LockAwareSlotMap<T> {
 
     private final StampedLock lock;
 
@@ -19,18 +20,18 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
         lock = new StampedLock();
     }
 
-    public ThreadSafeHashSlotMap(StampedLock lock, SlotMap oldMap) {
+    public ThreadSafeHashSlotMap(StampedLock lock, SlotMap<T> oldMap) {
         super(oldMap.dirtySize());
         this.lock = lock;
-        for (Slot n : oldMap) {
+        for (Slot<T> n : oldMap) {
             addWithLock(null, n.copySlot());
         }
     }
 
-    public ThreadSafeHashSlotMap(StampedLock lock, SlotMap oldMap, Slot newSlot) {
+    public ThreadSafeHashSlotMap(StampedLock lock, SlotMap<T> oldMap, Slot<T> newSlot) {
         super(oldMap.dirtySize() + 1);
         this.lock = lock;
-        for (Slot n : oldMap) {
+        for (Slot<T> n : oldMap) {
             addWithLock(null, n.copySlot());
         }
         addWithLock(null, newSlot);
@@ -75,7 +76,7 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public Slot modify(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modify(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         final long stamp = lock.writeLock();
         try {
             return super.modify(owner, key, index, attributes);
@@ -85,12 +86,12 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public <S extends Slot> S compute(
-            SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+    public <S extends Slot<T>> S compute(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> mutableMap,
             Object key,
             int index,
-            SlotComputer<S> c) {
+            SlotComputer<S, T> c) {
         final long stamp = lock.writeLock();
         try {
             return super.compute(owner, mutableMap, key, index, c);
@@ -100,9 +101,9 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public Slot query(Object key, int index) {
+    public Slot<T> query(Object key, int index) {
         long stamp = lock.tryOptimisticRead();
-        Slot s = super.query(key, index);
+        Slot<T> s = super.query(key, index);
         if (lock.validate(stamp)) {
             return s;
         }
@@ -116,7 +117,7 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public void add(SlotMapOwner owner, Slot newSlot) {
+    public void add(SlotMapOwner<T> owner, Slot<T> newSlot) {
         final long stamp = lock.writeLock();
         try {
             super.add(owner, newSlot);
@@ -126,17 +127,17 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public void addWithLock(SlotMapOwner owner, Slot newSlot) {
+    public void addWithLock(SlotMapOwner<T> owner, Slot<T> newSlot) {
         super.add(owner, newSlot);
     }
 
     @Override
-    public <S extends Slot> S computeWithLock(
-            SlotMapOwner owner,
-            CompoundOperationMap mutableMap,
+    public <S extends Slot<T>> S computeWithLock(
+            SlotMapOwner<T> owner,
+            CompoundOperationMap<T> mutableMap,
             Object key,
             int index,
-            SlotComputer<S> compute) {
+            SlotComputer<S, T> compute) {
         return super.compute(owner, mutableMap, key, index, compute);
     }
 
@@ -146,12 +147,12 @@ class ThreadSafeHashSlotMap extends HashSlotMap implements LockAwareSlotMap {
     }
 
     @Override
-    public Slot modifyWithLock(SlotMapOwner owner, Object key, int index, int attributes) {
+    public Slot<T> modifyWithLock(SlotMapOwner<T> owner, Object key, int index, int attributes) {
         return super.modify(owner, key, index, attributes);
     }
 
     @Override
-    public Slot queryWithLock(Object key, int index) {
+    public Slot<T> queryWithLock(Object key, int index) {
         return super.query(key, index);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Undefined.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Undefined.java
@@ -95,6 +95,11 @@ public class Undefined implements Serializable {
         public void delete(int index) {}
 
         @Override
+        public Scriptable getAncestor() {
+            return null;
+        }
+
+        @Override
         public Scriptable getPrototype() {
             return null;
         }

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapConcurrentLocksPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapConcurrentLocksPromotionTest.java
@@ -7,9 +7,10 @@ import org.junit.jupiter.api.Test;
 
 class SlotMapConcurrentLocksPromotionTest {
     @Test
+    @SuppressWarnings("unchecked")
     public void singleThreadPromotionInCompute_emptyToOne() {
         ScriptableObject obj = new TestScriptableObject();
-        obj.setMap(SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
+        obj.setMap((SlotMap<Scriptable>) SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
 
         obj.getMap()
                 .compute(
@@ -28,9 +29,10 @@ class SlotMapConcurrentLocksPromotionTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void singleThreadPromotionInCompute_emptyToTwo() {
         ScriptableObject obj = new TestScriptableObject();
-        obj.setMap(SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
+        obj.setMap((SlotMap<Scriptable>) SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP);
 
         obj.getMap()
                 .compute(
@@ -52,7 +54,7 @@ class SlotMapConcurrentLocksPromotionTest {
     @Test
     public void singleThreadPromotionInCompute_oneToTwo() {
         ScriptableObject obj = new TestScriptableObject();
-        obj.setMap(new SlotMapOwner.SingleEntrySlotMap(new Slot("a", 1, 0)));
+        obj.setMap(new SlotMapOwner.SingleEntrySlotMap<>(new Slot<Scriptable>("a", 1, 0)));
 
         obj.getMap()
                 .compute(
@@ -62,7 +64,7 @@ class SlotMapConcurrentLocksPromotionTest {
                         (key, index, existing, mutableMap, owner) -> {
                             assertSame(owner, obj);
 
-                            mutableMap.add(owner, new Slot("b", 2, 0));
+                            mutableMap.add(owner, new Slot<>("b", 2, 0));
 
                             return null;
                         });

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapPromotionTest.java
@@ -8,14 +8,19 @@ import org.junit.jupiter.api.Test;
 /** Ensures that slot map promotion */
 class SlotMapPromotionTest {
     @Test
+    @SuppressWarnings("unchecked")
     public void promotionFromEmptyToSingleSlot() {
-        assertPromotes(() -> SlotMapOwner.EMPTY_SLOT_MAP, SlotMapOwner.SingleEntrySlotMap.class);
+        assertPromotes(
+                () -> (SlotMap<Scriptable>) SlotMapOwner.EMPTY_SLOT_MAP,
+                SlotMapOwner.SingleEntrySlotMap.class);
     }
 
     @Test
     public void promotionFromSingleToEmbedded() {
         assertPromotes(
-                () -> new SlotMapOwner.SingleEntrySlotMap(new Slot(new Object(), 0, 0)),
+                () ->
+                        new SlotMapOwner.SingleEntrySlotMap<>(
+                                new Slot<Scriptable>(new Object(), 0, 0)),
                 EmbeddedSlotMap.class);
     }
 
@@ -23,7 +28,7 @@ class SlotMapPromotionTest {
     public void promotionFromEmbeddedToHash() {
         assertPromotes(
                 () -> {
-                    var map = new EmbeddedSlotMap(SlotMapOwner.LARGE_HASH_SIZE);
+                    var map = new EmbeddedSlotMap<Scriptable>(SlotMapOwner.LARGE_HASH_SIZE);
                     fillToCapacity(SlotMapOwner.LARGE_HASH_SIZE, map);
                     return map;
                 },
@@ -31,16 +36,19 @@ class SlotMapPromotionTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void promotionFromThreadSafeEmptyToSingleSlot() {
         assertPromotes(
-                () -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
+                () -> (SlotMap<Scriptable>) SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
                 SlotMapOwner.ThreadSafeSingleEntrySlotMap.class);
     }
 
     @Test
     public void promotionFromThreadSafeSingleToEmbedded() {
         assertPromotes(
-                () -> new SlotMapOwner.ThreadSafeSingleEntrySlotMap(new Slot(new Object(), 0, 0)),
+                () ->
+                        new SlotMapOwner.ThreadSafeSingleEntrySlotMap<>(
+                                new Slot<Scriptable>(new Object(), 0, 0)),
                 ThreadSafeEmbeddedSlotMap.class);
     }
 
@@ -48,21 +56,21 @@ class SlotMapPromotionTest {
     public void promotionFromThreadSafeEmbeddedToHash() {
         assertPromotes(
                 () -> {
-                    var map = new ThreadSafeEmbeddedSlotMap();
+                    var map = new ThreadSafeEmbeddedSlotMap<Scriptable>();
                     fillToCapacity(SlotMapOwner.LARGE_HASH_SIZE, map);
                     return map;
                 },
                 ThreadSafeHashSlotMap.class);
     }
 
-    private static void fillToCapacity(int size, EmbeddedSlotMap map) {
+    private static void fillToCapacity(int size, EmbeddedSlotMap<Scriptable> map) {
         for (int i = 0; i < size; ++i) {
-            map.add(null, new Slot(Integer.toString(i), i, 0));
+            map.add(null, new Slot<Scriptable>(Integer.toString(i), i, 0));
         }
     }
 
     private void assertPromotes(
-            Supplier<SlotMap> slotMapSupplier, Class<? extends SlotMap> expectedClass) {
+            Supplier<SlotMap<Scriptable>> slotMapSupplier, Class<?> expectedClass) {
         ScriptableObject obj = new TestScriptableObject();
         obj.setMap(slotMapSupplier.get());
 

--- a/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SlotMapTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
@@ -36,7 +35,7 @@ public class SlotMapTest {
     // when testing with one of those as the initial map.
     private final int startingSize;
 
-    public SlotMapTest(Supplier<SlotMap> mapSupplier) {
+    public SlotMapTest(Supplier<SlotMap<Scriptable>> mapSupplier) {
         this.obj = new TestScriptableObject();
         this.obj.setMap(mapSupplier.get());
         startingSize = this.obj.getMap().size();
@@ -44,18 +43,21 @@ public class SlotMapTest {
 
     @Parameterized.Parameters
     public static Collection<Object[]> mapTypes() {
-        List<Supplier<SlotMap>> suppliers =
+        @SuppressWarnings("unchecked")
+        List<Supplier<SlotMap<Scriptable>>> suppliers =
                 List.of(
-                        () -> SlotMapOwner.EMPTY_SLOT_MAP,
-                        () -> new SlotMapOwner.SingleEntrySlotMap(new Slot(new Object(), 0, 0)),
-                        () -> new EmbeddedSlotMap(),
-                        () -> new HashSlotMap(),
-                        () -> SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
+                        () -> (SlotMap<Scriptable>) SlotMapOwner.EMPTY_SLOT_MAP,
                         () ->
-                                new SlotMapOwner.ThreadSafeSingleEntrySlotMap(
-                                        new Slot(new Object(), 0, 0)),
-                        () -> new ThreadSafeEmbeddedSlotMap(),
-                        () -> new ThreadSafeHashSlotMap());
+                                new SlotMapOwner.SingleEntrySlotMap<Scriptable>(
+                                        new Slot<Scriptable>(new Object(), 0, 0)),
+                        () -> new EmbeddedSlotMap<>(),
+                        () -> new HashSlotMap<>(),
+                        () -> (SlotMap<Scriptable>) SlotMapOwner.THREAD_SAFE_EMPTY_SLOT_MAP,
+                        () ->
+                                new SlotMapOwner.ThreadSafeSingleEntrySlotMap<Scriptable>(
+                                        new Slot<Scriptable>(new Object(), 0, 0)),
+                        () -> new ThreadSafeEmbeddedSlotMap<>(),
+                        () -> new ThreadSafeHashSlotMap<>());
         return suppliers.stream().map(i -> new Object[] {i}).collect(Collectors.toList());
     }
 
@@ -75,14 +77,14 @@ public class SlotMapTest {
     @Test
     public void crudOneString() {
         assertNull(obj.getMap().query("foo", 0));
-        Slot slot = obj.getMap().modify(obj, "foo", 0, 0);
+        var slot = obj.getMap().modify(obj, "foo", 0, 0);
         assertNotNull(slot);
         slot.value = "Testing";
         assertEquals(1 + startingSize, obj.getMap().size());
         assertFalse(obj.getMap().isEmpty());
-        Slot newSlot = new Slot(slot);
+        var newSlot = new Slot<>(slot);
         obj.getMap().compute(obj, "foo", 0, (k, i, e, m, o) -> newSlot);
-        Slot foundNewSlot = obj.getMap().query("foo", 0);
+        var foundNewSlot = obj.getMap().query("foo", 0);
         assertEquals("Testing", foundNewSlot.value);
         assertSame(foundNewSlot, newSlot);
         obj.getMap().compute(obj, "foo", 0, (k, ii, e, m, o) -> null);
@@ -98,14 +100,14 @@ public class SlotMapTest {
     @Test
     public void crudOneIndex() {
         assertNull(obj.getMap().query(null, 11));
-        Slot slot = obj.getMap().modify(obj, null, 11, 0);
+        var slot = obj.getMap().modify(obj, null, 11, 0);
         assertNotNull(slot);
         slot.value = "Testing";
         assertEquals(1 + startingSize, obj.getMap().size());
         assertFalse(obj.getMap().isEmpty());
-        Slot newSlot = new Slot(slot);
+        var newSlot = new Slot<>(slot);
         obj.getMap().compute(obj, null, 11, (k, i, e, m, o) -> newSlot);
-        Slot foundNewSlot = obj.getMap().query(null, 11);
+        var foundNewSlot = obj.getMap().query(null, 11);
         assertEquals("Testing", foundNewSlot.value);
         assertSame(foundNewSlot, newSlot);
         obj.getMap().compute(obj, null, 11, (k, ii, e, m, o) -> null);
@@ -120,9 +122,9 @@ public class SlotMapTest {
 
     @Test
     public void computeReplaceSlot() {
-        Slot slot = obj.getMap().modify(obj, "one", 0, 0);
+        var slot = obj.getMap().modify(obj, "one", 0, 0);
         slot.value = "foo";
-        Slot newSlot =
+        var newSlot =
                 obj.getMap()
                         .compute(
                                 obj,
@@ -133,7 +135,7 @@ public class SlotMapTest {
                                     assertEquals(i, 0);
                                     assertNotNull(e);
                                     assertEquals(e.value, "foo");
-                                    Slot n = new Slot(e);
+                                    var n = new Slot<>(e);
                                     n.value = "bar";
                                     return n;
                                 });
@@ -145,7 +147,7 @@ public class SlotMapTest {
 
     @Test
     public void computeCreateNewSlot() {
-        Slot newSlot =
+        var newSlot =
                 obj.getMap()
                         .compute(
                                 obj,
@@ -155,13 +157,13 @@ public class SlotMapTest {
                                     assertEquals(k, "one");
                                     assertEquals(i, 0);
                                     assertNull(e);
-                                    Slot n = new Slot(k, i, 0);
+                                    var n = new Slot<Scriptable>(k, i, 0);
                                     n.value = "bar";
                                     return n;
                                 });
         assertNotNull(newSlot);
         assertEquals(newSlot.value, "bar");
-        Slot slot = obj.getMap().query("one", 0);
+        var slot = obj.getMap().query("one", 0);
         assertNotNull(slot);
         assertEquals(slot.value, "bar");
         assertEquals(1 + startingSize, obj.getMap().size());
@@ -169,9 +171,9 @@ public class SlotMapTest {
 
     @Test
     public void computeRemoveSlot() {
-        Slot slot = obj.getMap().modify(obj, "one", 0, 0);
+        var slot = obj.getMap().modify(obj, "one", 0, 0);
         slot.value = "foo";
-        Slot newSlot =
+        var newSlot =
                 obj.getMap()
                         .compute(
                                 obj,
@@ -195,11 +197,11 @@ public class SlotMapTest {
     @Test
     public void manyKeysAndIndices() {
         for (int i = 0; i < NUM_INDICES; i++) {
-            Slot newSlot = obj.getMap().modify(obj, null, i, 0);
+            var newSlot = obj.getMap().modify(obj, null, i, 0);
             newSlot.value = i;
         }
         for (String key : KEYS) {
-            Slot newSlot = obj.getMap().modify(obj, key, 0, 0);
+            var newSlot = obj.getMap().modify(obj, key, 0, 0);
             newSlot.value = key;
         }
         assertEquals(KEYS.length + NUM_INDICES + startingSize, obj.getMap().size());
@@ -209,15 +211,15 @@ public class SlotMapTest {
         // Randomly replace some slots
         for (int i = 0; i < 20; i++) {
             int ix = rand.nextInt(NUM_INDICES);
-            Slot slot = obj.getMap().query(null, ix);
+            var slot = obj.getMap().query(null, ix);
             assertNotNull(slot);
-            obj.getMap().compute(obj, null, ix, (k, j, e, m, o) -> new Slot(slot));
+            obj.getMap().compute(obj, null, ix, (k, j, e, m, o) -> new Slot<>(slot));
         }
         for (int i = 0; i < 20; i++) {
             int ix = rand.nextInt(KEYS.length);
-            Slot slot = obj.getMap().query(KEYS[ix], 0);
+            var slot = obj.getMap().query(KEYS[ix], 0);
             assertNotNull(slot);
-            obj.getMap().compute(obj, KEYS[ix], 0, (k, j, e, m, o) -> new Slot(slot));
+            obj.getMap().compute(obj, KEYS[ix], 0, (k, j, e, m, o) -> new Slot<>(slot));
         }
         verifyIndicesAndKeys();
 
@@ -237,7 +239,7 @@ public class SlotMapTest {
         }
 
         for (int i = 0; i < NUM_INDICES; i++) {
-            Slot slot = obj.getMap().query(null, i);
+            var slot = obj.getMap().query(null, i);
             if (removedIds.contains(i)) {
                 assertNull(slot);
             } else {
@@ -246,7 +248,7 @@ public class SlotMapTest {
             }
         }
         for (String key : KEYS) {
-            Slot slot = obj.getMap().query(key, 0);
+            var slot = obj.getMap().query(key, 0);
             if (removedKeys.contains(key)) {
                 assertNull(slot);
             } else {
@@ -258,20 +260,20 @@ public class SlotMapTest {
 
     private void verifyIndicesAndKeys() {
         try (var map = obj.startCompoundOp(false)) {
-            Iterator<Slot> it = map.iterator();
+            var it = map.iterator();
             for (int i = 0; i < startingSize; i++) {
                 // Skip initial slots
                 it.next();
             }
             for (int i = 0; i < NUM_INDICES; i++) {
-                Slot slot = map.query(null, i);
+                var slot = map.query(null, i);
                 assertNotNull(slot);
                 assertEquals(i, slot.value);
                 assertTrue(it.hasNext());
                 assertEquals(slot, it.next());
             }
             for (String key : KEYS) {
-                Slot slot = map.query(key, 0);
+                var slot = map.query(key, 0);
                 assertNotNull(slot);
                 assertEquals(key, slot.value);
                 assertTrue(it.hasNext());


### PR DESCRIPTION
Introduce a `PropHolder<T extends PropHolder<T>>` superclass of `Scriptable`. This stacks on #2348 and is the next commit broken out of #2329.