### PR TITLE
Fix javascript property access to Character field via Setter

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -340,10 +340,10 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
                     return 1;
                 } else if (to.isInstance(fromObj)) {
                     return 2;
+                } else if (to.isCharacter()) {
+                    return 3;
                 } else if (to.isPrimitive()) {
-                    if (to.isCharacter()) {
-                        return 3;
-                    } else if (!to.isBoolean()) {
+                    if (!to.isBoolean()) {
                         return 4;
                     }
                 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/GenericAccessTest.java
@@ -186,6 +186,27 @@ public class GenericAccessTest {
         expect(js, "Integer 4 Long 2 Long 2");
     }
 
+    @Test
+    public void testCharacters() {
+        String js = "bean.primitiveChar = 'a';\nbean.primitiveChar";
+        FieldBasedBean fieldBasedBean = new FieldBasedBean();
+        MethodBasedBean methodBasedBean = new MethodBasedBean();
+        expect(js, "97", Map.of("bean", fieldBasedBean));
+        Assertions.assertEquals('a', fieldBasedBean.primitiveChar);
+        expect(js, "97", Map.of("bean", methodBasedBean));
+        Assertions.assertEquals('a', methodBasedBean.getPrimitiveChar());
+
+        js = "bean.complexChar = 'b';\nbean.complexChar";
+        expect(js, "b", Map.of("bean", fieldBasedBean));
+        Assertions.assertEquals('b', fieldBasedBean.complexChar);
+        expect(js, "b", Map.of("bean", methodBasedBean));
+        Assertions.assertEquals('b', methodBasedBean.getComplexChar());
+
+        js = "bean.setComplexChar('c');\nbean.complexChar";
+        expect(js, "c", Map.of("bean", methodBasedBean));
+        Assertions.assertEquals('c', methodBasedBean.getComplexChar());
+    }
+
     private static void expect(String script, String expected) {
         var bindings = new HashMap<String, Object>();
         bindings.put("intList", IntegerArrayList.createTestObject());

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/test_object/FieldBasedBean.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/test_object/FieldBasedBean.java
@@ -15,6 +15,9 @@ import java.util.Map;
 public class FieldBasedBean implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    public char primitiveChar = 0;
+    public Character complexChar = null;
+
     public List<Integer> integers = new ArrayList<>();
     private List<Double> doubles = new ArrayList<>();
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/type_info/test_object/MethodBasedBean.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/type_info/test_object/MethodBasedBean.java
@@ -15,6 +15,9 @@ import java.util.Map;
 public class MethodBasedBean implements Serializable {
     private static final long serialVersionUID = 1L;
 
+    private char primitiveChar = 0;
+    private Character complexChar = null;
+
     private List<Integer> integers = new ArrayList<>();
     private List<Double> doubles = new ArrayList<>();
     private List<Number> numbers = new ArrayList<>();
@@ -28,6 +31,22 @@ public class MethodBasedBean implements Serializable {
     // beans with typeInfo in the dynamic type
     private GenericBean<Integer> intBean2 = new IntegerGenericBean();
     private GenericBean<Double> dblBean2 = new DoubleGenericBean();
+
+    public char getPrimitiveChar() {
+        return primitiveChar;
+    }
+
+    public void setPrimitiveChar(char primitiveChar) {
+        this.primitiveChar = primitiveChar;
+    }
+
+    public Character getComplexChar() {
+        return complexChar;
+    }
+
+    public void setComplexChar(Character complexChar) {
+        this.complexChar = complexChar;
+    }
 
     public List<Double> getDoubles() {
         return doubles;


### PR DESCRIPTION
While updating from Rhino 1.8.0 to 1.9.1, I found a regression when accessing a Java Character field through it's setter. I provided a Testcase checking for analogous behaviour of field-access vs. method-access as well as a fix for the issue.
Since the javascript code was working with 1.8.0 it might be a possibility of this fix to be ported to the 1.9.x branch. If that is desirable I can provide an additional pull request for that.