### PR TITLE
First round of conversion of `Scriptable` to `VarScope`.

### DIFF
--- a/examples/src/main/java/RunScript3.java
+++ b/examples/src/main/java/RunScript3.java
@@ -96,7 +96,7 @@ public class RunScript3 {
             } else {
                 Object functionArgs[] = {"my arg"};
                 Function f = (Function) fObj;
-                Object result = f.call(cx, scope, scope, functionArgs);
+                Object result = f.call(cx, scope, scope.getGlobalThis(), functionArgs);
                 String report = "f('my args') = " + Context.toString(result);
                 System.out.println(report);
             }

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Dim.java
@@ -977,7 +977,7 @@ public class Dim {
         private ContextData contextData;
 
         /** The scope. */
-        private Scriptable scope;
+        private VarScope scope;
 
         /** The 'this' object. */
         private Scriptable thisObj;
@@ -1008,7 +1008,7 @@ public class Dim {
         @Override
         public void onEnter(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
             contextData.pushFrame(this);
-            this.scope = scope;
+            this.scope = (VarScope) scope;
             this.thisObj = thisObj;
             if (dim.breakOnEnter) {
                 dim.handleBreakpointHit(this, cx);

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
@@ -54,7 +54,7 @@ public class Timers {
      * @param scope the global scope
      * @throws InterruptedException if the thread is interrupted while sleeping
      */
-    public void runAllTimers(Context cx, Scriptable scope) throws InterruptedException {
+    public void runAllTimers(Context cx, VarScope scope) throws InterruptedException {
         boolean executed;
         do {
             cx.processMicrotasks();
@@ -72,7 +72,7 @@ public class Timers {
      * @return true if something was placed on the queue, and false if the queue is empty
      * @throws InterruptedException if the thread was interrupted
      */
-    private boolean executeNext(Context cx, Scriptable scope) throws InterruptedException {
+    private boolean executeNext(Context cx, VarScope scope) throws InterruptedException {
         Timeout t = timerQueue.peek();
         if (t == null) {
             return false;

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -765,7 +765,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     private Object applyOrCall(
-            boolean isApply, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            boolean isApply, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         String methodName = isApply ? "apply" : "call";
         if (!(thisObj instanceof XMLList) || ((XMLList) thisObj).targetProperty == null)
             throw ScriptRuntime.typeErrorById("msg.isnt.function", methodName);

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -181,7 +181,7 @@ public class AbstractEcmaObjectOperations {
      * @see <a href="https://tc39.es/ecma262/#sec-speciesconstructor"></a>
      */
     public static Constructable speciesConstructor(
-            Context cx, Scriptable s, Constructable defaultConstructor) {
+            Context cx, Object s, Constructable defaultConstructor) {
         /*
         The abstract operation SpeciesConstructor takes arguments O (an Object) and
         defaultConstructor (a constructor). It is used to retrieve the constructor that should
@@ -198,7 +198,7 @@ public class AbstractEcmaObjectOperations {
         7. If IsConstructor(S) is true, return S.
         8. Throw a TypeError exception.
          */
-        Object constructor = ScriptableObject.getProperty(s, "constructor");
+        Object constructor = ScriptableObject.getProperty((Scriptable) s, "constructor");
         if (constructor == Scriptable.NOT_FOUND || Undefined.isUndefined(constructor)) {
             return defaultConstructor;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -38,7 +38,7 @@ public class ArrayLikeAbstractOperations {
     public static Object iterativeMethod(
             Context cx,
             IterativeOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             LengthAccessor lengthAccessor) {
@@ -53,7 +53,7 @@ public class ArrayLikeAbstractOperations {
             Context cx,
             IdFunctionObject fun,
             IterativeOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             LengthAccessor lengthAccessor) {
@@ -64,7 +64,7 @@ public class ArrayLikeAbstractOperations {
             Context cx,
             IdFunctionObject fun,
             IterativeOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             LengthAccessor lengthAccessor,
@@ -89,7 +89,7 @@ public class ArrayLikeAbstractOperations {
             Object tag,
             String name,
             IterativeOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             LengthAccessor lengthAccessor) {
@@ -102,7 +102,7 @@ public class ArrayLikeAbstractOperations {
             Object tag,
             String name,
             IterativeOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             LengthAccessor lengthAccessor,
@@ -125,8 +125,8 @@ public class ArrayLikeAbstractOperations {
     public static Object coercibleIterativeMethod(
             Context cx,
             IterativeOperation operation,
-            Scriptable scope,
-            Scriptable o,
+            VarScope scope,
+            Object o,
             Object[] args,
             long length) {
         if (operation == IterativeOperation.MAP && length > Integer.MAX_VALUE) {
@@ -168,7 +168,7 @@ public class ArrayLikeAbstractOperations {
                         : +1;
         for (long i = start; i != end; i += increment) {
             Object[] innerArgs = new Object[3];
-            Object elem = getRawElem(o, i);
+            Object elem = getRawElem((Scriptable) o, i);
             if (elem == NOT_FOUND) {
                 if (operation == IterativeOperation.FIND
                         || operation == IterativeOperation.FIND_INDEX
@@ -226,9 +226,9 @@ public class ArrayLikeAbstractOperations {
         }
     }
 
-    static Scriptable arraySpeciesCreate(Context cx, Scriptable scope, Scriptable o, int length) {
+    static Scriptable arraySpeciesCreate(Context cx, VarScope scope, Object o, int length) {
         if (o instanceof NativeArray) {
-            Object c = ScriptableObject.getProperty(o, "constructor");
+            Object c = ScriptableObject.getProperty((Scriptable) o, "constructor");
             if (c instanceof Scriptable) {
                 c = ScriptableObject.getProperty((Scriptable) c, SymbolKey.SPECIES);
                 if (c == null || c == NOT_FOUND) {
@@ -314,11 +314,7 @@ public class ArrayLikeAbstractOperations {
 
     /** Implements the methods "reduce" and "reduceRight". */
     public static Object reduceMethod(
-            Context cx,
-            ReduceOperation operation,
-            Scriptable scope,
-            Object thisObj,
-            Object[] args) {
+            Context cx, ReduceOperation operation, VarScope scope, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, scope, thisObj);
 
         long length = getLengthProperty(cx, o);
@@ -328,7 +324,7 @@ public class ArrayLikeAbstractOperations {
     public static Object reduceMethodWithLength(
             Context cx,
             ReduceOperation operation,
-            Scriptable scope,
+            VarScope scope,
             Object thisObj,
             Object[] args,
             long length) {
@@ -345,7 +341,7 @@ public class ArrayLikeAbstractOperations {
         Object value = args.length > 1 ? args[1] : NOT_FOUND;
         for (long i = 0; i < length; i++) {
             long index = movingLeft ? i : (length - 1 - i);
-            Object elem = getRawElem(o, index);
+            Object elem = getRawElem((Scriptable) o, index);
             if (elem == NOT_FOUND) {
                 continue;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -405,7 +405,7 @@ public class BaseFunction extends ScriptableObject implements Function {
     }
 
     private static Object js_hasInstance(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (!(thisObj instanceof Callable)) {
             return false;
         }
@@ -415,7 +415,7 @@ public class BaseFunction extends ScriptableObject implements Function {
                     ((JSFunction) ((BoundFunction) thisObj).getTargetFunction())
                             .getPrototypeProperty();
         else {
-            protoProp = ScriptableObject.getProperty(thisObj, PROTOTYPE_PROPERTY_NAME);
+            protoProp = ScriptableObject.getProperty((Scriptable) thisObj, PROTOTYPE_PROPERTY_NAME);
         }
 
         if (ScriptRuntime.isObject(protoProp) || protoProp instanceof XMLObject) {
@@ -434,7 +434,7 @@ public class BaseFunction extends ScriptableObject implements Function {
                         : "unknown");
     }
 
-    private static Object js_bind(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_bind(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (!(thisObj instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(thisObj);
         }
@@ -453,17 +453,15 @@ public class BaseFunction extends ScriptableObject implements Function {
         return new BoundFunction(cx, scope, targetFunction, boundThis, boundArgs);
     }
 
-    private static Object js_apply(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        return ScriptRuntime.applyOrCall(true, cx, scope, thisObj, args);
+    private static Object js_apply(Context cx, VarScope scope, Object thisObj, Object[] args) {
+        return ScriptRuntime.applyOrCall(true, cx, scope, (Scriptable) thisObj, args);
     }
 
-    private static Object js_call(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        return ScriptRuntime.applyOrCall(false, cx, scope, thisObj, args);
+    private static Object js_call(Context cx, VarScope scope, Object thisObj, Object[] args) {
+        return ScriptRuntime.applyOrCall(false, cx, scope, (Scriptable) thisObj, args);
     }
 
-    private static Object js_toSource(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
         BaseFunction realf = realFunction(thisObj, "toSource");
         int indent = 0;
         EnumSet<DecompilerFlag> flags = EnumSet.of(DecompilerFlag.TO_SOURCE);
@@ -478,15 +476,14 @@ public class BaseFunction extends ScriptableObject implements Function {
         return realf.decompile(indent, flags);
     }
 
-    private static Object js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         BaseFunction realf = realFunction(thisObj, "toString");
         int indent = ScriptRuntime.toInt32(args, 0);
         return realf.decompile(indent, EnumSet.noneOf(DecompilerFlag.class));
     }
 
     private static Scriptable js_gen_constructorCall(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return js_gen_constructor(cx, scope, args);
     }
 
@@ -495,7 +492,7 @@ public class BaseFunction extends ScriptableObject implements Function {
     }
 
     private static Scriptable js_constructorCall(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return js_constructor(cx, scope, args);
     }
 
@@ -503,11 +500,11 @@ public class BaseFunction extends ScriptableObject implements Function {
         return jsConstructor(cx, scope, args, true);
     }
 
-    private static BaseFunction realFunction(Scriptable thisObj, String functionName) {
+    private static BaseFunction realFunction(Object thisObj, String functionName) {
         if (thisObj == null) {
             throw ScriptRuntime.notFunctionError(null);
         }
-        Object x = thisObj.getDefaultValue(ScriptRuntime.FunctionClass);
+        Object x = ((Scriptable) thisObj).getDefaultValue(ScriptRuntime.FunctionClass);
         if (x instanceof Delegator) {
             x = ((Delegator) x).getDelegee();
         }

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -86,12 +86,11 @@ public final class ES6Generator extends ScriptableObject {
         return "Generator";
     }
 
-    private static ES6Generator realThis(Scriptable thisObj) {
+    private static ES6Generator realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, ES6Generator.class);
     }
 
-    private static Object js_return(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_return(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
@@ -100,7 +99,7 @@ public final class ES6Generator extends ScriptableObject {
         return generator.resumeDelegeeReturn(cx, scope, value);
     }
 
-    private static Object js_next(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
@@ -109,8 +108,7 @@ public final class ES6Generator extends ScriptableObject {
         return generator.resumeDelegee(cx, scope, value);
     }
 
-    private static Object js_throw(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_throw(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ES6Generator generator = realThis(thisObj);
         Object value = args.length >= 1 ? args[0] : Undefined.instance;
         if (generator.delegee == null) {
@@ -119,8 +117,7 @@ public final class ES6Generator extends ScriptableObject {
         return generator.resumeDelegeeThrow(cx, scope, value);
     }
 
-    private static Object js_iterator(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return thisObj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -63,17 +63,16 @@ public abstract class ES6Iterator extends ScriptableObject {
         setPrototype(prototype);
     }
 
-    private static ES6Iterator realThis(Scriptable thisObj) {
+    private static ES6Iterator realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, ES6Iterator.class);
     }
 
-    private static Object js_next(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ES6Iterator iterator = realThis(thisObj);
         return iterator.next(cx, scope);
     }
 
-    private static Object js_iterator(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return thisObj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -613,7 +613,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Scriptable callConstructorOrCreateArray(
-            Context cx, JSFunction f, Scriptable s, Object arg, long length, boolean lengthAlways) {
+            Context cx, JSFunction f, VarScope s, Object arg, long length, boolean lengthAlways) {
         Scriptable result = null;
 
         if (arg instanceof Constructable) {
@@ -641,7 +641,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_from(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         final Scriptable items =
                 ScriptRuntime.toObject(s, (args.length >= 1) ? args[0] : Undefined.instance);
         Object mapArg = (args.length >= 2) ? args[1] : Undefined.instance;
@@ -699,7 +699,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_of(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         final Scriptable result =
                 callConstructorOrCreateArray(cx, f, s, thisObj, args.length, true);
 
@@ -918,26 +918,26 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     // Similar as setElem(), but triggers deleteElem() if value is NOT_FOUND
-    private static void setRawElem(Context cx, Scriptable target, long index, Object value) {
+    private static void setRawElem(Context cx, Object target, long index, Object value) {
         if (value == NOT_FOUND) {
-            deleteElem(target, index);
+            deleteElem((Scriptable) target, index);
         } else {
-            setElem(cx, target, index, value);
+            setElem(cx, (Scriptable) target, index, value);
         }
     }
 
     private static String js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toStringHelper(cx, f, nt, s, thisObj, false, false);
     }
 
     private static String js_toLocaleString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toStringHelper(cx, f, nt, s, thisObj, false, true);
     }
 
     private static String js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toStringHelper(cx, f, nt, s, thisObj, true, false);
     }
 
@@ -945,7 +945,7 @@ public class NativeArray extends ScriptableObject implements List {
             Context cx,
             JSFunction f,
             Object nt,
-            Scriptable s,
+            VarScope s,
             Object thisObj,
             boolean toSource,
             boolean toLocale) {
@@ -1037,7 +1037,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     /** See ECMA 15.4.4.3 */
     private static String js_join(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         long llength = getLengthProperty(cx, o);
@@ -1101,7 +1101,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     /** See ECMA 15.4.4.4 */
     private static Scriptable js_reverse(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         if (o instanceof NativeArray) {
@@ -1169,7 +1169,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_push(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         if (o instanceof NativeArray) {
@@ -1192,7 +1192,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_pop(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         Object result;
@@ -1227,7 +1227,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_shift(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         if (o instanceof NativeArray) {
@@ -1271,7 +1271,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_unshift(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         if (o instanceof NativeArray) {
@@ -1311,7 +1311,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_splice(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         NativeArray na = null;
@@ -1516,7 +1516,7 @@ public class NativeArray extends ScriptableObject implements List {
      * See Ecma 262v3 15.4.4.4
      */
     private static Scriptable js_concat(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
 
         // create an empty Array to return.
@@ -1533,7 +1533,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Scriptable js_slice(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
 
         long len = getLengthProperty(cx, o);
@@ -1571,7 +1571,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_indexOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
@@ -1624,7 +1624,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_lastIndexOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object compareTo = args.length > 0 ? args[0] : Undefined.instance;
 
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
@@ -1679,7 +1679,7 @@ public class NativeArray extends ScriptableObject implements List {
        See ECMA-262 22.1.3.13
     */
     private static Boolean js_includes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
 
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, o);
@@ -1730,7 +1730,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_fill(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, o);
 
@@ -1765,7 +1765,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_copyWithin(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, o);
 
@@ -1837,7 +1837,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_at(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, o);
 
@@ -1853,7 +1853,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_flat(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         double depth;
         if (args.length < 1 || Undefined.isUndefined(args[0])) {
@@ -1865,7 +1865,7 @@ public class NativeArray extends ScriptableObject implements List {
         return flat(cx, s, o, depth);
     }
 
-    private static Scriptable flat(Context cx, Scriptable scope, Scriptable source, double depth) {
+    private static Scriptable flat(Context cx, VarScope scope, Scriptable source, double depth) {
         long length = getLengthProperty(cx, source);
 
         Scriptable result;
@@ -1892,7 +1892,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_flatMap(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
 
@@ -1932,7 +1932,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_every(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -1945,7 +1945,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_filter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -1958,7 +1958,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_forEach(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -1971,7 +1971,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_map(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -1984,7 +1984,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_some(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -1997,7 +1997,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_find(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -2010,7 +2010,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_findIndex(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -2023,7 +2023,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_findLast(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -2036,7 +2036,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_findLastIndex(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.iterativeMethod(
                 cx,
                 ARRAY_TAG,
@@ -2049,40 +2049,40 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_reduce(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.reduceMethod(
                 cx, ReduceOperation.REDUCE, s, thisObj, args);
     }
 
     private static Object js_reduceRight(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ArrayLikeAbstractOperations.reduceMethod(
                 cx, ReduceOperation.REDUCE_RIGHT, s, thisObj, args);
     }
 
     private static Object js_keys(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         return new NativeArrayIterator(
                 f.getDeclarationScope(), o, NativeArrayIterator.ARRAY_ITERATOR_TYPE.KEYS);
     }
 
     private static Object js_entries(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         return new NativeArrayIterator(
                 f.getDeclarationScope(), o, NativeArrayIterator.ARRAY_ITERATOR_TYPE.ENTRIES);
     }
 
     private static Object js_values(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         return new NativeArrayIterator(
                 f.getDeclarationScope(), o, NativeArrayIterator.ARRAY_ITERATOR_TYPE.VALUES);
     }
 
     private static Object js_isArrayMethod(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return Boolean.valueOf(args.length > 0 && js_isArray(args[0]));
     }
 
@@ -2097,7 +2097,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_toSorted(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, s, args);
 
         Scriptable source = ScriptRuntime.toObject(cx, s, thisObj);
@@ -2119,7 +2119,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_toReversed(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable source = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, source);
 
@@ -2139,7 +2139,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_toSpliced(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable source = ScriptRuntime.toObject(cx, s, thisObj);
         long len = getLengthProperty(cx, source);
 
@@ -2197,7 +2197,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static Object js_with(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable source = ScriptRuntime.toObject(cx, s, thisObj);
 
         long len = getLengthProperty(cx, source);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
@@ -29,10 +29,10 @@ public final class NativeArrayIterator extends ES6Iterator {
         super();
     }
 
-    public NativeArrayIterator(Scriptable scope, Scriptable arrayLike, ARRAY_ITERATOR_TYPE type) {
+    public NativeArrayIterator(VarScope scope, Object arrayLike, ARRAY_ITERATOR_TYPE type) {
         super(scope, ITERATOR_TAG);
         this.index = 0;
-        this.arrayLike = arrayLike;
+        this.arrayLike = (Scriptable) arrayLike;
         this.type = type;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBigInt.java
@@ -65,12 +65,12 @@ final class NativeBigInt extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static NativeBigInt toSelf(Scriptable thisObj) {
+    private static NativeBigInt toSelf(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeBigInt.class);
     }
 
     private static Object js_constructorFunc(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return (args.length >= 1) ? ScriptRuntime.toBigInt(args[0]) : BigInteger.ZERO;
     }
 
@@ -78,8 +78,7 @@ final class NativeBigInt extends ScriptableObject {
         throw ScriptRuntime.typeErrorById("msg.no.new", CLASS_NAME);
     }
 
-    private static Object js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         int base =
                 (args.length == 0 || args[0] == Undefined.instance)
                         ? 10
@@ -88,8 +87,7 @@ final class NativeBigInt extends ScriptableObject {
         return ScriptRuntime.bigIntToString(value, base);
     }
 
-    private static Object js_toSource(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return "(new BigInt(" + ScriptRuntime.toString(toSelf(thisObj).bigIntValue) + "))";
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
@@ -81,38 +81,37 @@ public class NativeConsole extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Object js_toSource(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return CLASS_NAME;
     }
 
-    private Object js_trace(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_trace(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptStackElement[] stack = new EvaluatorException("[object Object]").getScriptStack();
         printer.print(cx, scope, Level.TRACE, args, stack);
         return Undefined.instance;
     }
 
-    private Object js_debug(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_debug(Context cx, VarScope scope, Object thisObj, Object[] args) {
         printer.print(cx, scope, Level.DEBUG, args, null);
         return Undefined.instance;
     }
 
-    private Object js_log(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_log(Context cx, VarScope scope, Object thisObj, Object[] args) {
         printer.print(cx, scope, Level.INFO, args, null);
         return Undefined.instance;
     }
 
-    private Object js_info(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_info(Context cx, VarScope scope, Object thisObj, Object[] args) {
         printer.print(cx, scope, Level.INFO, args, null);
         return Undefined.instance;
     }
 
-    private Object js_warn(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_warn(Context cx, VarScope scope, Object thisObj, Object[] args) {
         printer.print(cx, scope, Level.WARN, args, null);
         return Undefined.instance;
     }
 
-    private Object js_error(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_error(Context cx, VarScope scope, Object thisObj, Object[] args) {
         printer.print(cx, scope, Level.ERROR, args, null);
         return Undefined.instance;
     }
@@ -294,7 +293,7 @@ public class NativeConsole extends ScriptableObject {
         }
     }
 
-    private Object js_assert(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_assert(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args != null && args.length > 0 && ScriptRuntime.toBoolean(args[0])) {
             return Undefined.instance;
         }
@@ -323,14 +322,14 @@ public class NativeConsole extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private Object js_count(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_count(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
         int count = counters.computeIfAbsent(label, l -> new AtomicInteger(0)).incrementAndGet();
         print(cx, scope, Level.INFO, label + ": " + count);
         return Undefined.instance;
     }
 
-    private Object js_countReset(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_countReset(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
         AtomicInteger counter = counters.remove(label);
         if (counter == null) {
@@ -339,7 +338,7 @@ public class NativeConsole extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private Object js_time(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_time(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
         Long start = timers.get(label);
         if (start != null) {
@@ -350,7 +349,7 @@ public class NativeConsole extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private Object js_timeEnd(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_timeEnd(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
         Long start = timers.remove(label);
         if (start == null) {
@@ -361,7 +360,7 @@ public class NativeConsole extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private Object js_timeLog(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private Object js_timeLog(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String label = args.length > 0 ? ScriptRuntime.toString(args[0]) : DEFAULT_LABEL;
         Long start = timers.get(label);
         if (start == null) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -55,28 +55,28 @@ final class NativeError extends ScriptableObject {
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return make(cx, s, f, args);
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_toString((Scriptable) thisObj);
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_toSource(cx, s, (Scriptable) thisObj);
     }
 
     private static Object js_captureStackTrace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         js_captureStackTrace(cx, f.getDeclarationScope(), thisObj, args);
         return Undefined.instance;
     }
 
     private static Object js_isError(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_isError(args);
     }
 
@@ -296,7 +296,8 @@ final class NativeError extends ScriptableObject {
         }
     }
 
-    private static String js_toSource(Context cx, Scriptable scope, Scriptable thisObj) {
+    private static String js_toSource(Context cx, VarScope scope, Object thisThing) {
+        var thisObj = (Scriptable) thisThing;
         // Emulation of SpiderMonkey behavior
         Object name = ScriptableObject.getProperty(thisObj, "name");
         Object message = ScriptableObject.getProperty(thisObj, "message");
@@ -335,7 +336,7 @@ final class NativeError extends ScriptableObject {
     }
 
     private static void js_captureStackTrace(
-            Context cx, Scriptable scope, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject obj = (ScriptableObject) ScriptRuntime.toObject(cx, scope, args[0]);
         Function func = null;
         if (args.length > 1) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -165,21 +165,18 @@ public class NativeGlobal implements Serializable {
         return functionObj instanceof EvalLambdaFunction;
     }
 
-    private static String js_uneval(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_uneval(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object value = (args.length != 0) ? args[0] : Undefined.instance;
         return ScriptRuntime.uneval(cx, (VarScope) scope, value);
     }
 
-    private static Boolean js_isXMLName(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Boolean js_isXMLName(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object name = (args.length == 0) ? Undefined.instance : args[0];
         XMLLib xmlLib = XMLLib.extractFromScope(scope);
         return xmlLib.isXMLName(cx, name);
     }
 
-    private static Boolean js_isNaN(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Boolean js_isNaN(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // The global method isNaN, as per ECMA-262 15.1.2.6.
         if (args.length < 1) {
             return true;
@@ -189,40 +186,37 @@ public class NativeGlobal implements Serializable {
         }
     }
 
-    private static Object js_isFinite(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_isFinite(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 1) {
             return Boolean.FALSE;
         }
         return NativeNumber.isFinite(args[0]);
     }
 
-    private static String js_decodeURI(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_decodeURI(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return decode(str, true);
     }
 
     private static String js_decodeURIComponent(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return decode(str, false);
     }
 
-    private static String js_encodeURI(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_encodeURI(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return encode(str, true);
     }
 
     private static String js_encodeURIComponent(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(args, 0);
         return encode(str, false);
     }
 
     /** The global method parseInt, as per ECMA-262 15.1.2.2. */
-    static Object js_parseInt(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    static Object js_parseInt(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String s = ScriptRuntime.toString(args, 0);
         int radix = ScriptRuntime.toInt32(args, 1);
 
@@ -275,7 +269,7 @@ public class NativeGlobal implements Serializable {
      *
      * @param args the arguments to parseFloat, ignoring args[>=1]
      */
-    static Object js_parseFloat(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    static Object js_parseFloat(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 1) return ScriptRuntime.NaNobj;
 
         String s = ScriptRuntime.toString(args[0]);
@@ -385,8 +379,7 @@ public class NativeGlobal implements Serializable {
      * <p>Includes code for the 'mask' argument supported by the C escape method, which used to be
      * part of the browser embedding. Blame for the strange constant names should be directed there.
      */
-    private static Object js_escape(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_escape(Context cx, VarScope scope, Object thisObj, Object[] args) {
         final int URL_XALPHAS = 1, URL_XPALPHAS = 2, URL_PATH = 4;
 
         String s = ScriptRuntime.toString(args, 0);
@@ -451,8 +444,7 @@ public class NativeGlobal implements Serializable {
     }
 
     /** The global unescape method, as per ECMA-262 15.1.2.5. */
-    private static Object js_unescape(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_unescape(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String s = ScriptRuntime.toString(args, 0);
         int firstEscapePos = s.indexOf('%');
         if (firstEscapePos >= 0) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -123,7 +123,7 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     private static Object jsConstructorCall(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         Scriptable target = requireIteratorTarget(cx, scope, args);
         boolean keyOnly = isKeyOnly(args);
 
@@ -165,7 +165,7 @@ public final class NativeIterator extends ScriptableObject {
         return args.length > 1 && ScriptRuntime.toBoolean(args[1]);
     }
 
-    private static Object js_next(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_next(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeIterator iterator = realThis(thisObj);
         return iterator.next(cx, scope);
     }
@@ -188,11 +188,11 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     private static Object js_iteratorMethod(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj);
     }
 
-    private static NativeIterator realThis(Scriptable thisObj) {
+    private static NativeIterator realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeIterator.class);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
@@ -54,7 +54,7 @@ public final class NativeJSON extends ScriptableObject {
         return "JSON";
     }
 
-    private static Object parse(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object parse(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String jtext = ScriptRuntime.toString(args, 0);
         Object reviver = null;
         if (args.length > 1) {
@@ -66,8 +66,7 @@ public final class NativeJSON extends ScriptableObject {
         return parse(cx, scope, jtext);
     }
 
-    private static Object stringify(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object stringify(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object value = Undefined.instance, replacer = null, space = null;
 
         if (args.length > 0) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -84,8 +84,7 @@ public class NativeMap extends ScriptableObject {
         return nm;
     }
 
-    private static Object jsGroupBy(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object jsGroupBy(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object items = args.length < 1 ? Undefined.instance : args[0];
         Object callback = args.length < 2 ? Undefined.instance : args[1];
 
@@ -109,7 +108,7 @@ public class NativeMap extends ScriptableObject {
         return map;
     }
 
-    private static Object js_set(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "set")
                 .js_set(key(args), args.length > 1 ? args[1] : Undefined.instance);
     }
@@ -124,8 +123,7 @@ public class NativeMap extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "delete").js_delete(key(args));
     }
 
@@ -133,7 +131,7 @@ public class NativeMap extends ScriptableObject {
         return entries.deleteEntry(arg);
     }
 
-    private static Object js_get(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_get(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "get").js_get(key(args));
     }
 
@@ -145,7 +143,7 @@ public class NativeMap extends ScriptableObject {
         return entry.value;
     }
 
-    private static Object js_has(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "has").js_has(key(args));
     }
 
@@ -157,17 +155,15 @@ public class NativeMap extends ScriptableObject {
         return entries.size();
     }
 
-    private static Object js_keys(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_keys(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "keys").js_iterator(scope, NativeCollectionIterator.Type.KEYS);
     }
 
-    private static Object js_values(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_values(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.VALUES);
     }
 
-    private static Object js_entries(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_entries(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "entries").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
     }
 
@@ -175,8 +171,7 @@ public class NativeMap extends ScriptableObject {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 
-    private static Object js_clear(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_clear(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "clear").js_clear();
     }
 
@@ -249,7 +244,7 @@ public class NativeMap extends ScriptableObject {
                 (key, value) -> set.call(cx, scope, map, new Object[] {key, value}));
     }
 
-    private static NativeMap realThis(Scriptable thisObj, String name) {
+    private static NativeMap realThis(Object thisObj, String name) {
         NativeMap nm = LambdaConstructor.convertThisObject(thisObj, NativeMap.class);
         if (!nm.instanceOfMap) {
             // Check for "Map internal data tag"

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMath.java
@@ -85,7 +85,7 @@ final class NativeMath extends ScriptableObject {
         return "Math";
     }
 
-    private static Object abs(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object abs(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // abs(-0.0) should be 0.0, but -0.0 < 0.0 == false
         x = (x == 0.0) ? 0.0 : (x < 0.0) ? -x : x;
@@ -93,7 +93,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object acos(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object acos(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             x = Math.acos(x);
@@ -103,7 +103,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object acosh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object acosh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x)) {
             return Double.valueOf(Math.log(x + Math.sqrt(x * x - 1.0)));
@@ -111,7 +111,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object asin(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object asin(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             x = Math.asin(x);
@@ -121,7 +121,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object asinh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object asinh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (Double.isInfinite(x)) {
             return Double.valueOf(x);
@@ -138,13 +138,13 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object atan(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object atan(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.atan(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object atanh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object atanh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && -1.0 <= x && x <= 1.0) {
             if (x == 0) {
@@ -158,25 +158,25 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object atan2(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object atan2(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.atan2(x, ScriptRuntime.toNumber(args, 1));
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object cbrt(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object cbrt(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.cbrt(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object ceil(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object ceil(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.ceil(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object clz32(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object clz32(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (x == 0 || Double.isNaN(x) || Double.isInfinite(x)) {
             return Double32;
@@ -214,19 +214,19 @@ final class NativeMath extends ScriptableObject {
         return Double.valueOf(32 - place);
     }
 
-    private static Object cos(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object cos(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Double.isInfinite(x) ? Double.NaN : Math.cos(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object cosh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object cosh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.cosh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object exp(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object exp(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x =
                 (x == Double.POSITIVE_INFINITY)
@@ -235,20 +235,19 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object expm1(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object expm1(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.expm1(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object floor(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object floor(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.floor(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object f16round(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object f16round(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // Handle missing arguments
         if (args.length == 0) {
             return ScriptRuntime.NaNobj;
@@ -393,7 +392,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(Double.longBitsToDouble(resultBits));
     }
 
-    private static Object fround(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object fround(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Rely on Java to truncate down to a "float" here"
         float fx = (float) x;
@@ -402,7 +401,7 @@ final class NativeMath extends ScriptableObject {
 
     // Based on code from
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
-    private static Object hypot(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object hypot(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args == null) {
             return 0.0;
         }
@@ -432,7 +431,7 @@ final class NativeMath extends ScriptableObject {
         return Math.sqrt(y);
     }
 
-    private static Object imul(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object imul(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args == null) {
             return 0;
         }
@@ -443,33 +442,33 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x * y);
     }
 
-    private static Object log(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object log(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Java's log(<0) = -Infinity; we need NaN
         x = (x < 0) ? Double.NaN : Math.log(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log1p(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object log1p(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.log1p(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log10(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object log10(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.log10(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object log2(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object log2(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         // Java's log(<0) = -Infinity; we need NaN
         x = (x < 0) ? Double.NaN : Math.log(x) * LOG2E;
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object max(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object max(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = Double.NEGATIVE_INFINITY;
         for (int i = 0; i != args.length; ++i) {
             double d = ScriptRuntime.toNumber(args[i]);
@@ -479,7 +478,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object min(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object min(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = Double.POSITIVE_INFINITY;
         for (int i = 0; i != args.length; ++i) {
             double d = ScriptRuntime.toNumber(args[i]);
@@ -490,7 +489,7 @@ final class NativeMath extends ScriptableObject {
     }
 
     // See Ecma 15.8.2.13
-    private static Object pow(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object pow(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         double y = ScriptRuntime.toNumber(args, 1);
         double result;
@@ -546,11 +545,11 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(result);
     }
 
-    private static Object random(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object random(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return ScriptRuntime.wrapNumber(Math.random());
     }
 
-    private static Object round(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object round(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x) && !Double.isInfinite(x)) {
             // Round only finite x
@@ -569,7 +568,7 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sign(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object sign(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         if (!Double.isNaN(x)) {
             if (x == 0) {
@@ -583,37 +582,37 @@ final class NativeMath extends ScriptableObject {
         return ScriptRuntime.NaNobj;
     }
 
-    private static Object sin(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object sin(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Double.isInfinite(x) ? Double.NaN : Math.sin(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sinh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object sinh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.sinh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object sqrt(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object sqrt(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.sqrt(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object tan(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object tan(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.tan(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object tanh(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object tanh(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = Math.tanh(x);
         return ScriptRuntime.wrapNumber(x);
     }
 
-    private static Object trunc(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object trunc(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double x = ScriptRuntime.toNumber(args, 0);
         x = ((x < 0.0) ? Math.ceil(x) : Math.floor(x));
         return ScriptRuntime.wrapNumber(x);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -132,17 +132,15 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_constructorFunc(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return (args.length > 0) ? ScriptRuntime.toNumeric(args[0]).doubleValue() : 0.0;
     }
 
-    private static Object js_valueOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_valueOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return toSelf(thisObj).doubleValue;
     }
 
-    private static Object js_toFixed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toFixed(Context cx, VarScope scope, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
 
         int fractionDigits;
@@ -164,7 +162,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toExponential(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
 
         double p;
@@ -190,7 +188,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toPrecision(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         double value = toSelf(thisObj).doubleValue;
         // Undefined precision, fall back to ToString()
         if (args.length == 0 || Undefined.isUndefined(args[0])) {
@@ -215,12 +213,11 @@ final class NativeNumber extends ScriptableObject {
         }
     }
 
-    private static NativeNumber toSelf(Scriptable thisObj) {
+    private static NativeNumber toSelf(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeNumber.class);
     }
 
-    private static Object js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         int base =
                 (args.length == 0 || Undefined.isUndefined(args[0]))
                         ? 10
@@ -229,7 +226,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toLocaleString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         if (!cx.hasFeature(Context.FEATURE_INTL_402)) {
             return js_toString(cx, scope, thisObj, ScriptRuntime.emptyArgs);
         }
@@ -248,7 +245,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_toSource(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         return "(new Number(" + ScriptRuntime.toString(toSelf(thisObj).doubleValue) + "))";
     }
 
@@ -266,8 +263,7 @@ final class NativeNumber extends ScriptableObject {
         return ScriptRuntime.numberToString(doubleValue, 10);
     }
 
-    private static Object js_isFinite(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_isFinite(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Number n = argToNumber(args);
         return n == null ? Boolean.FALSE : isFinite(n);
     }
@@ -277,8 +273,7 @@ final class NativeNumber extends ScriptableObject {
         return Double.isFinite(nd);
     }
 
-    private static Object js_isNaN(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_isNaN(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;
@@ -290,8 +285,7 @@ final class NativeNumber extends ScriptableObject {
         return Double.isNaN(d);
     }
 
-    private static Object js_isInteger(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_isInteger(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;
@@ -303,7 +297,7 @@ final class NativeNumber extends ScriptableObject {
     }
 
     private static Object js_isSafeInteger(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         Number val = argToNumber(args);
         if (val == null) {
             return false;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -110,7 +110,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Scriptable js_constructorCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
             return cx.newObject(f.getDeclarationScope());
         }
@@ -118,7 +118,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Scriptable js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length == 0 || args[0] == null || Undefined.isUndefined(args[0])) {
             return cx.newObject(f.getDeclarationScope());
         }
@@ -126,7 +126,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_toLocaleString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (thisObj == null) {
             throw ScriptRuntime.notFunctionError(null);
         }
@@ -140,12 +140,12 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ScriptRuntime.defaultObjectToString((Scriptable) thisObj);
     }
 
     private static Object js_valueOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (cx.getLanguageVersion() >= Context.VERSION_1_8
                 && (thisObj == null || Undefined.isUndefined(thisObj))) {
             throw ScriptRuntime.typeErrorById(
@@ -155,7 +155,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_hasOwnProperty(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (cx.getLanguageVersion() >= Context.VERSION_1_8
                 && (thisObj == null || Undefined.isUndefined(thisObj))) {
             throw ScriptRuntime.typeErrorById(
@@ -168,7 +168,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_propertyIsEnumerable(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (cx.getLanguageVersion() >= Context.VERSION_1_8
                 && (thisObj == null || Undefined.isUndefined(thisObj))) {
             throw ScriptRuntime.typeErrorById(
@@ -213,7 +213,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_isPrototypeOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (cx.getLanguageVersion() >= Context.VERSION_1_8
                 && (thisObj == null || Undefined.isUndefined(thisObj))) {
             throw ScriptRuntime.typeErrorById(
@@ -271,12 +271,12 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_defineGetter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_defineGetterOrSetter(cx, s, false, thisObj, args);
     }
 
     private static Object js_defineSetter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_defineGetterOrSetter(cx, s, true, thisObj, args);
     }
 
@@ -303,12 +303,12 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_lookupGetter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_lookupGetterOrSetter(cx, s, false, thisObj, args);
     }
 
     private static Object js_lookupSetter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_lookupGetterOrSetter(cx, s, true, thisObj, args);
     }
 
@@ -344,14 +344,14 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_getPrototypeOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable obj = getCompatibleObject(cx, s, arg);
         return obj.getPrototype();
     }
 
     private static Object js_setPrototypeOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -397,7 +397,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_keys(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable obj = getCompatibleObject(cx, f.getDeclarationScope(), arg);
         Object[] ids = obj.getIds();
@@ -408,7 +408,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_entries(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable obj = getCompatibleObject(cx, s, arg);
         Object[] ids = obj.getIds();
@@ -436,7 +436,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_fromEntries(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         arg = getCompatibleObject(cx, f.getDeclarationScope(), arg);
         Scriptable obj = cx.newObject(f.getDeclarationScope());
@@ -459,7 +459,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_values(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable obj = getCompatibleObject(cx, s, arg);
         Object[] ids = obj.getIds();
@@ -485,14 +485,14 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_hasOwn(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Object propertyName = args.length < 2 ? Undefined.instance : args[1];
         return AbstractEcmaObjectOperations.hasOwnProperty(cx, arg, propertyName);
     }
 
     private static Object js_getOwnPropertyNames(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s2 = getCompatibleObject(cx, s, arg);
         ScriptableObject obj = ensureScriptableObject(s2);
@@ -507,7 +507,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_getOwnPropertySymbols(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s2 = getCompatibleObject(cx, s, arg);
         ScriptableObject obj = ensureScriptableObject(s2);
@@ -525,7 +525,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_getOwnPropDesc(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         // TODO(norris): There's a deeper issue here if
         // arg instanceof Scriptable. Should we create a new
@@ -538,7 +538,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_getOwnPropDescs(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s2 = getCompatibleObject(cx, s, arg);
         ScriptableObject obj = ensureScriptableObject(s2);
@@ -564,7 +564,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_defineProperty(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         ScriptableObject obj = ensureScriptableObject(arg);
         Object name = args.length < 2 ? Undefined.instance : args[1];
@@ -576,7 +576,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_isExtensible(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return Boolean.FALSE;
@@ -587,7 +587,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_preventExtensions(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return arg;
@@ -601,7 +601,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_defineProperties(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         ScriptableObject obj = ensureScriptableObject(arg);
         Object propsObj = args.length < 2 ? Undefined.instance : args[1];
@@ -611,7 +611,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_create(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable obj = (arg == null) ? null : ensureScriptable(arg);
 
@@ -628,7 +628,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_isSealed(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return Boolean.TRUE;
@@ -639,7 +639,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_isFrozen(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return Boolean.TRUE;
@@ -650,7 +650,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_seal(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return arg;
@@ -666,7 +666,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_freeze(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         if (cx.getLanguageVersion() >= Context.VERSION_ES6 && !(arg instanceof ScriptableObject)) {
             return arg;
@@ -683,7 +683,7 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_assign(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable targetObj;
         if (args.length > 0) {
             targetObj = ScriptRuntime.toObject(cx, s, args[0]);
@@ -739,14 +739,14 @@ public class NativeObject extends ScriptableObject implements Map {
     }
 
     private static Object js_is(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object a1 = args.length < 1 ? Undefined.instance : args[0];
         Object a2 = args.length < 2 ? Undefined.instance : args[1];
         return ScriptRuntime.wrapBoolean(ScriptRuntime.same(a1, a2));
     }
 
     private static Object js_groupBy(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object items = args.length < 1 ? Undefined.instance : args[0];
         Object callback = args.length < 2 ? Undefined.instance : args[1];
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -1248,8 +1248,7 @@ class NativeProxy extends ScriptableObject {
     }
 
     // Proxy.revocable
-    private static Object revocable(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object revocable(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -55,7 +55,7 @@ final class NativeReflect extends ScriptableObject {
         return "Reflect";
     }
 
-    private static Object apply(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object apply(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -161,7 +161,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object defineProperty(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 3) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",
@@ -191,7 +191,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object deleteProperty(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -204,7 +204,7 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object get(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object get(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -224,7 +224,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Scriptable getOwnPropertyDescriptor(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -240,13 +240,13 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Scriptable getPrototypeOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.getPrototype();
     }
 
-    private static Object has(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object has(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         if (args.length > 1) {
@@ -259,14 +259,12 @@ final class NativeReflect extends ScriptableObject {
         return false;
     }
 
-    private static Object isExtensible(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object isExtensible(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         return target.isExtensible();
     }
 
-    private static Scriptable ownKeys(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Scriptable ownKeys(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         final List<Object> strings = new ArrayList<>();
@@ -292,13 +290,13 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object preventExtensions(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
 
         return target.preventExtensions();
     }
 
-    private static Object set(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object set(Context cx, VarScope scope, Object thisObj, Object[] args) {
         ScriptableObject target = checkTarget(args);
         if (args.length < 2) {
             return true;
@@ -337,7 +335,7 @@ final class NativeReflect extends ScriptableObject {
     }
 
     private static Object setPrototypeOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
@@ -114,20 +114,18 @@ class NativeScript extends BaseFunction {
         return super.decompile(indent, flags);
     }
 
-    private static Object js_compile(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_compile(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeScript real = realThis(thisObj, "compile");
         String source = ScriptRuntime.toString(args, 0);
         real.script = compile(cx, source);
         return real;
     }
 
-    private static Object js_exec(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_exec(Context cx, VarScope scope, Object thisObj, Object[] args) {
         throw Context.reportRuntimeErrorById("msg.cant.call.indirect", "exec");
     }
 
-    private static Object js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeScript real = realThis(thisObj, "toString");
         Script realScript = real.script;
         if (realScript == null) {
@@ -137,7 +135,7 @@ class NativeScript extends BaseFunction {
     }
 
     private static Scriptable js_constructorCall(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return js_constructor(cx, scope, args);
     }
 
@@ -149,7 +147,7 @@ class NativeScript extends BaseFunction {
         return nscript;
     }
 
-    private static NativeScript realThis(Scriptable thisObj, String name) {
+    private static NativeScript realThis(Object thisObj, String name) {
         return ensureType(thisObj, NativeScript.class, name);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -102,7 +102,7 @@ public class NativeSet extends ScriptableObject {
         return ns;
     }
 
-    private static Object js_add(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_add(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var k = NativeMap.key(args);
         return realThis.js_add(k);
@@ -118,8 +118,7 @@ public class NativeSet extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_delete(arg);
@@ -129,7 +128,7 @@ public class NativeSet extends ScriptableObject {
         return entries.deleteEntry(arg);
     }
 
-    private static Object js_has(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_has(arg);
@@ -143,8 +142,7 @@ public class NativeSet extends ScriptableObject {
         return entries.has(arg);
     }
 
-    private static Object js_clear(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_clear(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         return realThis.js_clear();
     }
@@ -154,8 +152,7 @@ public class NativeSet extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private static Object js_getSize(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_getSize(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         return realThis.js_getSize();
     }
@@ -164,14 +161,12 @@ public class NativeSet extends ScriptableObject {
         return entries.size();
     }
 
-    private static Object js_values(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_values(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.VALUES);
     }
 
-    private static Object js_entries(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_entries(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeSet realThis = realThis(thisObj, "add");
         return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
     }
@@ -180,8 +175,7 @@ public class NativeSet extends ScriptableObject {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 
-    private static Object js_forEach(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_forEach(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "forEach")
                 .js_forEach(
                         cx,
@@ -236,7 +230,7 @@ public class NativeSet extends ScriptableObject {
         }
     }
 
-    private static NativeSet realThis(Scriptable thisObj, String name) {
+    private static NativeSet realThis(Object thisObj, String name) {
         NativeSet ns = LambdaConstructor.convertThisObject(thisObj, NativeSet.class);
         if (!ns.instanceOfSet) {
             // If we get here, then this object doesn't have the "Set internal data slot."
@@ -248,7 +242,7 @@ public class NativeSet extends ScriptableObject {
     // ES2025 Set Methods Implementation
 
     private static Object js_intersection(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "intersection").js_intersection(cx, scope, args);
     }
 
@@ -334,8 +328,7 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_union(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_union(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "union").js_union(cx, scope, args);
     }
 
@@ -392,8 +385,7 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_difference(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_difference(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "difference").js_difference(cx, scope, args);
     }
 
@@ -493,7 +485,7 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_symmetricDifference(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "symmetricDifference").js_symmetricDifference(cx, scope, args);
     }
 
@@ -558,8 +550,7 @@ public class NativeSet extends ScriptableObject {
         return result;
     }
 
-    private static Object js_isSubsetOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_isSubsetOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "isSubsetOf").js_isSubsetOf(cx, scope, args);
     }
 
@@ -617,7 +608,7 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_isSupersetOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "isSupersetOf").js_isSupersetOf(cx, scope, args);
     }
 
@@ -668,7 +659,7 @@ public class NativeSet extends ScriptableObject {
     }
 
     private static Object js_isDisjointFrom(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "isDisjointFrom").js_isDisjointFrom(cx, scope, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -221,7 +221,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_constructorFunc(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence s;
         if (args.length == 0) {
             s = "";
@@ -237,7 +237,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_fromCharCode(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         int n = args.length;
         if (n < 1) {
             return "";
@@ -250,7 +250,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_fromCodePoint(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         int n = args.length;
         if (n < 1) {
             return "";
@@ -268,17 +268,15 @@ final class NativeString extends ScriptableObject {
         return new String(codePoints, 0, n);
     }
 
-    private static Object js_charAt(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_charAt(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return charAt(cx, thisObj, args, false);
     }
 
-    private static Object js_charCodeAt(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_charCodeAt(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return charAt(cx, thisObj, args, true);
     }
 
-    private static Object charAt(Context cx, Scriptable thisObj, Object[] args, boolean getCode) {
+    private static Object charAt(Context cx, Object thisObj, Object[] args, boolean getCode) {
         // See ECMA 15.5.4.[4,5]
         CharSequence target =
                 ScriptRuntime.toCharSequence(
@@ -293,8 +291,7 @@ final class NativeString extends ScriptableObject {
         return ScriptRuntime.wrapInt(c);
     }
 
-    private static Object js_indexOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_indexOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "indexOf"));
         String searchStr = ScriptRuntime.toString(args, 0);
@@ -310,8 +307,7 @@ final class NativeString extends ScriptableObject {
         return target.indexOf(searchStr, (int) position);
     }
 
-    private static Object js_startsWith(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_startsWith(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "startsWith"));
@@ -323,8 +319,7 @@ final class NativeString extends ScriptableObject {
         return target.startsWith(searchStr, (int) position);
     }
 
-    private static Object js_endsWith(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_endsWith(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "endsWith"));
         checkValidRegex(cx, args, 0, "endsWith");
@@ -338,8 +333,7 @@ final class NativeString extends ScriptableObject {
         return target.substring(0, (int) position).endsWith(searchStr);
     }
 
-    private static Object js_includes(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_includes(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "includes"));
         String searchStr = ScriptRuntime.toString(args, 0);
@@ -364,8 +358,7 @@ final class NativeString extends ScriptableObject {
         }
     }
 
-    private static Object js_split(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_split(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.23
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "split");
 
@@ -449,25 +442,22 @@ final class NativeString extends ScriptableObject {
         return cx.newArray(scope, substrings.toArray());
     }
 
-    private static NativeString realThis(Scriptable thisObj) {
+    private static NativeString realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeString.class);
     }
 
-    private static Object js_iterator(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_iterator(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return new NativeStringIterator(
                 scope, requireObjectCoercible(cx, thisObj, CLASS_NAME, "[Symbol.iterator]"));
     }
 
-    private static Object js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // ECMA 15.5.4.2: the toString function is not generic.
         CharSequence cs = realThis(thisObj).string;
         return cs instanceof String ? cs : cs.toString();
     }
 
-    private static Object js_toSource(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toSource(Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence s = realThis(thisObj).string;
         return "(new String(\"" + ScriptRuntime.escapeString(s.toString()) + "\"))";
     }
@@ -477,7 +467,7 @@ final class NativeString extends ScriptableObject {
      */
     private static String tagify(
             Context cx,
-            Scriptable thisObj,
+            Object thisObj,
             String functionName,
             String tag,
             String attribute,
@@ -586,8 +576,7 @@ final class NativeString extends ScriptableObject {
      * See ECMA 22.1.3.13
      *
      */
-    private static Object js_match(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_match(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "match");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
         RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
@@ -634,7 +623,7 @@ final class NativeString extends ScriptableObject {
      *
      */
     private static Object js_lastIndexOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "lastIndexOf"));
@@ -650,8 +639,7 @@ final class NativeString extends ScriptableObject {
     /*
      * See ECMA 15.5.4.15
      */
-    private static Object js_substring(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_substring(Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "substring"));
@@ -680,7 +668,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLowerCase(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMA 15.5.4.11
         String thisStr =
                 ScriptRuntime.toString(
@@ -689,7 +677,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toUpperCase(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMA 15.5.4.12
         String thisStr =
                 ScriptRuntime.toString(
@@ -705,7 +693,7 @@ final class NativeString extends ScriptableObject {
      * Non-ECMA methods.
      */
     private static CharSequence js_substr(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "substr"));
@@ -746,8 +734,7 @@ final class NativeString extends ScriptableObject {
     /*
      * Python-esque sequence operations.
      */
-    private static String js_concat(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_concat(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String target =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "concat"));
         int N = args.length;
@@ -776,8 +763,7 @@ final class NativeString extends ScriptableObject {
         return result.toString();
     }
 
-    private static Object js_slice(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_slice(Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence target =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "slice"));
@@ -806,7 +792,7 @@ final class NativeString extends ScriptableObject {
         return target.subSequence((int) begin, (int) end);
     }
 
-    private static Object js_at(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_at(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str = ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "at"));
         Object targetArg = (args.length >= 1) ? args[0] : Undefined.instance;
         int len = str.length();
@@ -821,22 +807,20 @@ final class NativeString extends ScriptableObject {
         return str.substring(k, k + 1);
     }
 
-    private static Object js_equals(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_equals(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String s1 = ScriptRuntime.toString(thisObj);
         String s2 = ScriptRuntime.toString(args, 0);
         return s1.equals(s2);
     }
 
     private static Object js_equalsIgnoreCase(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String s1 = ScriptRuntime.toString(thisObj);
         String s2 = ScriptRuntime.toString(args, 0);
         return s1.equalsIgnoreCase(s2);
     }
 
-    private static Object js_search(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_search(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "search");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
         RegExpProxy regExpProxy = ScriptRuntime.checkRegExpProxy(cx);
@@ -876,8 +860,7 @@ final class NativeString extends ScriptableObject {
         return ((Callable) method).call(cx, (VarScope) scope, rx, new Object[] {s});
     }
 
-    private static Object js_replace(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_replace(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.19
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "replace");
 
@@ -964,8 +947,7 @@ final class NativeString extends ScriptableObject {
         return preceding + replacement + following;
     }
 
-    private static Object js_replaceAll(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_replaceAll(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.20
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "replaceAll");
 
@@ -1068,8 +1050,7 @@ final class NativeString extends ScriptableObject {
         return result.toString();
     }
 
-    private static Object js_matchAll(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_matchAll(Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.1.3.14
         Object o = requireObjectCoercible(cx, thisObj, CLASS_NAME, "matchAll");
         Object regexp = args.length > 0 ? args[0] : Undefined.instance;
@@ -1114,7 +1095,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_localeCompare(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // For now, create and configure a collator instance. I can't
         // actually imagine that this'd be slower than caching them
         // a la ClassCache, so we aren't trying to outsmart ourselves
@@ -1129,7 +1110,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLocaleLowerCase(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String thisStr =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toLocaleLowerCase"));
@@ -1146,7 +1127,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toLocaleUpperCase(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String thisStr =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toLocaleUpperCase"));
@@ -1162,7 +1143,7 @@ final class NativeString extends ScriptableObject {
         return thisStr.toUpperCase(locale);
     }
 
-    private static Object js_trim(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_trim(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "trim"));
         char[] chars = str.toCharArray();
@@ -1179,8 +1160,7 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_trimLeft(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_trimLeft(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "trimLeft"));
         char[] chars = str.toCharArray();
@@ -1194,8 +1174,7 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_trimRight(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_trimRight(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "trimRight"));
@@ -1211,8 +1190,7 @@ final class NativeString extends ScriptableObject {
         return str.substring(start, end);
     }
 
-    private static Object js_normalize(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_normalize(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length == 0 || Undefined.isUndefined(args[0])) {
             return Normalizer.normalize(
                     ScriptRuntime.toString(
@@ -1237,8 +1215,7 @@ final class NativeString extends ScriptableObject {
                 form);
     }
 
-    private static String js_repeat(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_repeat(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(requireObjectCoercible(cx, thisObj, CLASS_NAME, "repeat"));
         double cnt = ScriptRuntime.toInteger(args, 0);
@@ -1274,7 +1251,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_codePointAt(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String str =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "codePointAt"));
@@ -1291,7 +1268,7 @@ final class NativeString extends ScriptableObject {
      *     fillString])</a>
      */
     private static String pad(
-            Context cx, Scriptable thisObj, String functionName, Object[] args, boolean atStart) {
+            Context cx, Object thisObj, String functionName, Object[] args, boolean atStart) {
         String pad =
                 ScriptRuntime.toString(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, functionName));
@@ -1323,13 +1300,11 @@ final class NativeString extends ScriptableObject {
         return concat.insert(0, pad).toString();
     }
 
-    private static Object js_padStart(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_padStart(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return pad(cx, thisObj, "padStart", args, true);
     }
 
-    private static Object js_padEnd(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_padEnd(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return pad(cx, thisObj, "padEnd", args, false);
     }
 
@@ -1340,7 +1315,7 @@ final class NativeString extends ScriptableObject {
      *
      * <p>22.1.2.4 String.raw [Draft ECMA-262 / April 28, 2021]
      */
-    private static Object js_raw(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_raw(Context cx, VarScope scope, Object thisObj, Object[] args) {
         /* step 1-2 */
         Object arg0 = args.length > 0 ? args[0] : Undefined.instance;
         Scriptable cooked = ScriptRuntime.toObject(cx, scope, arg0);
@@ -1378,7 +1353,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_isWellFormed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence str =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "isWellFormed"));
@@ -1404,7 +1379,7 @@ final class NativeString extends ScriptableObject {
     }
 
     private static Object js_toWellFormed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         CharSequence str =
                 ScriptRuntime.toCharSequence(
                         requireObjectCoercible(cx, thisObj, CLASS_NAME, "toWellFormed"));
@@ -1450,63 +1425,55 @@ final class NativeString extends ScriptableObject {
         return sb.toString();
     }
 
-    private static Object js_bold(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_bold(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "bold", "b", null, args);
     }
 
-    private static Object js_italics(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_italics(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "italics", "i", null, args);
     }
 
-    private static Object js_fixed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_fixed(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fixed", "tt", null, args);
     }
 
-    private static Object js_strike(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_strike(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "strike", "strike", null, args);
     }
 
-    private static Object js_small(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_small(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "small", "small", null, args);
     }
 
-    private static Object js_big(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_big(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "big", "big", null, args);
     }
 
-    private static Object js_blink(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_blink(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "blink", "blink", null, args);
     }
 
-    private static Object js_sup(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_sup(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "sup", "sup", null, args);
     }
 
-    private static Object js_sub(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_sub(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "sub", "sub", null, args);
     }
 
-    private static Object js_fontsize(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_fontsize(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fontsize", "font", "size", args);
     }
 
-    private static Object js_fontcolor(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_fontcolor(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "fontcolor", "font", "color", args);
     }
 
-    private static Object js_link(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_link(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "link", "a", "href", args);
     }
 
-    private static Object js_anchor(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_anchor(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return tagify(cx, thisObj, "anchor", "a", "name", args);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSymbol.java
@@ -84,12 +84,12 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         ctor.defineProperty(name, key, DONTENUM | READONLY | PERMANENT);
     }
 
-    private static NativeSymbol getSelf(Scriptable thisObj) {
+    private static NativeSymbol getSelf(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeSymbol.class);
     }
 
     private static SymbolKey js_constructorCall(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         String desc;
         if (args.length > 0 && !Undefined.isUndefined(args[0])) {
             desc = ScriptRuntime.toString(args[0]);
@@ -99,13 +99,11 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         return new SymbolKey(desc, Symbol.Kind.REGULAR);
     }
 
-    private static String js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_toString(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return getSelf(thisObj).toString();
     }
 
-    private static Object js_valueOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_valueOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return getSelf(thisObj).key;
     }
 
@@ -113,7 +111,7 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
         return getSelf(thisObj).getKey().getDescription();
     }
 
-    private static Object js_for(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_for(Context cx, VarScope scope, Object thisObj, Object[] args) {
         String name =
                 (args.length > 0
                         ? ScriptRuntime.toString(args[0])
@@ -124,8 +122,7 @@ public class NativeSymbol extends ScriptableObject implements Symbol {
     }
 
     @SuppressWarnings("ReferenceEquality")
-    private static Object js_keyFor(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_keyFor(Context cx, VarScope scope, Object thisObj, Object[] args) {
         Object s = (args.length > 0 ? args[0] : Undefined.instance);
         SymbolKey sym;
         if (s instanceof NativeSymbol) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakMap.java
@@ -69,8 +69,7 @@ public class NativeWeakMap extends ScriptableObject {
         return nm;
     }
 
-    private static Object js_delete(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "delete").js_delete(NativeMap.key(args));
     }
 
@@ -81,7 +80,7 @@ public class NativeWeakMap extends ScriptableObject {
         return map.remove(key) != null;
     }
 
-    private static Object js_get(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_get(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "get").js_get(NativeMap.key(args));
     }
 
@@ -98,7 +97,7 @@ public class NativeWeakMap extends ScriptableObject {
         return result;
     }
 
-    private static Object js_has(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "has").js_has(NativeMap.key(args));
     }
 
@@ -109,7 +108,7 @@ public class NativeWeakMap extends ScriptableObject {
         return map.containsKey(key);
     }
 
-    private static Object js_set(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "set")
                 .js_set(NativeMap.key(args), args.length > 1 ? args[1] : Undefined.instance);
     }
@@ -133,7 +132,7 @@ public class NativeWeakMap extends ScriptableObject {
         return ScriptRuntime.isUnregisteredSymbol(key) || ScriptRuntime.isObject(key);
     }
 
-    private static NativeWeakMap realThis(Scriptable thisObj, String name) {
+    private static NativeWeakMap realThis(Object thisObj, String name) {
         NativeWeakMap nm = LambdaConstructor.convertThisObject(thisObj, NativeWeakMap.class);
         if (!nm.instanceOfWeakMap) {
             // Check for "Map internal data tag"

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
@@ -64,7 +64,7 @@ public class NativeWeakSet extends ScriptableObject {
         return ns;
     }
 
-    private static Object js_add(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_add(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var k = NativeMap.key(args);
         return realThis.js_add(k);
@@ -84,8 +84,7 @@ public class NativeWeakSet extends ScriptableObject {
         return this;
     }
 
-    private static Object js_delete(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_delete(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_delete(arg);
@@ -98,7 +97,7 @@ public class NativeWeakSet extends ScriptableObject {
         return map.remove(key) != null;
     }
 
-    private static Object js_has(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_has(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeWeakSet realThis = realThis(thisObj, "add");
         var arg = NativeMap.key(args);
         return realThis.js_has(arg);
@@ -115,7 +114,7 @@ public class NativeWeakSet extends ScriptableObject {
         return ScriptRuntime.isUnregisteredSymbol(v) || ScriptRuntime.isObject(v);
     }
 
-    private static NativeWeakSet realThis(Scriptable thisObj, String name) {
+    private static NativeWeakSet realThis(Object thisObj, String name) {
         NativeWeakSet ns = LambdaConstructor.convertThisObject(thisObj, NativeWeakSet.class);
         if (!ns.instanceOfWeakSet) {
             // Check for "Set internal data tag"

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -26,8 +26,7 @@ public interface RegExpProxy {
 
     public Scriptable wrapRegExp(Context cx, Scriptable scope, Object compiled);
 
-    public Object action(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args, int actionType);
+    public Object action(Context cx, VarScope scope, Object thisObj, Object[] args, int actionType);
 
     public int find_split(
             Context cx,

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -1148,18 +1148,18 @@ public class ScriptRuntime {
         }
     }
 
-    static String defaultObjectToString(Scriptable obj) {
+    static String defaultObjectToString(Object obj) {
         if (obj == null) return "[object Null]";
         if (Undefined.isUndefined(obj)) return "[object Undefined]";
 
-        Object tagValue = ScriptableObject.getProperty(obj, SymbolKey.TO_STRING_TAG);
+        Object tagValue = ScriptableObject.getProperty((Scriptable) obj, SymbolKey.TO_STRING_TAG);
         // Note: Scriptable.NOT_FOUND is not a CharSequence, so we don't need to explicitly check
         // for it
         if (tagValue instanceof CharSequence) {
             return "[object " + tagValue + "]";
         }
 
-        return "[object " + obj.getClassName() + "]";
+        return "[object " + ((Scriptable) obj).getClassName() + "]";
     }
 
     public static String toString(Object[] args, int index) {
@@ -1239,7 +1239,7 @@ public class ScriptRuntime {
     }
 
     static String defaultObjectToSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         boolean toplevel, iterating;
         if (cx.iterating == null) {
             toplevel = true;

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -4304,12 +4304,12 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_compile(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).compile(cx, s, args);
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         // thisObj != scope is a strange hack but i had no better idea for the moment
         if (thisObj != s && thisObj instanceof NativeObject) {
             NativeObject realThis = (NativeObject) thisObj;
@@ -4324,17 +4324,17 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).toString();
     }
 
     private static Object js_exec(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_exec(cx, s, thisObj, args);
     }
 
     private static Object js_test(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         {
             Object x = realThis(thisObj, f).execSub(cx, s, args, TEST);
             return Boolean.TRUE.equals(x) ? Boolean.TRUE : Boolean.FALSE;
@@ -4342,32 +4342,32 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_prefix(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return realThis(thisObj, f).execSub(cx, s, args, PREFIX);
     }
 
     private static Object js_match(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_SymbolMatch(cx, s, thisObj, args);
     }
 
     private static Object js_matchAll(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_SymbolMatchAll(cx, s, thisObj, args);
     }
 
     private static Object js_search(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_SymbolSearch(cx, s, thisObj, args);
     }
 
     private static Object js_replace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_SymbolReplace(cx, s, thisObj, args);
     }
 
     private static Object js_split(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return js_SymbolSplit(cx, s, thisObj, args);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -45,7 +45,7 @@ public class RegExpImpl implements RegExpProxy {
 
     @Override
     public Object action(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args, int actionType) {
+            Context cx, VarScope scope, Object thisObj, Object[] args, int actionType) {
         GlobData data = new GlobData();
         data.mode = actionType;
         data.str = ScriptRuntime.toString(thisObj);
@@ -205,8 +205,8 @@ public class RegExpImpl implements RegExpProxy {
     /** Analog of C match_or_replace. */
     private static Object matchOrReplace(
             Context cx,
-            Scriptable scope,
-            Scriptable thisObj,
+            VarScope scope,
+            Object thisObj,
             Object[] args,
             RegExpImpl reImpl,
             GlobData data,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -619,7 +619,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return getLength();
     }
 
-    private static NativeTypedArrayView realThis(Scriptable thisObj) {
+    private static NativeTypedArrayView realThis(Object thisObj) {
         return LambdaConstructor.convertThisObject(thisObj, NativeTypedArrayView.class);
     }
 
@@ -713,8 +713,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         }
     }
 
-    private static Object js_entries(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_entries(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
@@ -722,15 +721,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.ENTRIES);
     }
 
-    private static Object js_every(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_every(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx, IterativeOperation.EVERY, lscope, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_filter(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_filter(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         Scriptable array =
                 (Scriptable)
@@ -750,15 +747,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return newArray;
     }
 
-    private static Object js_find(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_find(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx, IterativeOperation.FIND, lscope, self, args, self.validateAndGetLength());
     }
 
     private static Object js_findIndex(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx,
@@ -769,15 +765,14 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 self.validateAndGetLength());
     }
 
-    private static Object js_findLast(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_findLast(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx, IterativeOperation.FIND_LAST, lscope, self, args, self.validateAndGetLength());
     }
 
     private static Object js_findLastIndex(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx,
@@ -788,15 +783,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
                 self.validateAndGetLength());
     }
 
-    private static Object js_forEach(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_forEach(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx, IterativeOperation.FOR_EACH, lscope, self, args, self.validateAndGetLength());
     }
 
-    private static Boolean js_includes(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Boolean js_includes(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -824,8 +817,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return Boolean.FALSE;
     }
 
-    private static Object js_indexOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_indexOf(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -857,12 +849,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static Object js_iterator(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+            Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) {
         return js_values(lcx, lscope, thisObj, args);
     }
 
-    private static Object js_keys(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_keys(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
@@ -871,7 +862,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static Object js_lastIndexOf(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -900,8 +891,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return -1;
     }
 
-    private static Object js_map(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_map(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
         NativeTypedArrayView<?> newArray =
@@ -916,22 +906,20 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return newArray;
     }
 
-    private static Object js_reduce(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_reduce(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.reduceMethodWithLength(
                 lcx, ReduceOperation.REDUCE, lscope, self, args, self.validateAndGetLength());
     }
 
     private static Object js_reduceRight(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+            Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.reduceMethodWithLength(
                 lcx, ReduceOperation.REDUCE_RIGHT, lscope, self, args, self.validateAndGetLength());
     }
 
-    private static Scriptable js_slice(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Scriptable js_slice(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long srcLength = self.validateAndGetLength();
 
@@ -979,15 +967,13 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return a;
     }
 
-    private static Object js_some(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_some(Context lcx, VarScope lscope, Scriptable thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         return ArrayLikeAbstractOperations.coercibleIterativeMethod(
                 lcx, IterativeOperation.SOME, lscope, self, args, self.validateAndGetLength());
     }
 
-    private static Object js_values(
-            Context lcx, Scriptable lscope, Scriptable thisObj, Object[] args) {
+    private static Object js_values(Context lcx, VarScope lscope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
@@ -995,7 +981,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return new NativeArrayIterator(lscope, self, ARRAY_ITERATOR_TYPE.VALUES);
     }
 
-    private static String js_join(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static String js_join(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1033,7 +1019,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static NativeTypedArrayView<?> js_reverse(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1046,7 +1032,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static NativeTypedArrayView<?> js_fill(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1085,8 +1071,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self;
     }
 
-    private static Scriptable js_sort(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Scriptable js_sort(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (isArg(args, 0) && !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.function.expected");
         }
@@ -1116,8 +1101,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return working;
     }
 
-    private static Object js_copyWithin(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_copyWithin(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1178,7 +1162,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self;
     }
 
-    private static Object js_set(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_set(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         double offset = isArg(args, 1) ? ScriptRuntime.toIntegerOrInfinity(args[1]) : 0;
         if (offset < 0) {
@@ -1194,8 +1178,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return Undefined.instance;
     }
 
-    private static Object js_subarray(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_subarray(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length == 0 && cx.getLanguageVersion() < Context.VERSION_ES6) {
             throw ScriptRuntime.constructError("Error", "invalid arguments");
         }
@@ -1227,7 +1210,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self.typedArraySpeciesCreate(cx, scope, constructorArgs, "subarray");
     }
 
-    private static Object js_at(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_at(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         long len = self.validateAndGetLength();
 
@@ -1242,11 +1225,11 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             return Undefined.instance;
         }
 
-        return getProperty(thisObj, (int) k);
+        return getProperty((Scriptable) thisObj, (int) k);
     }
 
     private NativeTypedArrayView<?> typedArraySpeciesCreate(
-            Context cx, Scriptable scope, Object[] args, String methodName) {
+            Context cx, VarScope scope, Object[] args, String methodName) {
         Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
         Function defaultConstructor =
                 ScriptRuntime.getExistingCtor(cx, topLevelScope, getClassName());
@@ -1269,8 +1252,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return (NativeTypedArrayView<?>) newArray;
     }
 
-    private static Object js_toReversed(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toReversed(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         int len = self.getLength();
 
@@ -1290,8 +1272,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_toSorted(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_toSorted(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         int len = self.getLength();
 
@@ -1311,7 +1292,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_with(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object js_with(Context cx, VarScope scope, Object thisObj, Object[] args) {
         NativeTypedArrayView<?> self = realThis(thisObj);
 
         long relativeIndex = args.length > 0 ? (int) ScriptRuntime.toInteger(args[0]) : 0;
@@ -1345,7 +1326,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_from(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object js_from(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (args.length < 1) {
             throw ScriptRuntime.typeErrorById("msg.missing.argument");
         }
@@ -1447,7 +1428,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return result;
     }
 
-    private static Object js_of(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+    private static Object js_of(Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (!AbstractEcmaObjectOperations.isConstructor(cx, thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.constructor.expected");
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArrayIteratorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeArrayIteratorTest.java
@@ -17,12 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeArrayIterator;
 import org.mozilla.javascript.NativeArrayIterator.ARRAY_ITERATOR_TYPE;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class NativeArrayIteratorTest {
     private Context cx;
-    private Scriptable root;
+    private VarScope root;
 
     @BeforeEach
     public void init() {
@@ -31,7 +31,7 @@ public class NativeArrayIteratorTest {
         cx.setGeneratingDebug(true);
 
         Global global = new Global(cx);
-        root = cx.newObject(global);
+        root = cx.newVarEnv(global);
     }
 
     @AfterEach


### PR DESCRIPTION
Start moving a bunch of internal API uses over to `VarScope`, this is the next commit from #2330.