### PR TITLE
Removed dead code from `Evaluator` interface

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
@@ -84,14 +84,6 @@ public interface Evaluator {
      */
     public List<String> getScriptStack(RhinoException ex);
 
-    /**
-     * Mark the given script to indicate it was created by a call to eval() or to a Function
-     * constructor.
-     *
-     * @param script script to mark as from eval
-     */
-    public void setEvalScriptFlag(Script script);
-
     public default DebuggableScript getDebuggableScript(Object bytecode) {
         return null;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -753,11 +753,6 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     @Override
-    public void setEvalScriptFlag(Script script) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     @SuppressWarnings("unchecked")
     public Function createFunctionObject(
             Context cx, Scriptable scope, Object bytecode, Object staticSecurityDomain) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -67,11 +67,6 @@ public class Codegen implements Evaluator {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public void setEvalScriptFlag(Script script) {
-        throw new UnsupportedOperationException();
-    }
-
     private static class CompilationResult<T extends ScriptOrFn<T>> {
         final JSDescriptor.Builder<T> builder;
         final String className;


### PR DESCRIPTION
The `setEvalScriptFlag` was never called and all the implementations just threw an `UnsupportedOperationException`.