### PR TITLE
Prefere non-vararg methods over methods with same argument types but with trailing vararg

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -9,6 +9,7 @@ package org.mozilla.javascript;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.mozilla.javascript.lc.ReflectUtils;
@@ -415,12 +416,12 @@ public class NativeJavaMethod extends BaseFunction {
         int totalPreference = 0;
         for (int j = 0; j < args.length; j++) {
             final var type1 =
-                    member1.isVarArgs() && j >= types1.size()
-                            ? types1.get(types1.size() - 1)
+                    member1.isVarArgs() && j >= types1.size() - 1
+                            ? extractVarargType(args, j, types1)
                             : types1.get(j);
             final var type2 =
-                    member2.isVarArgs() && j >= types2.size()
-                            ? types2.get(types2.size() - 1)
+                    member2.isVarArgs() && j >= types2.size() - 1
+                            ? extractVarargType(args, j, types2)
                             : types2.get(j);
             if (type1.asClass() == type2.asClass()) {
                 continue;
@@ -464,7 +465,31 @@ public class NativeJavaMethod extends BaseFunction {
                 break;
             }
         }
+        if (totalPreference == PREFERENCE_EQUAL && member1.isVarArgs() != member2.isVarArgs()) {
+            return member1.isVarArgs() ? PREFERENCE_SECOND_ARG : PREFERENCE_FIRST_ARG;
+        }
         return totalPreference;
+    }
+
+    /**
+     * Determines weather to use the array component's type of a vararg or the array itself as an
+     * argument type.
+     */
+    private static TypeInfo extractVarargType(
+            Object[] args, int argIndex, List<TypeInfo> methodArgTypes) {
+        final int varargIndex = methodArgTypes.size() - 1;
+        final var varargArrayType = methodArgTypes.get(varargIndex);
+        // If the argument for the vararg method is the last, and it is null or an array, use the
+        // vararg array type
+        if (argIndex == varargIndex
+                && args.length == methodArgTypes.size()
+                && (args[argIndex] == null
+                        || args[argIndex] instanceof NativeArray
+                        || args[argIndex] instanceof NativeJavaArray)) {
+            return varargArrayType;
+        }
+
+        return varargArrayType.getComponentType();
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -464,6 +464,9 @@ public class NativeJavaMethod extends BaseFunction {
                 break;
             }
         }
+        if (totalPreference == PREFERENCE_EQUAL && member1.isVarArgs() != member2.isVarArgs()) {
+            return member1.isVarArgs() ? PREFERENCE_SECOND_ARG : PREFERENCE_FIRST_ARG;
+        }
         return totalPreference;
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript.tests;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
@@ -31,6 +32,10 @@ public class NativeJavaMethodTest {
             captured.add("1.2");
         }
 
+        public void f1(String s, MethodDummy... varargObj) {
+            captured.add("1.N");
+        }
+
         public void f2(String s1, String s2) {
             captured.add("2");
         }
@@ -41,6 +46,14 @@ public class NativeJavaMethodTest {
 
         public void fN(String s1, String s2, String... sN) {
             captured.add("N." + sN.length);
+        }
+
+        public void f3(Map<String, String> m, String... sN) {
+            captured.add("3.N");
+        }
+
+        public void f3(Map<String, String> m, Class<?> c, String... sN) {
+            captured.add("3.C.N");
         }
     }
 
@@ -100,11 +113,20 @@ public class NativeJavaMethodTest {
     @Test
     void overload() {
         expect(
-                Arrays.asList("1", "1.2", "1.1", "1.2"),
+                Arrays.asList("1", "1.2", "1.1", "1.N", "1.2"),
                 "d.f1('xxx');",
                 "d.f1('x', 'y');",
                 "d.f1('x', 3);",
+                "d.f1('x', d);",
                 "d.f1('x', '3');");
+    }
+
+    @Test
+    void overloadClass() {
+        expect(
+                Arrays.asList("3.N", "3.C.N"),
+                "d.f3({'foo':'bar'}, 'baz');",
+                "d.f3({'foo':'bar'}, java.lang.String, 'baz');");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript.tests;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
@@ -41,6 +42,14 @@ public class NativeJavaMethodTest {
 
         public void fN(String s1, String s2, String... sN) {
             captured.add("N." + sN.length);
+        }
+
+        public void f3(Map<String, String> m, String... sN) {
+            captured.add("3.N");
+        }
+
+        public void f3(Map<String, String> m, Class<?> c, String... sN) {
+            captured.add("3.C.N");
         }
     }
 
@@ -105,6 +114,14 @@ public class NativeJavaMethodTest {
                 "d.f1('x', 'y');",
                 "d.f1('x', 3);",
                 "d.f1('x', '3');");
+    }
+
+    @Test
+    void overloadClass() {
+        expect(
+                Arrays.asList("3.N", "3.C.N"),
+                "d.f3({'foo':'bar'}, 'baz');",
+                "d.f3({'foo':'bar'}, java.lang.String, 'baz');");
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMethodTest.java
@@ -3,7 +3,7 @@ package org.mozilla.javascript.tests;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
@@ -17,8 +17,11 @@ import org.mozilla.javascript.testutils.Utils;
  */
 public class NativeJavaMethodTest {
 
-    public static class MethodDummy {
+    public abstract static class CaptureDummy {
         public final List<String> captured = new ArrayList<>();
+    }
+
+    public static class MethodDummy extends CaptureDummy {
 
         public void f1(String s) {
             captured.add("1");
@@ -43,31 +46,52 @@ public class NativeJavaMethodTest {
         public void fN(String s1, String s2, String... sN) {
             captured.add("N." + sN.length);
         }
+    }
 
-        public void f3(Map<String, String> m, String... sN) {
-            captured.add("3.N");
-        }
-
-        public void f3(Map<String, String> m, Class<?> c, String... sN) {
-            captured.add("3.C.N");
+    public abstract static class NonVarArgParent extends CaptureDummy {
+        public void someMethod(int i) {
+            captured.add("NonVarArgParent.someMethod");
         }
     }
 
-    private static void expect(List<String> expected, String... lines) {
+    public static class VarArgAtSubclass extends NonVarArgParent {
+        public void someMethod(int i, int... extra) {
+            captured.add("VarArgAtSubclass.someMethod");
+        }
+    }
+
+    public abstract static class VarArgParent extends CaptureDummy {
+        public void someMethod(int i, int... extra) {
+            captured.add("VarArgParent.someMethod");
+        }
+    }
+
+    public static class VarArgAtParent extends VarArgParent {
+        public void someMethod(int i) {
+            captured.add("VarArgAtParent.someMethod");
+        }
+    }
+
+    public static void expect(List<String> expected, String... lines) {
+        expect(expected, MethodDummy::new, lines);
+    }
+
+    public static void expect(
+            List<String> expected, Supplier<CaptureDummy> beanSupplier, String... lines) {
         Utils.runWithAllModes(
                 cx -> {
-                    final var methodDummy = new MethodDummy();
-                    final var scope = initContext(cx, methodDummy);
+                    final var bean = beanSupplier.get();
+                    final var scope = initContext(cx, bean);
 
                     cx.evaluateString(
                             scope, String.join("\n", lines), "NativeJavaMethodTest.js", 0, null);
 
-                    Assertions.assertEquals(expected, methodDummy.captured);
+                    Assertions.assertEquals(expected, bean.captured);
                     return null;
                 });
     }
 
-    private static ScopeObject initContext(Context cx, MethodDummy methodDummy) {
+    private static ScopeObject initContext(Context cx, CaptureDummy methodDummy) {
         cx.setLanguageVersion(Context.VERSION_ES6);
         final var scope = cx.initStandardObjects();
         ScriptableObject.putProperty(scope, "d", Context.javaToJS(methodDummy, scope));
@@ -117,11 +141,18 @@ public class NativeJavaMethodTest {
     }
 
     @Test
-    void overloadClass() {
+    void overloadMethodOrdering() {
         expect(
-                Arrays.asList("3.N", "3.C.N"),
-                "d.f3({'foo':'bar'}, 'baz');",
-                "d.f3({'foo':'bar'}, java.lang.String, 'baz');");
+                List.of("NonVarArgParent.someMethod", "VarArgAtSubclass.someMethod"),
+                VarArgAtSubclass::new,
+                "d.someMethod(1);",
+                "d.someMethod(1, 2);");
+
+        expect(
+                List.of("VarArgAtParent.someMethod", "VarArgParent.someMethod"),
+                VarArgAtParent::new,
+                "d.someMethod(1);",
+                "d.someMethod(1, 2);");
     }
 
     @Test


### PR DESCRIPTION
While updating from Rhino 1.8.0 to 1.9.1, I found a regression where rhino seems to favor the vararg version of two methods with the same base argument types. I provided a Testcase checking for this behaviour as well as a fix for the issue.
Since the javascript code was working with 1.8.0 it might be a possibility of this fix to be ported to the 1.9.x branch. If that is desired I can provide an additional pull request for that.