### PR TITLE
Second round of conversion of `Scriptable` to `VarScope`.

### DIFF
--- a/examples/src/main/java/File.java
+++ b/examples/src/main/java/File.java
@@ -18,6 +18,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.annotations.JSConstructor;
 import org.mozilla.javascript.annotations.JSFunction;
 import org.mozilla.javascript.annotations.JSGetter;
@@ -277,7 +278,7 @@ public class File extends ScriptableObject {
         // Here we use javaToJS() to "wrap" the LineNumberReader object
         // in a Scriptable object so that it can be manipulated by
         // JavaScript.
-        Scriptable parent = ScriptableObject.getTopLevelScope(this);
+        VarScope parent = ScriptableObject.getTopLevelScope(this);
         return Context.javaToJS(reader, parent);
     }
 
@@ -295,7 +296,7 @@ public class File extends ScriptableObject {
     @JSFunction
     public Object getWriter() {
         if (writer == null) return null;
-        Scriptable parent = ScriptableObject.getTopLevelScope(this);
+        VarScope parent = ScriptableObject.getTopLevelScope(this);
         return Context.javaToJS(writer, parent);
     }
 

--- a/examples/src/main/java/PrimitiveWrapFactory.java
+++ b/examples/src/main/java/PrimitiveWrapFactory.java
@@ -5,7 +5,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.WrapFactory;
 import org.mozilla.javascript.lc.type.TypeInfo;
 
@@ -25,7 +25,7 @@ import org.mozilla.javascript.lc.type.TypeInfo;
 public class PrimitiveWrapFactory extends WrapFactory {
 
     @Override
-    public Object wrap(Context cx, Scriptable scope, Object obj, TypeInfo staticType) {
+    public Object wrap(Context cx, VarScope scope, Object obj, TypeInfo staticType) {
         if (obj instanceof String || obj instanceof Number || obj instanceof Boolean) {
             return obj;
         } else if (obj instanceof Character) {

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/RhinoScriptEngine.java
@@ -254,7 +254,7 @@ public class RhinoScriptEngine extends AbstractScriptEngine implements Compilabl
             throw new IllegalArgumentException("Not an interface");
         }
         try (Context cx = ctxFactory.enterContext()) {
-            Scriptable scope = initScope(cx, context);
+            VarScope scope = initScope(cx, context);
             Scriptable thisObj = Context.toObject(thiz, scope);
             if (methodsMissing(thisObj, clasz)) {
                 return null;

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
@@ -366,7 +366,7 @@ public class Global extends ImporterTopLevel {
         }
         String filename = Context.toString(args[0]);
         try (FileInputStream fis = new FileInputStream(filename)) {
-            Scriptable scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
+            VarScope scope = ScriptableObject.getTopLevelScope(funObj.getDeclarationScope());
             try (ObjectInputStream in = new ScriptableInputStream(fis, scope)) {
                 Object deserialized = in.readObject();
                 return Context.toObject(deserialized, scope);
@@ -540,7 +540,7 @@ public class Global extends ImporterTopLevel {
      * </pre>
      */
     public static Object spawn(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
-        Scriptable scope = funObj.getParentScope();
+        VarScope scope = funObj.getParentScope();
         ContextAction<?> action = getAsyncAction(cx, args, scope);
         ContextFactory factory = cx.getFactory();
         Thread thread = new Thread(() -> factory.call(action));

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellConsolePrinter.java
@@ -8,7 +8,7 @@ import java.nio.charset.Charset;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeConsole;
 import org.mozilla.javascript.ScriptStackElement;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 /** Provide a printer use in console API */
 class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
@@ -17,7 +17,7 @@ class ShellConsolePrinter implements NativeConsole.ConsolePrinter {
     @Override
     public void print(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             NativeConsole.Level level,
             Object[] args,
             ScriptStackElement[] stack) {

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 
 /** Class Namespace */
 class Namespace extends ScriptableObject {
@@ -37,7 +38,7 @@ class Namespace extends ScriptableObject {
     }
 
     public static void init(Context cx, Scriptable scope, ScriptableObject proto, boolean sealed) {
-        DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
+        DESCRIPTOR.buildConstructor(cx, (VarScope) scope, proto, sealed);
     }
 
     private Namespace prototype;

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 
 /** Class QName */
 final class QName extends ScriptableObject {
@@ -34,7 +35,7 @@ final class QName extends ScriptableObject {
     }
 
     static void init(Context cx, Scriptable scope, ScriptableObject proto, boolean sealed) {
-        DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
+        DESCRIPTOR.buildConstructor(cx, (VarScope) scope, proto, sealed);
     }
 
     private static Object js_constructor(

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -47,7 +47,7 @@ class XMLList extends XMLObjectImpl implements Function {
             Context cx, Scriptable scope, XMLObjectImpl proto, boolean sealdd, XMLLibImpl lib) {
         DESCRIPTOR.buildConstructor(
                 cx,
-                scope,
+                (VarScope) scope,
                 proto,
                 sealdd,
                 (ctx, ctor) -> {

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -285,7 +285,7 @@ public class AbstractEcmaObjectOperations {
      */
     static Map<Object, List<Object>> groupBy(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             IdFunctionObject f,
             Object items,
             Object callback,
@@ -295,7 +295,7 @@ public class AbstractEcmaObjectOperations {
 
     static Map<Object, List<Object>> groupBy(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object classTag,
             String functionName,
             Object items,
@@ -535,7 +535,7 @@ public class AbstractEcmaObjectOperations {
      * <p><a href="https://tc39.es/ecma262/multipage/abstract-operations.html#sec-isregexp">7.2.6
      * IsRegExp (argument)</a>
      */
-    static boolean isRegExp(Context cx, Scriptable scope, Object argument) {
+    static boolean isRegExp(Context cx, VarScope scope, Object argument) {
         if (!ScriptRuntime.isObject(argument)) {
             return false;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaStringOperations.java
@@ -116,7 +116,7 @@ public class AbstractEcmaStringOperations {
 
     public static <T> String getSubstitution(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String matched,
             String str,
             int position,
@@ -155,7 +155,7 @@ public class AbstractEcmaStringOperations {
 
         abstract <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -174,7 +174,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -194,7 +194,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -223,7 +223,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -255,7 +255,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -269,7 +269,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -283,7 +283,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,
@@ -305,7 +305,7 @@ public class AbstractEcmaStringOperations {
         @Override
         <T> String replacement(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String matched,
                 String str,
                 int position,

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -26,7 +26,7 @@ public class ClassCache implements Serializable {
     private transient volatile Map<JavaAdapter.JavaAdapterSignature, Class<?>> classAdapterCache;
     private transient volatile Map<Class<?>, Object> interfaceAdapterCache;
     private int generatedClassSerial;
-    private Scriptable associatedScope;
+    private VarScope associatedScope;
 
     /**
      * CacheKey is a combination of class and securityContext. This is required when classes are
@@ -205,7 +205,7 @@ public class ClassCache implements Serializable {
         }
     }
 
-    Scriptable getAssociatedScope() {
+    VarScope getAssociatedScope() {
         return associatedScope;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -87,7 +87,7 @@ public class ClassDescriptor {
             this.attributes = attributes;
         }
 
-        abstract void makeProp(Context cx, Scriptable scope, ScriptableObject object);
+        abstract void makeProp(Context cx, VarScope scope, ScriptableObject object);
     }
 
     private static class LambdaGetSetPropDesc extends PropDesc {
@@ -105,7 +105,7 @@ public class ClassDescriptor {
         }
 
         @Override
-        void makeProp(Context cx, Scriptable scope, ScriptableObject obj) {
+        void makeProp(Context cx, VarScope scope, ScriptableObject obj) {
             if (name instanceof String) {
                 obj.defineProperty(cx, scope, (String) name, getter, setter, attributes);
             } else {
@@ -144,7 +144,7 @@ public class ClassDescriptor {
 
         @Override
         @SuppressWarnings("unchecked")
-        void makeProp(Context cx, Scriptable scope, ScriptableObject obj) {
+        void makeProp(Context cx, VarScope scope, ScriptableObject obj) {
             if (attrUpdater == null && propDescSetter == null) {
                 ScriptableObject.defineBuiltInProperty((T) obj, name, attributes, getter, setter);
             } else if (propDescSetter == null) {
@@ -158,7 +158,7 @@ public class ClassDescriptor {
     }
 
     public interface ValueCreator {
-        DescriptorInfo apply(Context cx, Scriptable Scope, ScriptableObject obj);
+        DescriptorInfo apply(Context cx, VarScope scope, ScriptableObject obj);
     }
 
     private static class CreateValuePropDesc extends PropDesc {
@@ -170,7 +170,7 @@ public class ClassDescriptor {
         }
 
         @Override
-        void makeProp(Context cx, Scriptable scope, ScriptableObject obj) {
+        void makeProp(Context cx, VarScope scope, ScriptableObject obj) {
             if (name instanceof String) {
                 obj.defineOwnProperty(cx, name, creator.apply(cx, scope, obj), false);
             } else {
@@ -200,12 +200,12 @@ public class ClassDescriptor {
 
     /** Build a constructor from this descriptor. */
     public JSFunction buildConstructor(
-            Context cx, Scriptable scope, ScriptableObject proto, boolean sealed) {
+            Context cx, VarScope scope, ScriptableObject proto, boolean sealed) {
         return buildConstructor(cx, scope, proto, sealed, (c, s) -> {});
     }
 
     public ScriptableObject populateGlobal(
-            Context cx, Scriptable scope, ScriptableObject global, boolean sealed) {
+            Context cx, VarScope scope, ScriptableObject global, boolean sealed) {
         var objProto = ScriptableObject.getObjectPrototype(scope);
         global.setPrototype(objProto);
         ScriptableObject.defineProperty(
@@ -237,7 +237,7 @@ public class ClassDescriptor {
      */
     public JSFunction buildConstructor(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             ScriptableObject proto,
             boolean sealed,
             BiConsumer<Context, JSFunction> customStep) {

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1748,7 +1748,7 @@ public class Context implements Closeable {
      * @param scope global scope containing constructors for Number, Boolean, and String
      * @return new JavaScript object
      */
-    public static Scriptable toObject(Object value, Scriptable scope) {
+    public static Scriptable toObject(Object value, VarScope scope) {
         return ScriptRuntime.toObject(scope, value);
     }
 
@@ -1757,7 +1757,7 @@ public class Context implements Closeable {
      * @see #toObject(Object, Scriptable)
      */
     @Deprecated
-    public static Scriptable toObject(Object value, Scriptable scope, Class<?> staticType) {
+    public static Scriptable toObject(Object value, VarScope scope, Class<?> staticType) {
         return ScriptRuntime.toObject(scope, value);
     }
 
@@ -1787,7 +1787,7 @@ public class Context implements Closeable {
      * @param scope top scope object
      * @return value suitable to pass to any API that takes JavaScript values.
      */
-    public static Object javaToJS(Object value, Scriptable scope) {
+    public static Object javaToJS(Object value, VarScope scope) {
         return javaToJS(value, scope, null);
     }
 
@@ -1817,7 +1817,7 @@ public class Context implements Closeable {
      * @param cx context to use for wrapping LiveConnect objects
      * @return value suitable to pass to any API that takes JavaScript values.
      */
-    public static Object javaToJS(Object value, Scriptable scope, Context cx) {
+    public static Object javaToJS(Object value, VarScope scope, Context cx) {
         if (value instanceof String
                 || value instanceof Number
                 || value instanceof Boolean
@@ -1892,8 +1892,8 @@ public class Context implements Closeable {
      * of {@link java.util.Map Map}, {@link java.util.Collection Collection}, or {@link
      * java.lang.Object Object[]}.
      *
-     * <p>Objects returned by the converter will converted with {@link #javaToJS(Object,
-     * Scriptable)} and then stringified themselves.
+     * <p>Objects returned by the converter will converted with {@link #javaToJS(Object, VarScope)}
+     * and then stringified themselves.
      *
      * @param javaToJSONConverter
      * @throws IllegalArgumentException if javaToJSONConverter is null

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -121,7 +121,7 @@ public final class ES6Generator extends ScriptableObject {
         return thisObj;
     }
 
-    private Scriptable resumeDelegee(Context cx, Scriptable scope, Object value) {
+    private Scriptable resumeDelegee(Context cx, VarScope scope, Object value) {
         try {
             // Be super-careful and only pass an arg to next if it expects one
             Object[] nextArgs =
@@ -151,7 +151,7 @@ public final class ES6Generator extends ScriptableObject {
         }
     }
 
-    private Scriptable resumeDelegeeThrow(Context cx, Scriptable scope, Object value) {
+    private Scriptable resumeDelegeeThrow(Context cx, VarScope scope, Object value) {
         boolean returnCalled = false;
         try {
             // Delegate to "throw" method. If it's not defined we'll get an error here.
@@ -193,7 +193,7 @@ public final class ES6Generator extends ScriptableObject {
         }
     }
 
-    private Scriptable resumeDelegeeReturn(Context cx, Scriptable scope, Object value) {
+    private Scriptable resumeDelegeeReturn(Context cx, VarScope scope, Object value) {
         try {
             // Call "return" but don't throw if it can't be found
             Object retResult = callReturnOptionally(cx, scope, value);
@@ -230,7 +230,7 @@ public final class ES6Generator extends ScriptableObject {
         }
     }
 
-    private Scriptable resumeLocal(Context cx, Scriptable scope, Object value) {
+    private Scriptable resumeLocal(Context cx, VarScope scope, Object value) {
         if (state == State.COMPLETED) {
             return ES6Iterator.makeIteratorResult(cx, scope, Boolean.TRUE);
         }
@@ -308,7 +308,7 @@ public final class ES6Generator extends ScriptableObject {
         return result;
     }
 
-    private Scriptable resumeAbruptLocal(Context cx, Scriptable scope, int op, Object value) {
+    private Scriptable resumeAbruptLocal(Context cx, VarScope scope, int op, Object value) {
         if (state == State.EXECUTING) {
             throw ScriptRuntime.typeErrorById("msg.generator.executing");
         }
@@ -382,7 +382,7 @@ public final class ES6Generator extends ScriptableObject {
         return result;
     }
 
-    private Object callReturnOptionally(Context cx, Scriptable scope, Object value) {
+    private Object callReturnOptionally(Context cx, VarScope scope, Object value) {
         Object[] retArgs =
                 Undefined.isUndefined(value) ? ScriptRuntime.emptyArgs : new Object[] {value};
         // Delegate to "return" method. If it's not defined we ignore it

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -76,11 +76,11 @@ public abstract class ES6Iterator extends ScriptableObject {
         return thisObj;
     }
 
-    protected abstract boolean isDone(Context cx, Scriptable scope);
+    protected abstract boolean isDone(Context cx, VarScope scope);
 
-    protected abstract Object nextValue(Context cx, Scriptable scope);
+    protected abstract Object nextValue(Context cx, VarScope scope);
 
-    protected Object next(Context cx, Scriptable scope) {
+    protected Object next(Context cx, VarScope scope) {
         Object value = Undefined.instance;
         boolean done = isDone(cx, scope) || this.exhausted;
         if (!done) {
@@ -96,11 +96,11 @@ public abstract class ES6Iterator extends ScriptableObject {
     }
 
     // 25.1.1.3 The IteratorResult Interface
-    static Scriptable makeIteratorResult(Context cx, Scriptable scope, Boolean done) {
+    static Scriptable makeIteratorResult(Context cx, VarScope scope, Boolean done) {
         return makeIteratorResult(cx, scope, done, Undefined.instance);
     }
 
-    static Scriptable makeIteratorResult(Context cx, Scriptable scope, Boolean done, Object value) {
+    static Scriptable makeIteratorResult(Context cx, VarScope scope, Boolean done, Object value) {
         final Scriptable iteratorResult = cx.newObject(scope);
         ScriptableObject.putProperty(iteratorResult, VALUE_PROPERTY, value);
         ScriptableObject.putProperty(iteratorResult, DONE_PROPERTY, done);

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -76,7 +76,7 @@ public class FunctionObject extends BaseFunction {
      * @param scope enclosing scope of function
      * @see org.mozilla.javascript.Scriptable
      */
-    public FunctionObject(String name, Member methodOrConstructor, Scriptable scope) {
+    public FunctionObject(String name, Member methodOrConstructor, VarScope scope) {
         if (methodOrConstructor instanceof Constructor) {
             member = new MemberBox(scope, (Constructor<?>) methodOrConstructor);
             isStatic = true; // well, doesn't take a 'this'
@@ -161,12 +161,12 @@ public class FunctionObject extends BaseFunction {
         return JAVA_UNSUPPORTED_TYPE;
     }
 
-    public static Object convertArg(Context cx, Scriptable scope, Object arg, int typeTag) {
+    public static Object convertArg(Context cx, VarScope scope, Object arg, int typeTag) {
         return convertArg(cx, scope, arg, typeTag, false);
     }
 
     public static Object convertArg(
-            Context cx, Scriptable scope, Object arg, int typeTag, boolean isNullable) {
+            Context cx, VarScope scope, Object arg, int typeTag, boolean isNullable) {
         switch (typeTag) {
             case JAVA_STRING_TYPE:
                 if (arg instanceof String) return arg;
@@ -331,11 +331,11 @@ public class FunctionObject extends BaseFunction {
     }
 
     /**
-     * @deprecated Use {@link #getTypeTag(Class)} and {@link #convertArg(Context, Scriptable,
-     *     Object, int, boolean)} for type conversion.
+     * @deprecated Use {@link #getTypeTag(Class)} and {@link #convertArg(Context, VarScope, Object,
+     *     int, boolean)} for type conversion.
      */
     @Deprecated
-    public static Object convertArg(Context cx, Scriptable scope, Object arg, Class<?> desired) {
+    public static Object convertArg(Context cx, VarScope scope, Object arg, Class<?> desired) {
         int tag = getTypeTag(desired);
         if (tag == JAVA_UNSUPPORTED_TYPE) {
             throw Context.reportRuntimeErrorById("msg.cant.convert", desired.getName());

--- a/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
@@ -148,7 +148,7 @@ public class ImporterTopLevel extends TopLevel {
     }
 
     public static void init(Context cx, Scriptable scope, boolean sealed, boolean isTopScope) {
-        var ctor = DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
+        var ctor = DESCRIPTOR.buildConstructor(cx, (VarScope) scope, new NativeObject(), sealed);
         var proto = (Scriptable) ctor.getPrototypeProperty();
 
         if (isTopScope) {

--- a/rhino/src/main/java/org/mozilla/javascript/Initializable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Initializable.java
@@ -8,5 +8,5 @@ import java.io.Serializable;
  */
 public interface Initializable extends Serializable {
     /** Initialize the class in question, returning the new constructor. */
-    Object initialize(Context cx, Scriptable scope, boolean sealed);
+    Object initialize(Context cx, VarScope scope, boolean sealed);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/IteratorLikeIterable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IteratorLikeIterable.java
@@ -21,13 +21,13 @@ import java.util.NoSuchElementException;
  */
 public class IteratorLikeIterable implements Iterable<Object>, Closeable {
     private final Context cx;
-    private final Scriptable scope;
+    private final VarScope scope;
     private final Callable next;
     private final Callable returnFunc;
     private final Scriptable iterator;
     private boolean closed;
 
-    public IteratorLikeIterable(Context cx, Scriptable scope, Object target) {
+    public IteratorLikeIterable(Context cx, VarScope scope, Object target) {
         this.cx = cx;
         this.scope = scope;
         // This will throw if "next" is not a function or undefined

--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -541,7 +541,7 @@ public final class JavaAdapter {
             factory = ContextFactory.getGlobal();
         }
 
-        final Scriptable scope = f.getDeclarationScope();
+        final VarScope scope = f.getDeclarationScope();
         if (argsToWrap == 0) {
             return Context.call(factory, f, scope, thisObj, args);
         }
@@ -555,7 +555,7 @@ public final class JavaAdapter {
 
     private static Object doCall(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Scriptable thisObj,
             Function f,
             Object[] args,

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -45,11 +45,11 @@ class JavaMembers {
 
     private static final Permission allPermission = new AllPermission();
 
-    JavaMembers(Scriptable scope, Class<?> cl) {
+    JavaMembers(VarScope scope, Class<?> cl) {
         this(scope, cl, false);
     }
 
-    JavaMembers(Scriptable scope, Class<?> cl, boolean includeProtected) {
+    JavaMembers(VarScope scope, Class<?> cl, boolean includeProtected) {
         try (Context cx = ContextFactory.getGlobal().enterContext()) {
             ClassShutter shutter = cx.getClassShutter();
             if (shutter != null && !shutter.visibleToScripts(cl.getName())) {
@@ -444,7 +444,7 @@ class JavaMembers {
     }
 
     private void reflect(
-            Context cx, Scriptable scope, boolean includeProtected, boolean includePrivate) {
+            Context cx, VarScope scope, boolean includeProtected, boolean includePrivate) {
         var typeFactory = TypeInfoFactory.get(scope);
 
         var accessibleMethods = discoverAccessibleMethods(cl, includeProtected, includePrivate);
@@ -852,7 +852,7 @@ class JavaMembers {
     }
 
     private static JavaMembers createJavaMembers(
-            Scriptable associatedScope, Class<?> cl, boolean includeProtected) {
+            VarScope associatedScope, Class<?> cl, boolean includeProtected) {
         if (STRICT_REFLECTIVE_ACCESS) {
             return new JavaMembers_jdk11(associatedScope, cl, includeProtected);
         } else {
@@ -931,7 +931,7 @@ class FieldAndMethods extends NativeJavaMethod {
                     "msg.java.internal.private", field.raw().getName());
         }
         Context cx = Context.getContext();
-        rval = cx.getWrapFactory().wrap(cx, this, rval, field.type());
+        rval = cx.getWrapFactory().wrap(cx, this.getParentScope(), rval, field.type());
         if (rval instanceof Scriptable) {
             rval = ((Scriptable) rval).getDefaultValue(hint);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
@@ -14,7 +14,7 @@ import java.util.Map;
 /** Version of {@link JavaMembers} for modular JDKs. */
 class JavaMembers_jdk11 extends JavaMembers {
 
-    JavaMembers_jdk11(Scriptable scope, Class<?> cl, boolean includeProtected) {
+    JavaMembers_jdk11(VarScope scope, Class<?> cl, boolean includeProtected) {
         super(scope, cl, includeProtected);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazilyLoadedCtor.java
@@ -93,7 +93,7 @@ public final class LazilyLoadedCtor<T extends PropHolder<T>> implements Serializ
                 propertyName,
                 sealed,
                 privileged,
-                (Context lcx, Scriptable lscope, boolean lsealed) ->
+                (Context lcx, VarScope lscope, boolean lsealed) ->
                         buildUsingReflection(lscope, className, propertyName, lsealed));
     }
 
@@ -133,7 +133,7 @@ public final class LazilyLoadedCtor<T extends PropHolder<T>> implements Serializ
     @SuppressWarnings("unchecked")
     private Object buildValueInternal() {
         Context cx = Context.getCurrentContext();
-        Object value = initializer.initialize(cx, (Scriptable) scope, sealed);
+        Object value = initializer.initialize(cx, (VarScope) scope, sealed);
         if (value != null) {
             return value;
         }
@@ -141,7 +141,7 @@ public final class LazilyLoadedCtor<T extends PropHolder<T>> implements Serializ
     }
 
     private static Object buildUsingReflection(
-            Scriptable scope, String className, String propertyName, boolean sealed) {
+            VarScope scope, String className, String propertyName, boolean sealed) {
         Class<? extends Scriptable> cl = cast(Kit.classOrNull(className));
         if (cl != null) {
             try {

--- a/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
+++ b/rhino/src/main/java/org/mozilla/javascript/MemberBox.java
@@ -36,17 +36,17 @@ final class MemberBox implements Serializable {
     transient Function asSetterFunction;
     transient Object delegateTo;
 
-    final Scriptable scope;
+    final VarScope scope;
 
     private static final NullabilityDetector nullDetector =
             ScriptRuntime.loadOneServiceImplementation(NullabilityDetector.class);
 
-    MemberBox(Scriptable scope, Method method) {
+    MemberBox(VarScope scope, Method method) {
         this.scope = scope;
         init(method);
     }
 
-    MemberBox(Scriptable scope, Constructor<?> constructor) {
+    MemberBox(VarScope scope, Constructor<?> constructor) {
         this.scope = scope;
         init(constructor);
     }
@@ -211,7 +211,7 @@ final class MemberBox implements Serializable {
                                     originalArgs.length > 0
                                             ? FunctionObject.convertArg(
                                                     cx,
-                                                    thisObj,
+                                                    callScope,
                                                     originalArgs[0],
                                                     setterTypeTag,
                                                     nativeSetter.getArgNullability().isNullable(0))

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -169,7 +169,7 @@ public class NativeArray extends ScriptableObject implements List {
         };
     }
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static void init(Context cx, VarScope scope, boolean sealed) {
         DESCRIPTOR.buildConstructor(cx, scope, new NativeArray(0), sealed);
     }
 
@@ -214,7 +214,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static DescriptorInfo makeUnscopables(
-            Context cx, Scriptable scope, ScriptableObject obj) {
+            Context cx, VarScope scope, ScriptableObject obj) {
         NativeObject res;
 
         res = (NativeObject) cx.newObject(scope);
@@ -490,7 +490,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     /** See ECMA 15.4.1,2 */
     static Scriptable jsConstructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeArray res;
         if (args.length == 0) {
             res = new NativeArray(0);
@@ -1130,7 +1130,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     /** See ECMA 15.4.4.5 */
     private static Scriptable js_sort(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, f.getDeclarationScope(), thisObj);
         Comparator<Object> comparator = ArrayLikeAbstractOperations.getSortComparator(cx, s, args);
         return sort(cx, o, comparator);
@@ -1437,7 +1437,7 @@ public class NativeArray extends ScriptableObject implements List {
         return result;
     }
 
-    private static boolean isConcatSpreadable(Context cx, Scriptable scope, Object val) {
+    private static boolean isConcatSpreadable(Context cx, VarScope scope, Object val) {
         // First, look for the new @@isConcatSpreadable test as per ECMAScript 6 and up
         if (val instanceof Scriptable) {
             final Object spreadable =
@@ -1504,7 +1504,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     private static long doConcat(
-            Context cx, Scriptable scope, Scriptable result, Object arg, long offset) {
+            Context cx, VarScope scope, Scriptable result, Object arg, long offset) {
         if (isConcatSpreadable(cx, scope, arg)) {
             return concatSpreadArg(cx, result, (Scriptable) arg, offset);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArrayIterator.java
@@ -42,7 +42,7 @@ public final class NativeArrayIterator extends ES6Iterator {
     }
 
     @Override
-    protected boolean isDone(Context cx, Scriptable scope) {
+    protected boolean isDone(Context cx, VarScope scope) {
         if (arrayLike instanceof NativeTypedArrayView) {
             NativeTypedArrayView<?> typedArray = (NativeTypedArrayView<?>) arrayLike;
             if (typedArray.isTypedArrayOutOfBounds()) {
@@ -53,7 +53,7 @@ public final class NativeArrayIterator extends ES6Iterator {
     }
 
     @Override
-    protected Object nextValue(Context cx, Scriptable scope) {
+    protected Object nextValue(Context cx, VarScope scope) {
         if (type == ARRAY_ITERATOR_TYPE.KEYS) {
             return Integer.valueOf(index++);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
@@ -37,7 +37,7 @@ final class NativeBoolean extends ScriptableObject {
 
     static void init(Context cx, Scriptable scope, boolean sealed) {
         // Boolean is an unusual object in that the prototype is itself a Boolean
-        DESCRIPTOR.buildConstructor(cx, scope, new NativeBoolean(false), sealed);
+        DESCRIPTOR.buildConstructor(cx, (VarScope) scope, new NativeBoolean(false), sealed);
     }
 
     NativeBoolean(boolean b) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
@@ -42,12 +42,12 @@ public class NativeCollectionIterator extends ES6Iterator {
     }
 
     @Override
-    protected boolean isDone(Context cx, Scriptable scope) {
+    protected boolean isDone(Context cx, VarScope scope) {
         return !iterator.hasNext();
     }
 
     @Override
-    protected Object nextValue(Context cx, Scriptable scope) {
+    protected Object nextValue(Context cx, VarScope scope) {
         final Hashtable.Entry e = iterator.next();
         switch (type) {
             case KEYS:

--- a/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
@@ -39,11 +39,7 @@ public class NativeConsole extends ScriptableObject {
 
     public interface ConsolePrinter extends Serializable {
         void print(
-                Context cx,
-                Scriptable scope,
-                Level level,
-                Object[] args,
-                ScriptStackElement[] stack);
+                Context cx, VarScope scope, Level level, Object[] args, ScriptStackElement[] stack);
     }
 
     public static void init(Scriptable scope, boolean sealed, ConsolePrinter printer) {
@@ -116,11 +112,11 @@ public class NativeConsole extends ScriptableObject {
         return Undefined.instance;
     }
 
-    private void print(Context cx, Scriptable scope, Level level, String msg) {
+    private void print(Context cx, VarScope scope, Level level, String msg) {
         printer.print(cx, scope, level, new String[] {msg}, null);
     }
 
-    public static String format(Context cx, Scriptable scope, Object[] args) {
+    public static String format(Context cx, VarScope scope, Object[] args) {
         if (args == null || args.length == 0) {
             return "";
         }
@@ -233,7 +229,7 @@ public class NativeConsole extends ScriptableObject {
         return ScriptRuntime.numberToString(ScriptRuntime.toNumber(val), 10);
     }
 
-    private static String formatObj(Context cx, Scriptable scope, Object arg) {
+    private static String formatObj(Context cx, VarScope scope, Object arg) {
         if (arg == null) {
             return "null";
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeDate.java
@@ -103,10 +103,10 @@ final class NativeDate extends ScriptableObject {
                         .build();
     }
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static void init(Context cx, VarScope scope, boolean sealed) {
         DESCRIPTOR.buildConstructor(
                 cx,
-                scope,
+                (VarScope) scope,
                 cx.getLanguageVersion() >= Context.VERSION_ES6
                         ? new NativeObject()
                         : new NativeDate(Double.NaN),
@@ -135,23 +135,23 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_now(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ScriptRuntime.wrapNumber(now());
     }
 
     private static Object js_parse(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         String dataStr = ScriptRuntime.toString(args, 0);
         return ScriptRuntime.wrapNumber(date_parseString(cx, dataStr));
     }
 
     private static Object js_UTC(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return ScriptRuntime.wrapNumber(jsStaticFunction_UTC(args));
     }
 
     private static Object js_constructor(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var res = jsConstructor(cx, args);
         ScriptRuntime.setBuiltinProtoAndParent(res, f, nt, s, TopLevel.Builtins.Date);
 
@@ -159,12 +159,12 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_constructorFunc(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return date_format(cx, now(), Id_toString);
     }
 
     private static Object js_toJSON(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         final String toISOString = "toISOString";
 
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
@@ -196,7 +196,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toPrimitive(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Scriptable o = ScriptRuntime.toObject(cx, s, thisObj);
         final Object arg0 = args.length > 0 ? args[0] : Undefined.instance;
         final String hint = (arg0 instanceof CharSequence) ? arg0.toString() : null;
@@ -215,7 +215,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -226,7 +226,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toTimeString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -237,7 +237,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toDateString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -248,7 +248,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toLocaleString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -259,7 +259,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toLocaleDateString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -270,7 +270,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toLocaleTimeString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -281,7 +281,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toUTCString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -292,7 +292,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -300,7 +300,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_valueOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -308,7 +308,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getTime(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -316,7 +316,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -329,7 +329,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getFullYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -341,7 +341,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCFullYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -352,7 +352,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getMonth(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -364,7 +364,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCMonth(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -375,7 +375,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getDate(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -387,7 +387,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCDate(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -398,7 +398,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getDay(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -410,7 +410,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCDay(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -421,7 +421,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getHours(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -433,7 +433,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCHours(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -444,7 +444,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getMinutes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -456,7 +456,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCMinutes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -467,7 +467,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getSeconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -479,7 +479,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCSeconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -490,7 +490,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getMilliseconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -502,7 +502,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getUTCMilliseconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -513,7 +513,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_getTimezoneOffset(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -524,7 +524,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setTime(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -534,7 +534,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setMilliseconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -544,7 +544,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCMilliseconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -554,7 +554,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setSeconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -564,7 +564,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCSeconds(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -574,7 +574,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setMinutes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -584,7 +584,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCMinutes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -594,7 +594,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setHours(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -604,7 +604,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCHours(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -614,7 +614,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setDate(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -624,7 +624,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCDate(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -634,7 +634,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setMonth(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -644,7 +644,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCMonth(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -654,7 +654,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setFullYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -664,7 +664,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setUTCFullYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -674,7 +674,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_setYear(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 
@@ -701,7 +701,7 @@ final class NativeDate extends ScriptableObject {
     }
 
     private static Object js_toISOString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         var realThis = realThis(thisObj);
         double t = realThis.date;
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -81,7 +81,7 @@ final class NativeError extends ScriptableObject {
     }
 
     static void init(Context cx, Scriptable scope, boolean sealed) {
-        var ctor = DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
+        var ctor = DESCRIPTOR.buildConstructor(cx, (VarScope) scope, new NativeObject(), sealed);
         NativeCallSite.init(scope, sealed);
 
         ProtoProps protoProps = new ProtoProps();
@@ -135,8 +135,7 @@ final class NativeError extends ScriptableObject {
         return obj;
     }
 
-    static NativeError makeAggregate(
-            Context cx, Scriptable scope, Function ctorObj, Object[] args) {
+    static NativeError makeAggregate(Context cx, VarScope scope, Function ctorObj, Object[] args) {
         NativeError obj = makeProto(scope, ctorObj);
 
         int arglen = args.length;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -129,7 +129,7 @@ public final class NativeIterator extends ScriptableObject {
 
         Iterator<?> iterator = getJavaIterator(target);
         if (iterator != null) {
-            Scriptable topScope = ScriptableObject.getTopLevelScope(scope);
+            VarScope topScope = ScriptableObject.getTopLevelScope(scope);
             return cx.getWrapFactory()
                     .wrap(
                             cx,
@@ -146,13 +146,13 @@ public final class NativeIterator extends ScriptableObject {
         return createNativeIterator(cx, scope, target, keyOnly);
     }
 
-    private static Scriptable jsConstructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
         Scriptable target = requireIteratorTarget(cx, scope, args);
         boolean keyOnly = isKeyOnly(args);
         return createNativeIterator(cx, scope, target, keyOnly);
     }
 
-    private static Scriptable requireIteratorTarget(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable requireIteratorTarget(Context cx, VarScope scope, Object[] args) {
         if (args.length == 0 || args[0] == null || args[0] == Undefined.instance) {
             Object argument = args.length == 0 ? Undefined.instance : args[0];
             throw ScriptRuntime.typeErrorById(
@@ -171,7 +171,7 @@ public final class NativeIterator extends ScriptableObject {
     }
 
     private static NativeIterator createNativeIterator(
-            Context cx, Scriptable scope, Scriptable obj, boolean keyOnly) {
+            Context cx, VarScope scope, Scriptable obj, boolean keyOnly) {
         Object objectIterator =
                 ScriptRuntime.enumInit(
                         obj,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJSON.java
@@ -156,7 +156,7 @@ public final class NativeJSON extends ScriptableObject {
     private static class StringifyState {
         StringifyState(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 String indent,
                 String gap,
                 Callable replacer,
@@ -177,11 +177,11 @@ public final class NativeJSON extends ScriptableObject {
         Object[] propertyList;
 
         Context cx;
-        Scriptable scope;
+        VarScope scope;
     }
 
     public static Object stringify(
-            Context cx, Scriptable scope, Object value, Object replacer, Object space) {
+            Context cx, VarScope scope, Object value, Object replacer, Object space) {
         String indent = "";
         String gap = "";
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -74,7 +74,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         }
 
         Context cx = Context.getContext();
-        Scriptable scope = ScriptableObject.getTopLevelScope(start);
+        VarScope scope = ScriptableObject.getTopLevelScope(start);
         WrapFactory wrapFactory = cx.getWrapFactory();
 
         if (javaClassPropertyName.equals(name)) {
@@ -181,11 +181,11 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     }
 
     static Scriptable constructSpecific(
-            Context cx, Scriptable scope, Object[] args, ExecutableBox ctor) {
+            Context cx, VarScope scope, Object[] args, ExecutableBox ctor) {
         Object instance = constructInternal(args, ctor);
         // we need to force this to be wrapped, because construct _has_
         // to return a scriptable
-        Scriptable topLevel = ScriptableObject.getTopLevelScope(scope);
+        VarScope topLevel = ScriptableObject.getTopLevelScope(scope);
         return cx.getWrapFactory().wrapNewObject(cx, topLevel, instance);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaList.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaList.java
@@ -49,7 +49,7 @@ public class NativeJavaList extends NativeJavaObject {
     private final TypeInfo elementType;
 
     @SuppressWarnings("unchecked")
-    public NativeJavaList(Scriptable scope, Object list, TypeInfo staticType) {
+    public NativeJavaList(VarScope scope, Object list, TypeInfo staticType) {
         super(scope, list, staticType);
         assert list instanceof List;
         this.list = (List<Object>) list;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -193,12 +193,12 @@ public class NativeJavaMap extends NativeJavaObject {
         }
 
         @Override
-        protected boolean isDone(Context cx, Scriptable scope) {
+        protected boolean isDone(Context cx, VarScope scope) {
             return !iterator.hasNext();
         }
 
         @Override
-        protected Object nextValue(Context cx, Scriptable scope) {
+        protected Object nextValue(Context cx, VarScope scope) {
             if (!iterator.hasNext()) {
                 return cx.newArray(scope, new Object[] {Undefined.instance, Undefined.instance});
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMethod.java
@@ -48,7 +48,7 @@ public class NativeJavaMethod extends BaseFunction {
     }
 
     @Deprecated
-    public NativeJavaMethod(Scriptable scope, Method method, String name) {
+    public NativeJavaMethod(VarScope scope, Method method, String name) {
         this(new ExecutableBox(method, TypeInfoFactory.GLOBAL, method.getDeclaringClass()), name);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -186,7 +186,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
      *     WrapFactory#wrap(Context, Scriptable, Object, Class)}
      */
     @Deprecated
-    public static Object wrap(Scriptable scope, Object obj, Class<?> staticType) {
+    public static Object wrap(VarScope scope, Object obj, Class<?> staticType) {
 
         Context cx = Context.getContext();
         return cx.getWrapFactory().wrap(cx, scope, obj, staticType);
@@ -928,7 +928,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             super();
         }
 
-        JavaIterableIterator(Scriptable scope, Iterable iterable) {
+        JavaIterableIterator(VarScope scope, Iterable iterable) {
             super(scope, ITERATOR_TAG);
             this.iterator = iterable.iterator();
         }
@@ -939,12 +939,12 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         }
 
         @Override
-        protected boolean isDone(Context cx, Scriptable scope) {
+        protected boolean isDone(Context cx, VarScope scope) {
             return !iterator.hasNext();
         }
 
         @Override
-        protected Object nextValue(Context cx, Scriptable scope) {
+        protected Object nextValue(Context cx, VarScope scope) {
             if (!iterator.hasNext()) {
                 return Undefined.instance;
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -96,7 +96,7 @@ public class NativeObject extends ScriptableObject implements Map {
 
     static JSFunction init(Context cx, Scriptable s, boolean sealed) {
         var desc = cx.version >= Context.VERSION_ES6 ? ES6_DESCRIPTOR : LEGACY_DESCRIPTOR;
-        return desc.buildConstructor(cx, s, new NativeObject(), sealed);
+        return desc.buildConstructor(cx, (VarScope) s, new NativeObject(), sealed);
     }
 
     @Override
@@ -239,8 +239,7 @@ public class NativeObject extends ScriptableObject implements Map {
         Let O be ? ToObject(this value).
         2. Return ? O.[[GetPrototypeOf]]().
         */
-        ScriptableObject o = (ScriptableObject) ScriptRuntime.toObject(thisObj, thisObj);
-        return o.getPrototype();
+        return thisObj.getPrototype();
     }
 
     public static void js_protoSetter(Scriptable thisObj, Object proto) {
@@ -821,7 +820,7 @@ public class NativeObject extends ScriptableObject implements Map {
         }
     }
 
-    private static Scriptable getCompatibleObject(Context cx, Scriptable scope, Object arg) {
+    private static Scriptable getCompatibleObject(Context cx, VarScope scope, Object arg) {
         if (cx.getLanguageVersion() >= Context.VERSION_ES6) {
             Scriptable s = ScriptRuntime.toObject(cx, scope, arg);
             return ensureScriptable(s);

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -878,7 +878,7 @@ public class NativePromise extends ScriptableObject {
             this.capability = cap;
         }
 
-        Object reject(Context topCx, Scriptable topScope) {
+        Object reject(Context topCx, VarScope topScope) {
             int index = 0;
             // Do this first because we should catch any exception before
             // invoking the iterator.

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -93,7 +93,7 @@ public class NativeSet extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
         NativeSet ns = new NativeSet();
         ns.instanceOfSet = true;
         if (args.length > 0) {
@@ -184,7 +184,7 @@ public class NativeSet extends ScriptableObject {
                         args.length > 1 ? args[1] : Undefined.SCRIPTABLE_UNDEFINED);
     }
 
-    private Object js_forEach(Context cx, Scriptable scope, Object arg1, Object arg2) {
+    private Object js_forEach(Context cx, VarScope scope, Object arg1, Object arg2) {
         if (!(arg1 instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(arg1);
         }
@@ -202,7 +202,7 @@ public class NativeSet extends ScriptableObject {
      * If an "iterable" object was passed to the constructor, there are many many things to do. This
      * is common code with NativeWeakSet.
      */
-    static void loadFromIterable(Context cx, Scriptable scope, ScriptableObject set, Object arg1) {
+    static void loadFromIterable(Context cx, VarScope scope, ScriptableObject set, Object arg1) {
         if ((arg1 == null) || Undefined.instance.equals(arg1)) {
             return;
         }
@@ -246,7 +246,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "intersection").js_intersection(cx, scope, args);
     }
 
-    private Object js_intersection(Context cx, Scriptable scope, Object[] args) {
+    private Object js_intersection(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         NativeSet result = (NativeSet) cx.newObject(scope, CLASS_NAME);
@@ -266,7 +266,7 @@ public class NativeSet extends ScriptableObject {
 
     private Object js_intersectionSetLike(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object otherObj,
             NativeSet result,
             Object sizeVal,
@@ -311,7 +311,7 @@ public class NativeSet extends ScriptableObject {
                     ScriptRuntime.callIterator(
                             keysMethod.call(
                                     cx,
-                                    (VarScope) scope,
+                                    scope,
                                     ScriptableObject.ensureScriptable(otherObj),
                                     ScriptRuntime.emptyArgs),
                             cx,
@@ -332,7 +332,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "union").js_union(cx, scope, args);
     }
 
-    private Object js_union(Context cx, Scriptable scope, Object[] args) {
+    private Object js_union(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         NativeSet result = (NativeSet) cx.newObject(scope, CLASS_NAME);
@@ -373,9 +373,7 @@ public class NativeSet extends ScriptableObject {
         Callable keysMethod = (Callable) keysVal;
         Object iterator =
                 ScriptRuntime.callIterator(
-                        keysMethod.call(cx, (VarScope) scope, scriptable, ScriptRuntime.emptyArgs),
-                        cx,
-                        scope);
+                        keysMethod.call(cx, scope, scriptable, ScriptRuntime.emptyArgs), cx, scope);
         try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
             for (Object key : it) {
                 result.js_add(key);
@@ -389,7 +387,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "difference").js_difference(cx, scope, args);
     }
 
-    private Object js_difference(Context cx, Scriptable scope, Object[] args) {
+    private Object js_difference(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         NativeSet result = (NativeSet) cx.newObject(scope, CLASS_NAME);
@@ -409,7 +407,7 @@ public class NativeSet extends ScriptableObject {
 
     private Object js_differenceSetLike(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object otherObj,
             NativeSet result,
             Object sizeVal,
@@ -489,7 +487,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "symmetricDifference").js_symmetricDifference(cx, scope, args);
     }
 
-    private Object js_symmetricDifference(Context cx, Scriptable scope, Object[] args) {
+    private Object js_symmetricDifference(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         NativeSet result = (NativeSet) cx.newObject(scope, CLASS_NAME);
@@ -536,9 +534,7 @@ public class NativeSet extends ScriptableObject {
         // Add elements from other that are not in this
         Object iterator =
                 ScriptRuntime.callIterator(
-                        keysMethod.call(cx, (VarScope) scope, scriptable, ScriptRuntime.emptyArgs),
-                        cx,
-                        scope);
+                        keysMethod.call(cx, scope, scriptable, ScriptRuntime.emptyArgs), cx, scope);
         try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
             for (Object key : it) {
                 if (js_has(key) != Boolean.TRUE) {
@@ -612,7 +608,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "isSupersetOf").js_isSupersetOf(cx, scope, args);
     }
 
-    private Object js_isSupersetOf(Context cx, Scriptable scope, Object[] args) {
+    private Object js_isSupersetOf(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         // ES2025: GetSetRecord requires size, has, and keys properties
@@ -645,9 +641,7 @@ public class NativeSet extends ScriptableObject {
         Callable keysMethod = (Callable) keysVal;
         Object iterator =
                 ScriptRuntime.callIterator(
-                        keysMethod.call(cx, (VarScope) scope, scriptable, ScriptRuntime.emptyArgs),
-                        cx,
-                        scope);
+                        keysMethod.call(cx, scope, scriptable, ScriptRuntime.emptyArgs), cx, scope);
         try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
             for (Object value : it) {
                 if (js_has(value) != Boolean.TRUE) {
@@ -663,7 +657,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "isDisjointFrom").js_isDisjointFrom(cx, scope, args);
     }
 
-    private Object js_isDisjointFrom(Context cx, Scriptable scope, Object[] args) {
+    private Object js_isDisjointFrom(Context cx, VarScope scope, Object[] args) {
         Object otherObj = args.length > 0 ? args[0] : Undefined.instance;
 
         // ES2025: GetSetRecord requires size, has, and keys properties

--- a/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
@@ -31,12 +31,12 @@ public final class NativeStringIterator extends ES6Iterator {
     }
 
     @Override
-    protected boolean isDone(Context cx, Scriptable scope) {
+    protected boolean isDone(Context cx, VarScope scope) {
         return index >= string.length();
     }
 
     @Override
-    protected Object nextValue(Context cx, Scriptable scope) {
+    protected Object nextValue(Context cx, VarScope scope) {
         int newIndex = string.offsetByCodePoints(index, 1);
         Object value = string.substring(index, newIndex);
         index = newIndex;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakSet.java
@@ -55,7 +55,7 @@ public class NativeWeakSet extends ScriptableObject {
         return CLASS_NAME;
     }
 
-    private static Scriptable jsConstructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable jsConstructor(Context cx, VarScope scope, Object[] args) {
         NativeWeakSet ns = new NativeWeakSet();
         ns.instanceOfWeakSet = true;
         if (args.length > 0) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
@@ -185,7 +185,7 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
         return false;
     }
 
-    static Object newWithSpecial(Context cx, Scriptable scope, Object[] args) {
+    static Object newWithSpecial(Context cx, VarScope scope, Object[] args) {
         ScriptRuntime.checkDeprecated(cx, "With");
         TopLevel top = ScriptableObject.getTopLevelScope(scope);
         var obj =

--- a/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NewLiteralStorage.java
@@ -60,7 +60,7 @@ public abstract class NewLiteralStorage {
         }
     }
 
-    public void spread(Context cx, Scriptable scope, Object source, int sourcePosition) {
+    public void spread(Context cx, VarScope scope, Object source, int sourcePosition) {
         int indexBefore = index;
         if (keys == null) {
             spreadArray(cx, scope, source);
@@ -75,7 +75,7 @@ public abstract class NewLiteralStorage {
         }
     }
 
-    private void spreadArray(Context cx, Scriptable scope, Object source) {
+    private void spreadArray(Context cx, VarScope scope, Object source) {
         // See ecma-262 2026, 13.2.5.5 (Array Spread)
         if (source != null && !Undefined.isUndefined(source)) {
             Scriptable src = ScriptRuntime.toObject(cx, scope, source);
@@ -134,7 +134,7 @@ public abstract class NewLiteralStorage {
         }
     }
 
-    private void spreadObject(Context cx, Scriptable scope, Object source) {
+    private void spreadObject(Context cx, VarScope scope, Object source) {
         // See ECMAScript 13.2.5.5 (Object Spread)
         if (source != null && !Undefined.isUndefined(source)) {
             Scriptable src = ScriptRuntime.toObject(cx, scope, source);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -914,7 +914,7 @@ public class ScriptRuntime {
      * @return a new object with all properties except the excluded ones
      */
     public static Scriptable doObjectRest(
-            Context cx, Scriptable scope, Object source, Object[] excludeKeys) {
+            Context cx, VarScope scope, Object source, Object[] excludeKeys) {
         Scriptable sourceObj = toObject(cx, scope, source);
         Scriptable result = cx.newObject(scope);
 
@@ -979,7 +979,7 @@ public class ScriptRuntime {
 
     /** Copy a single property from source to result */
     private static void copyProperty(
-            Scriptable source, Scriptable result, Object id, Context cx, Scriptable scope) {
+            Scriptable source, Scriptable result, Object id, Context cx, VarScope scope) {
         Object value;
 
         if (id instanceof Integer) {
@@ -990,7 +990,7 @@ public class ScriptRuntime {
             }
         } else if (id instanceof String) {
             String propName = (String) id;
-            value = getObjectProp(source, propName, cx, scope);
+            value = getObjectProp(source, propName, cx, (VarScope) scope);
             if (value != Scriptable.NOT_FOUND) {
                 result.put(propName, result, value);
             }
@@ -1302,7 +1302,7 @@ public class ScriptRuntime {
         return result.toString();
     }
 
-    public static Scriptable toObject(Scriptable scope, Object val) {
+    public static Scriptable toObject(VarScope scope, Object val) {
         if (val instanceof Scriptable) {
             return (Scriptable) val;
         }
@@ -1313,7 +1313,7 @@ public class ScriptRuntime {
      * <strong>Warning</strong>: This doesn't allow to resolve primitive prototype properly when
      * many top scopes are involved
      *
-     * @deprecated Use {@link #toObjectOrNull(Context, Object, Scriptable)} instead
+     * @deprecated Use {@link #toObjectOrNull(Context, Object, VarScope)} instead
      */
     @Deprecated
     public static Scriptable toObjectOrNull(Context cx, Object obj) {
@@ -1328,7 +1328,7 @@ public class ScriptRuntime {
     /**
      * @param scope the scope that should be used to resolve primitive prototype
      */
-    public static Scriptable toObjectOrNull(Context cx, Object obj, Scriptable scope) {
+    public static Scriptable toObjectOrNull(Context cx, Object obj, VarScope scope) {
         if (obj instanceof Scriptable) {
             return (Scriptable) obj;
         } else if (obj != null && !Undefined.isUndefined(obj)) {
@@ -1338,10 +1338,10 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #toObject(Scriptable, Object)} instead.
+     * @deprecated Use {@link #toObject(VarScope, Object)} instead.
      */
     @Deprecated
-    public static Scriptable toObject(Scriptable scope, Object val, Class<?> staticClass) {
+    public static Scriptable toObject(VarScope scope, Object val, Class<?> staticClass) {
         if (val instanceof Scriptable) {
             return (Scriptable) val;
         }
@@ -1353,7 +1353,7 @@ public class ScriptRuntime {
      *
      * <p>See ECMA 9.9.
      */
-    public static Scriptable toObject(Context cx, Scriptable scope, Object val) {
+    public static Scriptable toObject(Context cx, VarScope scope, Object val) {
         if (val == null) {
             throw typeErrorById("msg.null.to.object");
         }
@@ -1398,11 +1398,11 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #toObject(Context, Scriptable, Object)} instead.
+     * @deprecated Use {@link #toObject(Context, VarScope, Object)} instead.
      */
     @Deprecated
     public static Scriptable toObject(
-            Context cx, Scriptable scope, Object val, Class<?> staticClass) {
+            Context cx, VarScope scope, Object val, Class<?> staticClass) {
         return toObject(cx, scope, val);
     }
 
@@ -1411,7 +1411,7 @@ public class ScriptRuntime {
      */
     @Deprecated
     public static Object call(
-            Context cx, Object fun, Object thisArg, Object[] args, Scriptable scope) {
+            Context cx, Object fun, Object thisArg, Object[] args, VarScope scope) {
         if (!(fun instanceof Function)) {
             throw notFunctionError(toString(fun));
         }
@@ -1814,7 +1814,7 @@ public class ScriptRuntime {
     /**
      * Call obj.[[Get]](id)
      *
-     * @deprecated Use {@link #getObjectElem(Object, Object, Context, Scriptable)} instead
+     * @deprecated Use {@link #getObjectElem(Object, Object, Context, VarScope)} instead
      */
     @Deprecated
     public static Object getObjectElem(Object obj, Object elem, Context cx) {
@@ -1822,7 +1822,7 @@ public class ScriptRuntime {
     }
 
     /** Call obj.[[Get]](id) */
-    public static Object getObjectElem(Object obj, Object elem, Context cx, Scriptable scope) {
+    public static Object getObjectElem(Object obj, Object elem, Context cx, VarScope scope) {
         Scriptable sobj = asScriptableOrThrowUndefReadError(cx, scope, obj, elem);
         return getObjectElem(sobj, elem, cx);
     }
@@ -1851,7 +1851,7 @@ public class ScriptRuntime {
     }
 
     public static Object getSuperElem(
-            Object superObject, Object elem, Context cx, Scriptable scope, Object thisObject) {
+            Object superObject, Object elem, Context cx, VarScope scope, Object thisObject) {
         Scriptable superScriptable =
                 asScriptableOrThrowUndefReadError(cx, scope, superObject, elem);
         Scriptable thisScriptable = asScriptableOrThrowUndefReadError(cx, scope, thisObject, elem);
@@ -1887,7 +1887,7 @@ public class ScriptRuntime {
     /**
      * Version of getObjectElem when elem is a valid JS identifier name.
      *
-     * @deprecated Use {@link #getObjectProp(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #getObjectProp(Object, String, Context, VarScope)} instead
      */
     @Deprecated
     public static Object getObjectProp(Object obj, String property, Context cx) {
@@ -1899,7 +1899,7 @@ public class ScriptRuntime {
      *
      * @param scope the scope that should be used to resolve primitive prototype
      */
-    public static Object getObjectProp(Object obj, String property, Context cx, Scriptable scope) {
+    public static Object getObjectProp(Object obj, String property, Context cx, VarScope scope) {
         Scriptable sobj = asScriptableOrThrowUndefReadError(cx, scope, obj, property);
         return getObjectProp(sobj, property, cx);
     }
@@ -1918,7 +1918,7 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #getObjectPropNoWarn(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #getObjectPropNoWarn(Object, String, Context, VarScope)} instead
      */
     @Deprecated
     public static Object getObjectPropNoWarn(Object obj, String property, Context cx) {
@@ -1926,7 +1926,7 @@ public class ScriptRuntime {
     }
 
     public static Object getObjectPropNoWarn(
-            Object obj, String property, Context cx, Scriptable scope) {
+            Object obj, String property, Context cx, VarScope scope) {
         Scriptable sobj = asScriptableOrThrowUndefReadError(cx, scope, obj, property);
         Object result = ScriptableObject.getProperty(sobj, property);
         if (result == Scriptable.NOT_FOUND) {
@@ -1939,7 +1939,7 @@ public class ScriptRuntime {
             Object superObject,
             String property,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object thisObject,
             boolean noWarn) {
         Scriptable superScriptable =
@@ -1974,7 +1974,7 @@ public class ScriptRuntime {
     /**
      * A cheaper and less general version of the above for well-known argument types.
      *
-     * @deprecated Use {@link #getObjectIndex(Object, double, Context, Scriptable)} instead
+     * @deprecated Use {@link #getObjectIndex(Object, double, Context, VarScope)} instead
      */
     @Deprecated
     public static Object getObjectIndex(Object obj, double dblIndex, Context cx) {
@@ -1982,7 +1982,7 @@ public class ScriptRuntime {
     }
 
     /** A cheaper and less general version of the above for well-known argument types. */
-    public static Object getObjectIndex(Object obj, double dblIndex, Context cx, Scriptable scope) {
+    public static Object getObjectIndex(Object obj, double dblIndex, Context cx, VarScope scope) {
         Scriptable sobj = asScriptableOrThrowUndefReadError(cx, scope, obj, dblIndex);
 
         int index = (int) dblIndex;
@@ -2002,7 +2002,7 @@ public class ScriptRuntime {
     }
 
     public static Object getSuperIndex(
-            Object superObject, double dblIndex, Context cx, Scriptable scope, Object thisObject) {
+            Object superObject, double dblIndex, Context cx, VarScope scope, Object thisObject) {
         Scriptable superScriptable =
                 asScriptableOrThrowUndefReadError(cx, scope, superObject, dblIndex);
         Scriptable thisScriptable =
@@ -2029,7 +2029,7 @@ public class ScriptRuntime {
     /**
      * Call obj.[[Put]](id, value)
      *
-     * @deprecated Use {@link #setObjectElem(Object, Object, Object, Context, Scriptable)} instead
+     * @deprecated Use {@link #setObjectElem(Object, Object, Object, Context, VarScope)} instead
      */
     @Deprecated
     public static Object setObjectElem(Object obj, Object elem, Object value, Context cx) {
@@ -2038,7 +2038,7 @@ public class ScriptRuntime {
 
     /** Call obj.[[Put]](id, value) */
     public static Object setObjectElem(
-            Object obj, Object elem, Object value, Context cx, Scriptable scope) {
+            Object obj, Object elem, Object value, Context cx, VarScope scope) {
         verifyIsScriptableOrComplainWriteErrorInEs5Strict(obj, elem, value, cx);
         Scriptable sobj = asScriptableOrThrowUndefWriteError(cx, scope, obj, elem, value);
         return setObjectElem(sobj, elem, value, cx);
@@ -2067,7 +2067,7 @@ public class ScriptRuntime {
             Object elem,
             Object value,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object thisObject) {
         Scriptable superScriptable =
                 asScriptableOrThrowUndefWriteError(cx, scope, superObject, elem, value);
@@ -2101,7 +2101,7 @@ public class ScriptRuntime {
     /**
      * Version of setObjectElem when elem is a valid JS identifier name.
      *
-     * @deprecated Use {@link #setObjectProp(Object, String, Object, Context, Scriptable)} instead
+     * @deprecated Use {@link #setObjectProp(Object, String, Object, Context, VarScope)} instead
      */
     @Deprecated
     public static Object setObjectProp(Object obj, String property, Object value, Context cx) {
@@ -2110,7 +2110,7 @@ public class ScriptRuntime {
 
     /** Version of setObjectElem when elem is a valid JS identifier name. */
     public static Object setObjectProp(
-            Object obj, String property, Object value, Context cx, Scriptable scope) {
+            Object obj, String property, Object value, Context cx, VarScope scope) {
         verifyIsScriptableOrComplainWriteErrorInEs5Strict(obj, property, value, cx);
         Scriptable sobj = asScriptableOrThrowUndefWriteError(cx, scope, obj, property, value);
         return setObjectProp(sobj, property, value, cx);
@@ -2127,7 +2127,7 @@ public class ScriptRuntime {
             String property,
             Object value,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object thisObject) {
         verifyIsScriptableOrComplainWriteErrorInEs5Strict(superObject, property, value, cx);
         verifyIsScriptableOrComplainWriteErrorInEs5Strict(thisObject, property, value, cx);
@@ -2153,7 +2153,7 @@ public class ScriptRuntime {
     /**
      * A cheaper and less general version of the above for well-known argument types.
      *
-     * @deprecated Use {@link #setObjectIndex(Object, double, Object, Context, Scriptable)} instead
+     * @deprecated Use {@link #setObjectIndex(Object, double, Object, Context, VarScope)} instead
      */
     @Deprecated
     public static Object setObjectIndex(Object obj, double dblIndex, Object value, Context cx) {
@@ -2162,7 +2162,7 @@ public class ScriptRuntime {
 
     /** A cheaper and less general version of the above for well-known argument types. */
     public static Object setObjectIndex(
-            Object obj, double dblIndex, Object value, Context cx, Scriptable scope) {
+            Object obj, double dblIndex, Object value, Context cx, VarScope scope) {
         verifyIsScriptableOrComplainWriteErrorInEs5Strict(obj, dblIndex, value, cx);
         Scriptable sobj = asScriptableOrThrowUndefWriteError(cx, scope, obj, dblIndex, value);
         int index = (int) dblIndex;
@@ -2184,7 +2184,7 @@ public class ScriptRuntime {
             double dblIndex,
             Object value,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object thisObject) {
         Scriptable superScriptable =
                 asScriptableOrThrowUndefWriteError(cx, scope, superObject, dblIndex, value);
@@ -2267,19 +2267,19 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #specialRef(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #specialRef(Object, String, Context, VarScope)} instead
      */
     @Deprecated
     public static Ref specialRef(Object obj, String specialProperty, Context cx) {
         return specialRef(obj, specialProperty, cx, getTopCallScope(cx));
     }
 
-    public static Ref specialRef(Object obj, String specialProperty, Context cx, Scriptable scope) {
+    public static Ref specialRef(Object obj, String specialProperty, Context cx, VarScope scope) {
         return SpecialRef.createSpecial(cx, scope, obj, specialProperty);
     }
 
     /**
-     * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
+     * @deprecated Use {@link #delete(Object, Object, Context, VarScope, boolean)} instead
      */
     @Deprecated
     public static Object delete(Object obj, Object id, Context cx) {
@@ -2295,7 +2295,7 @@ public class ScriptRuntime {
      * method returns a value. However, the definition of the [[Delete]] operator (8.6.2.5) does not
      * define a return value. Here we assume that the [[Delete]] method doesn't return a value.
      *
-     * @deprecated Use {@link #delete(Object, Object, Context, Scriptable, boolean)} instead
+     * @deprecated Use {@link #delete(Object, Object, Context, VarScope, boolean)} instead
      */
     @Deprecated
     public static Object delete(Object obj, Object id, Context cx, boolean isName) {
@@ -2311,8 +2311,7 @@ public class ScriptRuntime {
      * method returns a value. However, the definition of the [[Delete]] operator (8.6.2.5) does not
      * define a return value. Here we assume that the [[Delete]] method doesn't return a value.
      */
-    public static Object delete(
-            Object obj, Object id, Context cx, Scriptable scope, boolean isName) {
+    public static Object delete(Object obj, Object id, Context cx, VarScope scope, boolean isName) {
         Scriptable sobj = toObjectOrNull(cx, obj, scope);
         if (sobj == null) {
             if (isName) {
@@ -2668,7 +2667,7 @@ public class ScriptRuntime {
     /**
      * For backwards compatibility with generated class files
      *
-     * @deprecated Use {@link #enumInit(Object, Context, Scriptable, int)} instead
+     * @deprecated Use {@link #enumInit(Object, Context, VarScope, int)} instead
      */
     @Deprecated
     public static Object enumInit(Object value, Context cx, boolean enumValues) {
@@ -2684,14 +2683,14 @@ public class ScriptRuntime {
     public static final int ENUMERATE_VALUES_IN_ORDER = 6;
 
     /**
-     * @deprecated Use {@link #enumInit(Object, Context, Scriptable, int)} instead
+     * @deprecated Use {@link #enumInit(Object, Context, VarScope, int)} instead
      */
     @Deprecated
     public static Object enumInit(Object value, Context cx, int enumType) {
         return enumInit(value, cx, getTopCallScope(cx), enumType);
     }
 
-    public static Object enumInit(Object value, Context cx, Scriptable scope, int enumType) {
+    public static Object enumInit(Object value, Context cx, VarScope scope, int enumType) {
         IdEnumeration x = new IdEnumeration();
         x.obj = toObjectOrNull(cx, value, scope);
         // "for of" loop
@@ -2818,13 +2817,13 @@ public class ScriptRuntime {
             throw notFunctionError(enumObj.iterator, ES6Iterator.NEXT_METHOD);
         }
         Callable f = (Callable) v;
-        Scriptable scope;
+        VarScope scope;
         if (f instanceof Function) {
             scope = ((Function) f).getDeclarationScope();
         } else {
             scope = cx.topCallScope;
         }
-        Object r = f.call(cx, (VarScope) scope, enumObj.iterator, emptyArgs);
+        Object r = f.call(cx, scope, enumObj.iterator, emptyArgs);
         Scriptable iteratorResult = toObject(cx, scope, r);
         Object done = ScriptableObject.getProperty(iteratorResult, ES6Iterator.DONE_PROPERTY);
         if (done != Scriptable.NOT_FOUND && toBoolean(done)) {
@@ -2910,7 +2909,7 @@ public class ScriptRuntime {
      * @return true, if arg1 was iterable.
      */
     public static boolean loadFromIterable(
-            Context cx, Scriptable scope, Object arg1, BiConsumer<Object, Object> setter) {
+            Context cx, VarScope scope, Object arg1, BiConsumer<Object, Object> setter) {
         if ((arg1 == null) || Undefined.isUndefined(arg1)) return false;
 
         // Call the "[Symbol.iterator]" property as a function.
@@ -2947,24 +2946,23 @@ public class ScriptRuntime {
      * scope available as ScriptRuntime.lastStoredScriptable() for consumption as thisObj. The
      * caller must call ScriptRuntime.lastStoredScriptable() immediately after calling this method.
      *
-     * @deprecated use {@link #getNameAndThis(String, Context, Scriptable)}
+     * @deprecated use {@link #getNameAndThis(String, Context, VarScope)}
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
-    public static Callable getNameFunctionAndThis(String name, Context cx, Scriptable scope) {
+    public static Callable getNameFunctionAndThis(String name, Context cx, VarScope scope) {
         return getNameFunctionAndThisInner(name, cx, scope, false);
     }
 
     /**
-     * @deprecated use {@link #getNameAndThisOptional(String, Context, Scriptable)}
+     * @deprecated use {@link #getNameAndThisOptional(String, Context, VarScope)}
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
-    public static Callable getNameFunctionAndThisOptional(
-            String name, Context cx, Scriptable scope) {
+    public static Callable getNameFunctionAndThisOptional(String name, Context cx, VarScope scope) {
         return getNameFunctionAndThisInner(name, cx, scope, true);
     }
 
     private static Callable getNameFunctionAndThisInner(
-            String name, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
+            String name, Context cx, VarScope scope, boolean isOptionalChainingCall) {
         Scriptable parent = scope.getParentScope();
         if (parent == null) {
             Object result = topScopeName(cx, scope, name);
@@ -2995,16 +2993,16 @@ public class ScriptRuntime {
      * Prepare for calling name(...): return function corresponding to name and make current top
      * scope available as part of the result.
      */
-    public static LookupResult getNameAndThis(String name, Context cx, Scriptable scope) {
+    public static LookupResult getNameAndThis(String name, Context cx, VarScope scope) {
         return getNameAndThisInner(name, cx, scope, false);
     }
 
-    public static LookupResult getNameAndThisOptional(String name, Context cx, Scriptable scope) {
+    public static LookupResult getNameAndThisOptional(String name, Context cx, VarScope scope) {
         return getNameAndThisInner(name, cx, scope, true);
     }
 
     private static LookupResult getNameAndThisInner(
-            String name, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
+            String name, Context cx, VarScope scope, boolean isOptionalChainingCall) {
         Scriptable parent = scope.getParentScope();
         if (parent == null) {
             Object result = topScopeName(cx, scope, name);
@@ -3041,7 +3039,7 @@ public class ScriptRuntime {
      * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
      *
-     * @deprecated Use {@link #getElemFunctionAndThis(Object, Object, Context, Scriptable)} instead
+     * @deprecated Use {@link #getElemFunctionAndThis(Object, Object, Context, VarScope)} instead
      */
     @Deprecated
     public static Callable getElemFunctionAndThis(Object obj, Object elem, Context cx) {
@@ -3054,25 +3052,25 @@ public class ScriptRuntime {
      * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
      *
-     * @deprecated use {@link #getElemAndThis(Object, Object, Context, Scriptable)}
+     * @deprecated use {@link #getElemAndThis(Object, Object, Context, VarScope)}
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getElemFunctionAndThis(
-            Object obj, Object elem, Context cx, Scriptable scope) {
+            Object obj, Object elem, Context cx, VarScope scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, false);
     }
 
     /**
-     * @deprecated use {@link #getElemAndThisOptional(Object, Object, Context, Scriptable)}
+     * @deprecated use {@link #getElemAndThisOptional(Object, Object, Context, VarScope)}
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getElemFunctionAndThisOptional(
-            Object obj, Object elem, Context cx, Scriptable scope) {
+            Object obj, Object elem, Context cx, VarScope scope) {
         return getElemFunctionAndThisInner(obj, elem, cx, scope, true);
     }
 
     private static Callable getElemFunctionAndThisInner(
-            Object obj, Object elem, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
+            Object obj, Object elem, Context cx, VarScope scope, boolean isOptionalChainingCall) {
         Scriptable thisObj;
         Object value;
 
@@ -3116,18 +3114,17 @@ public class ScriptRuntime {
      * Prepare for calling obj[id](...): return function corresponding to obj[id] and make obj
      * properly converted to Scriptable available in the result.
      */
-    public static LookupResult getElemAndThis(
-            Object obj, Object elem, Context cx, Scriptable scope) {
+    public static LookupResult getElemAndThis(Object obj, Object elem, Context cx, VarScope scope) {
         return getElemAndThisInner(obj, elem, cx, scope, false);
     }
 
     public static LookupResult getElemAndThisOptional(
-            Object obj, Object elem, Context cx, Scriptable scope) {
+            Object obj, Object elem, Context cx, VarScope scope) {
         return getElemAndThisInner(obj, elem, cx, scope, true);
     }
 
     private static LookupResult getElemAndThisInner(
-            Object obj, Object elem, Context cx, Scriptable scope, boolean isOptionalChainingCall) {
+            Object obj, Object elem, Context cx, VarScope scope, boolean isOptionalChainingCall) {
         Scriptable thisObj;
         Object value;
 
@@ -3171,7 +3168,7 @@ public class ScriptRuntime {
      * after calling this method. Warning: this doesn't allow to resolve primitive prototype
      * properly when many top scopes are involved.
      *
-     * @deprecated Use {@link #getPropFunctionAndThis(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #getPropFunctionAndThis(Object, String, Context, VarScope)} instead
      */
     @Deprecated
     public static Callable getPropFunctionAndThis(Object obj, String property, Context cx) {
@@ -3184,20 +3181,20 @@ public class ScriptRuntime {
      * consumption as thisObj. The caller must call ScriptRuntime.lastStoredScriptable() immediately
      * after calling this method.
      *
-     * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #getPropAndThis(Object, String, Context, VarScope)} instead
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getPropFunctionAndThis(
-            Object obj, String property, Context cx, Scriptable scope) {
+            Object obj, String property, Context cx, VarScope scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, false);
     }
 
     /**
-     * @deprecated Use {@link #getPropAndThis(Object, String, Context, Scriptable)} instead
+     * @deprecated Use {@link #getPropAndThis(Object, String, Context, VarScope)} instead
      */
     @Deprecated(since = "1.8.1", forRemoval = true)
     public static Callable getPropFunctionAndThisOptional(
-            Object obj, String property, Context cx, Scriptable scope) {
+            Object obj, String property, Context cx, VarScope scope) {
         return getPropFunctionAndThisInner(obj, property, cx, scope, true);
     }
 
@@ -3205,7 +3202,7 @@ public class ScriptRuntime {
             Object obj,
             String property,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             boolean isOptionalChainingCall) {
         Scriptable thisObj = toObjectOrNull(cx, obj, scope);
         return getPropFunctionAndThisHelper(obj, property, cx, thisObj, isOptionalChainingCall);
@@ -3252,12 +3249,12 @@ public class ScriptRuntime {
      * obj properly converted to Scriptable in the result.
      */
     public static LookupResult getPropAndThis(
-            Object obj, String property, Context cx, Scriptable scope) {
+            Object obj, String property, Context cx, VarScope scope) {
         return getPropAndThisInner(obj, property, cx, scope, false);
     }
 
     public static LookupResult getPropAndThisOptional(
-            Object obj, String property, Context cx, Scriptable scope) {
+            Object obj, String property, Context cx, VarScope scope) {
         return getPropAndThisInner(obj, property, cx, scope, true);
     }
 
@@ -3265,7 +3262,7 @@ public class ScriptRuntime {
             Object obj,
             String property,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             boolean isOptionalChainingCall) {
         Scriptable thisObj = toObjectOrNull(cx, obj, scope);
         return getPropAndThisHelper(obj, property, cx, thisObj, isOptionalChainingCall);
@@ -3388,11 +3385,11 @@ public class ScriptRuntime {
      * then call the result, (throwing a TypeError if the result is not a function), and return that
      * result, whatever it is.
      */
-    public static Object callIterator(Object obj, Context cx, Scriptable scope) {
+    public static Object callIterator(Object obj, Context cx, VarScope scope) {
         final Callable getIterator =
                 ScriptRuntime.getElemFunctionAndThis(obj, SymbolKey.ITERATOR, cx, scope);
         final Scriptable iterable = ScriptRuntime.lastStoredScriptable(cx);
-        return getIterator.call(cx, (VarScope) scope, iterable, ScriptRuntime.emptyArgs);
+        return getIterator.call(cx, scope, iterable, ScriptRuntime.emptyArgs);
     }
 
     /**
@@ -3470,7 +3467,7 @@ public class ScriptRuntime {
     }
 
     public static Object newSpecial(
-            Context cx, Object fun, Object[] args, Scriptable scope, int callType) {
+            Context cx, Object fun, Object[] args, VarScope scope, int callType) {
         if (callType == Node.SPECIALCALL_EVAL) {
             if (NativeGlobal.isEvalFunction(fun)) {
                 throw typeErrorById("msg.not.ctor", "eval");
@@ -3492,7 +3489,7 @@ public class ScriptRuntime {
      * <p>See Ecma 15.3.4.[34]
      */
     public static Object applyOrCall(
-            boolean isApply, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            boolean isApply, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         int L = args.length;
         Callable function = getCallable(thisObj);
 
@@ -3517,7 +3514,7 @@ public class ScriptRuntime {
     }
 
     public static Scriptable getApplyOrCallThis(
-            Context cx, Scriptable scope, Object arg0, int l, Function target) {
+            Context cx, VarScope scope, Object arg0, int l, Function target) {
         Scriptable callThis;
         if (cx.hasFeature(Context.FEATURE_OLD_UNDEF_NULL_THIS)) {
             // Legacy behavior
@@ -4060,7 +4057,7 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #propIncrDecr(Object, String, Context, Scriptable, int)} instead
+     * @deprecated Use {@link #propIncrDecr(Object, String, Context, VarScope, int)} instead
      */
     @Deprecated
     public static Object propIncrDecr(Object obj, String id, Context cx, int incrDecrMask) {
@@ -4068,7 +4065,7 @@ public class ScriptRuntime {
     }
 
     public static Object propIncrDecr(
-            Object obj, String id, Context cx, Scriptable scope, int incrDecrMask) {
+            Object obj, String id, Context cx, VarScope scope, int incrDecrMask) {
         Scriptable start = asScriptableOrThrowUndefReadError(cx, scope, obj, id);
 
         Scriptable target = start;
@@ -4132,7 +4129,7 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #elemIncrDecr(Object, Object, Context, Scriptable, int)} instead
+     * @deprecated Use {@link #elemIncrDecr(Object, Object, Context, VarScope, int)} instead
      */
     @Deprecated
     public static Object elemIncrDecr(Object obj, Object index, Context cx, int incrDecrMask) {
@@ -4140,7 +4137,7 @@ public class ScriptRuntime {
     }
 
     public static Object elemIncrDecr(
-            Object obj, Object index, Context cx, Scriptable scope, int incrDecrMask) {
+            Object obj, Object index, Context cx, VarScope scope, int incrDecrMask) {
         Object value = getObjectElem(obj, index, cx, scope);
         final boolean post = (incrDecrMask & Node.POST_FLAG) != 0;
 
@@ -5074,7 +5071,7 @@ public class ScriptRuntime {
             Scriptable lastCatchScope,
             String exceptionName,
             Context cx,
-            Scriptable scope) {
+            VarScope scope) {
         Object obj;
         boolean cacheObj;
 
@@ -5199,7 +5196,7 @@ public class ScriptRuntime {
         return catchScopeObject;
     }
 
-    public static Scriptable wrapException(Throwable t, Scriptable scope, Context cx) {
+    public static Scriptable wrapException(Throwable t, VarScope scope, Context cx) {
         RhinoException re;
         String errorName;
         String errorMsg;
@@ -5335,7 +5332,7 @@ public class ScriptRuntime {
      */
     @Deprecated
     public static void setFunctionProtoAndParent(
-            BaseFunction fn, Scriptable scope, boolean es6GeneratorFunction) {
+            BaseFunction fn, VarScope scope, boolean es6GeneratorFunction) {
         setFunctionProtoAndParent(fn, Context.getCurrentContext(), scope, es6GeneratorFunction);
     }
 
@@ -5369,7 +5366,7 @@ public class ScriptRuntime {
     }
 
     public static void setBuiltinProtoAndParent(
-            ScriptableObject obj, JSFunction f, Object nt, Scriptable s, TopLevel.Builtins type) {
+            ScriptableObject obj, JSFunction f, Object nt, VarScope s, TopLevel.Builtins type) {
         obj.setPrototype((Scriptable) f.getPrototypeProperty());
         obj.setParentScope(s);
     }
@@ -5454,11 +5451,11 @@ public class ScriptRuntime {
      * <strong>This method only present for compatibility.</strong>
      *
      * @deprecated Use {@link #fillObjectLiteral(Scriptable, Object[], Object[], int[], Context,
-     *     Scriptable)} instead
+     *     VarScope)} instead
      */
     @Deprecated
     public static Scriptable newObjectLiteral(
-            Object[] propertyIds, Object[] propertyValues, Context cx, Scriptable scope) {
+            Object[] propertyIds, Object[] propertyValues, Context cx, VarScope scope) {
         // Passing null for getterSetters means no getters or setters
         Scriptable object = cx.newObject(scope);
         fillObjectLiteral(object, propertyIds, propertyValues, null, cx, scope);
@@ -5470,7 +5467,7 @@ public class ScriptRuntime {
      * present for compatibility.</strong>
      *
      * @deprecated Use {@link #fillObjectLiteral(Scriptable, Object[], Object[], int[], Context,
-     *     Scriptable)}
+     *     VarScope)}
      */
     @Deprecated
     public static Scriptable newObjectLiteral(
@@ -5478,7 +5475,7 @@ public class ScriptRuntime {
             Object[] propertyValues,
             int[] getterSetters,
             Context cx,
-            Scriptable scope) {
+            VarScope scope) {
         Scriptable object = cx.newObject(scope);
         fillObjectLiteral(object, propertyIds, propertyValues, getterSetters, cx, scope);
         return object;
@@ -5490,7 +5487,7 @@ public class ScriptRuntime {
             Object[] propertyValues,
             int[] getterSetters,
             Context cx,
-            Scriptable scope) {
+            VarScope scope) {
         int end = propertyIds == null ? 0 : propertyIds.length;
         for (int i = 0; i != end; ++i) {
             Object id = propertyIds[i];
@@ -5774,7 +5771,7 @@ public class ScriptRuntime {
     }
 
     private static Scriptable asScriptableOrThrowUndefReadError(
-            Context cx, Scriptable scope, Object obj, Object elem) {
+            Context cx, VarScope scope, Object obj, Object elem) {
         Scriptable scriptable = toObjectOrNull(cx, obj, scope);
         if (scriptable == null) {
             throw undefReadError(obj, elem);
@@ -5783,7 +5780,7 @@ public class ScriptRuntime {
     }
 
     private static Scriptable asScriptableOrThrowUndefWriteError(
-            Context cx, Scriptable scope, Object obj, Object elem, Object value) {
+            Context cx, VarScope scope, Object obj, Object elem, Object value) {
         Scriptable scriptable = toObjectOrNull(cx, obj, scope);
         if (scriptable == null) {
             throw undefWriteError(obj, elem, value);
@@ -6163,13 +6160,13 @@ public class ScriptRuntime {
         }
     }
 
-    public static Scriptable getThisForScope(Scriptable scope, Object callThisArg) {
+    public static Scriptable getThisForScope(VarScope scope, Object callThisArg) {
         if (Undefined.isUndefined(callThisArg)) {
             callThisArg = Undefined.SCRIPTABLE_UNDEFINED;
         } else if (callThisArg == null) {
             return null;
         }
-        return ScriptRuntime.toObject(scope, callThisArg);
+        return ScriptRuntime.toObject((VarScope) scope, callThisArg);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -547,7 +547,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      *     to regular property access.
      * @since 1.7.6
      */
-    public void setExternalArrayData(Scriptable scope, ExternalArrayData array) {
+    public void setExternalArrayData(VarScope scope, ExternalArrayData array) {
         externalData = array;
 
         if (array == null) {
@@ -838,7 +838,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @see org.mozilla.javascript.ScriptableObject#READONLY
      * @see org.mozilla.javascript.ScriptableObject #defineProperty(String, Class, int)
      */
-    public static <T extends Scriptable> void defineClass(Scriptable scope, Class<T> clazz)
+    public static <T extends Scriptable> void defineClass(VarScope scope, Class<T> clazz)
             throws IllegalAccessException, InstantiationException, InvocationTargetException {
         defineClass(scope, clazz, false, false);
     }
@@ -862,7 +862,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @since 1.4R3
      */
     public static <T extends Scriptable> void defineClass(
-            Scriptable scope, Class<T> clazz, boolean sealed)
+            VarScope scope, Class<T> clazz, boolean sealed)
             throws IllegalAccessException, InstantiationException, InvocationTargetException {
         defineClass(scope, clazz, sealed, false);
     }
@@ -890,7 +890,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @since 1.6R2
      */
     public static <T extends Scriptable> String defineClass(
-            Scriptable scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
+            VarScope scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
             throws IllegalAccessException, InstantiationException, InvocationTargetException {
         BaseFunction ctor = buildClassCtor(scope, clazz, sealed, mapInheritance);
         if (ctor == null) return null;
@@ -900,7 +900,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     }
 
     static <T extends Scriptable> BaseFunction buildClassCtor(
-            Scriptable scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
+            VarScope scope, Class<T> clazz, boolean sealed, boolean mapInheritance)
             throws IllegalAccessException, InstantiationException, InvocationTargetException {
         Method[] methods = FunctionObject.getMethodList(clazz);
         for (Method method : methods) {
@@ -1294,7 +1294,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @see org.mozilla.javascript.Scriptable#put(String, Scriptable, Object)
      */
     public void defineProperty(
-            Scriptable scope, String propertyName, Class<?> clazz, int attributes) {
+            VarScope scope, String propertyName, Class<?> clazz, int attributes) {
         int length = propertyName.length();
         if (length == 0) throw new IllegalArgumentException();
         char[] buf = new char[3 + length];
@@ -1363,7 +1363,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @param attributes the attributes of the JavaScript property
      */
     public void defineProperty(
-            Scriptable scope,
+            VarScope scope,
             String propertyName,
             Object delegateTo,
             Method getter,
@@ -1829,7 +1829,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * "defineProperty" method.
      */
     public interface LambdaSetterFunction extends Serializable {
-        void accept(Scriptable scope, Object value);
+        void accept(Scriptable owner, Object value);
     }
 
     /**
@@ -2163,7 +2163,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @see org.mozilla.javascript.FunctionObject
      */
     public void defineFunctionProperties(
-            Scriptable scope, String[] names, Class<?> clazz, int attributes) {
+            VarScope scope, String[] names, Class<?> clazz, int attributes) {
         Method[] methods = FunctionObject.getMethodList(clazz);
         for (String name : names) {
             Method m = FunctionObject.findSingleMethod(methods, name);

--- a/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SpecialRef.java
@@ -13,17 +13,19 @@ class SpecialRef extends Ref {
     private static final int SPECIAL_PROTO = 1;
     private static final int SPECIAL_PARENT = 2;
 
-    private Scriptable target;
-    private int type;
-    private String name;
+    private final Scriptable target;
+    private final int type;
+    private final String name;
+    private final VarScope scope;
 
-    private SpecialRef(Scriptable target, int type, String name) {
+    private SpecialRef(Scriptable target, int type, String name, VarScope scope) {
         this.target = target;
         this.type = type;
         this.name = name;
+        this.scope = scope;
     }
 
-    static Ref createSpecial(Context cx, Scriptable scope, Object object, String name) {
+    static Ref createSpecial(Context cx, VarScope scope, Object object, String name) {
         Scriptable target = ScriptRuntime.toObjectOrNull(cx, object, scope);
         if (target == null) {
             throw ScriptRuntime.undefReadError(object, name);
@@ -43,7 +45,7 @@ class SpecialRef extends Ref {
             type = SPECIAL_NONE;
         }
 
-        return new SpecialRef(target, type, name);
+        return new SpecialRef(target, type, name, scope);
     }
 
     @Override
@@ -78,7 +80,7 @@ class SpecialRef extends Ref {
     }
 
     @Override
-    public Object set(Context cx, Scriptable scope, Object value) {
+    public Object set(Context cx, Scriptable owner, Object value) {
         switch (type) {
             case SPECIAL_NONE:
                 return ScriptRuntime.setObjectProp(target, name, value, cx);

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -430,7 +430,7 @@ public class TopLevel extends ScopeObject {
     }
 
     public void defineFunctionProperties(
-            Scriptable scope, String[] names, Class<?> clazz, int attributes) {
+            VarScope scope, String[] names, Class<?> clazz, int attributes) {
         getGlobalThis().defineFunctionProperties(scope, names, clazz, attributes);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/WrapFactory.java
@@ -28,7 +28,7 @@ public class WrapFactory {
     /**
      * @see #wrap(Context, Scriptable, Object, TypeInfo)
      */
-    public final Object wrap(Context cx, Scriptable scope, Object obj, Class<?> staticType) {
+    public final Object wrap(Context cx, VarScope scope, Object obj, Class<?> staticType) {
         return wrap(cx, scope, obj, TypeInfoFactory.GLOBAL.create(staticType));
     }
 
@@ -54,7 +54,7 @@ public class WrapFactory {
      * @return the wrapped value.
      * @since 1.9.0
      */
-    public Object wrap(Context cx, Scriptable scope, Object obj, TypeInfo staticType) {
+    public Object wrap(Context cx, VarScope scope, Object obj, TypeInfo staticType) {
         if (obj == null || obj == Undefined.instance || obj instanceof Scriptable) {
             return obj;
         }
@@ -92,7 +92,7 @@ public class WrapFactory {
      * @param obj the object to be wrapped
      * @return the wrapped value.
      */
-    public Scriptable wrapNewObject(Context cx, Scriptable scope, Object obj) {
+    public Scriptable wrapNewObject(Context cx, VarScope scope, Object obj) {
         if (obj instanceof Scriptable) {
             return (Scriptable) obj;
         }
@@ -103,7 +103,7 @@ public class WrapFactory {
      * @see #wrapAsJavaObject(Context, Scriptable, Object, TypeInfo)
      */
     public final Scriptable wrapAsJavaObject(
-            Context cx, Scriptable scope, Object javaObject, Class<?> staticType) {
+            Context cx, VarScope scope, Object javaObject, Class<?> staticType) {
         return wrapAsJavaObject(cx, scope, javaObject, TypeInfoFactory.GLOBAL.create(staticType));
     }
 
@@ -111,8 +111,8 @@ public class WrapFactory {
      * Wrap Java object as Scriptable instance to allow full access to its methods and fields from
      * JavaScript.
      *
-     * <p>{@link #wrap(Context, Scriptable, Object, Class)} and {@link #wrapNewObject(Context,
-     * Scriptable, Object)} call this method when they can not convert {@code javaObject} to
+     * <p>{@link #wrap(Context, VarScope, Object, Class)} and {@link #wrapNewObject(Context,
+     * VarScope, Object)} call this method when they can not convert {@code javaObject} to
      * JavaScript primitive value or JavaScript array.
      *
      * <p>Subclasses can override the method to provide custom wrappers for Java objects.
@@ -126,7 +126,7 @@ public class WrapFactory {
      * @since 1.9.0
      */
     public Scriptable wrapAsJavaObject(
-            Context cx, Scriptable scope, Object javaObject, TypeInfo staticType) {
+            Context cx, VarScope scope, Object javaObject, TypeInfo staticType) {
         if (staticType.shouldReplace() && javaObject != null) {
             staticType =
                     TypeInfoFactory.getOrElse(scope, TypeInfoFactory.GLOBAL)

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BaseFunctionLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BaseFunctionLinker.java
@@ -12,7 +12,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
 import jdk.dynalink.linker.support.Guards;
 import org.mozilla.javascript.BaseFunction;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This linker optimizes accesses to the "prototype" property of any standard Rhino function so that
@@ -58,7 +58,7 @@ class BaseFunctionLinker implements TypeBasedGuardingDynamicLinker {
     }
 
     @SuppressWarnings("unused")
-    private static Object getPrototype(Object o, Context cx, Scriptable scope) {
+    private static Object getPrototype(Object o, Context cx, VarScope scope) {
         return ((BaseFunction) o).getPrototypeProperty();
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -755,7 +755,7 @@ class BodyCodegen {
                                     + "Lorg/mozilla/javascript/Scriptable;"
                                     + "Ljava/lang/String;"
                                     + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + ")Lorg/mozilla/javascript/Scriptable;");
                     cfw.addAStore(local);
                 }
@@ -847,7 +847,7 @@ class BodyCodegen {
                         "enumInit",
                         "(Ljava/lang/Object;"
                                 + "Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
+                                + "Lorg/mozilla/javascript/VarScope;"
                                 + "I"
                                 + ")Ljava/lang/Object;");
                 cfw.addAStore(getLocalBlockRegister(node));
@@ -1047,7 +1047,7 @@ class BodyCodegen {
                     addScriptRuntimeInvoke(
                             "doObjectRest",
                             "(Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "Ljava/lang/Object;"
                                     + "[Ljava/lang/Object;"
                                     + ")Lorg/mozilla/javascript/Scriptable;");
@@ -1826,7 +1826,7 @@ class BodyCodegen {
                 "(Ljava/lang/Object;"
                         + "Ljava/lang/String;"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + ")Lorg/mozilla/javascript/Ref;");
     }
 
@@ -2102,7 +2102,7 @@ class BodyCodegen {
                 "initFunction",
                 "(Lorg/mozilla/javascript/JSFunction;"
                         + "I"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + "Lorg/mozilla/javascript/Context;"
                         + ")V");
     }
@@ -2345,7 +2345,7 @@ class BodyCodegen {
                         "org/mozilla/javascript/NewLiteralStorage",
                         "spread",
                         "(Lorg/mozilla/javascript/Context;"
-                                + "Lorg/mozilla/javascript/Scriptable;"
+                                + "Lorg/mozilla/javascript/VarScope;"
                                 + "Ljava/lang/Object;"
                                 + "I"
                                 + ")V");
@@ -2442,7 +2442,7 @@ class BodyCodegen {
                     addOptRuntimeInvoke(
                             "spread",
                             "(Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "Lorg/mozilla/javascript/NewLiteralStorage;"
                                     + "Ljava/lang/Object;"
                                     + "I"
@@ -2491,7 +2491,7 @@ class BodyCodegen {
                     addOptRuntimeInvoke(
                             "spread",
                             "(Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "Lorg/mozilla/javascript/NewLiteralStorage;"
                                     + "Ljava/lang/Object;"
                                     + "I"
@@ -2639,7 +2639,7 @@ class BodyCodegen {
                         + "[Ljava/lang/Object;"
                         + "[I"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + ")V");
     }
 
@@ -2666,7 +2666,7 @@ class BodyCodegen {
                 "(Lorg/mozilla/javascript/Context;"
                         + "Ljava/lang/Object;"
                         + "[Ljava/lang/Object;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + "I"
                         + ")Ljava/lang/Object;");
     }
@@ -3090,7 +3090,7 @@ class BodyCodegen {
                                 "(Ljava/lang/Object;"
                                         + "Ljava/lang/Object;"
                                         + "Lorg/mozilla/javascript/Context;"
-                                        + "Lorg/mozilla/javascript/Scriptable;"
+                                        + "Lorg/mozilla/javascript/VarScope;"
                                         + ")Lorg/mozilla/javascript/ScriptRuntime$LookupResult;");
                     }
                     break;
@@ -3876,7 +3876,7 @@ class BodyCodegen {
                             "(Ljava/lang/Object;"
                                     + "Ljava/lang/String;"
                                     + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "I)Ljava/lang/Object;");
                     break;
                 }
@@ -3894,7 +3894,7 @@ class BodyCodegen {
                                 "(Ljava/lang/Object;"
                                         + "D"
                                         + "Lorg/mozilla/javascript/Context;"
-                                        + "Lorg/mozilla/javascript/Scriptable;"
+                                        + "Lorg/mozilla/javascript/VarScope;"
                                         + "I"
                                         + ")Ljava/lang/Object;");
                     } else {
@@ -3903,7 +3903,7 @@ class BodyCodegen {
                                 "(Ljava/lang/Object;"
                                         + "Ljava/lang/Object;"
                                         + "Lorg/mozilla/javascript/Context;"
-                                        + "Lorg/mozilla/javascript/Scriptable;"
+                                        + "Lorg/mozilla/javascript/VarScope;"
                                         + "I"
                                         + ")Ljava/lang/Object;");
                     }
@@ -3920,7 +3920,7 @@ class BodyCodegen {
                             "refIncrDecr",
                             "(Lorg/mozilla/javascript/Ref;"
                                     + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "I)Ljava/lang/Object;");
                     break;
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ConsStringLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ConsStringLinker.java
@@ -12,7 +12,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
 import jdk.dynalink.linker.support.Guards;
 import org.mozilla.javascript.ConsString;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This linker optimizes:
@@ -85,7 +85,7 @@ class ConsStringLinker implements TypeBasedGuardingDynamicLinker {
     }
 
     @SuppressWarnings("unused")
-    private static Object getLength(Object o, Context cx, Scriptable scope) {
+    private static Object getLength(Object o, Context cx, VarScope scope) {
         return ((ConsString) o).length();
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -13,6 +13,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.Token;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.config.RhinoConfig;
 
 /**
@@ -155,7 +156,7 @@ class DefaultLinker implements GuardingDynamicLinker {
                             ScriptRuntime.LookupResult.class,
                             String.class,
                             Context.class,
-                            Scriptable.class);
+                            VarScope.class);
             mh = lookup.findStatic(ScriptRuntime.class, "getNameAndThis", tt);
             mh = MethodHandles.insertArguments(mh, 0, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);
@@ -165,7 +166,7 @@ class DefaultLinker implements GuardingDynamicLinker {
                             ScriptRuntime.LookupResult.class,
                             String.class,
                             Context.class,
-                            Scriptable.class);
+                            VarScope.class);
             mh = lookup.findStatic(ScriptRuntime.class, "getNameAndThisOptional", tt);
             mh = MethodHandles.insertArguments(mh, 0, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/NativeArrayLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/NativeArrayLinker.java
@@ -12,7 +12,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
 import jdk.dynalink.linker.support.Guards;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This linker optimizes accesses to the "length" property of native arrays by delegating directly
@@ -59,7 +59,7 @@ class NativeArrayLinker implements TypeBasedGuardingDynamicLinker {
     }
 
     @SuppressWarnings("unused")
-    private static Object getLength(Object o, Context cx, Scriptable scope) {
+    private static Object getLength(Object o, Context cx, VarScope scope) {
         long length = ((NativeArray) o).getLength();
         if (length < Integer.MAX_VALUE) {
             return (int) length;

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -58,14 +58,14 @@ public final class OptRuntime extends ScriptRuntime {
 
     /** Implement ....(arg0, arg1, ...) call shrinking optimizer code. */
     public static Object callN(
-            Callable fun, Scriptable thisObj, Object[] args, Context cx, Scriptable scope) {
-        return fun.call(cx, (VarScope) scope, thisObj, args);
+            Callable fun, Scriptable thisObj, Object[] args, Context cx, VarScope scope) {
+        return fun.call(cx, scope, thisObj, args);
     }
 
     /** Implement name(args) call shrinking optimizer code. */
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
-    public static Object callName(Object[] args, String name, Context cx, Scriptable scope) {
+    public static Object callName(Object[] args, String name, Context cx, VarScope scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, (VarScope) scope, thisObj, args);
@@ -74,7 +74,7 @@ public final class OptRuntime extends ScriptRuntime {
     /** Implement name() call shrinking optimizer code. */
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
-    public static Object callName0(String name, Context cx, Scriptable scope) {
+    public static Object callName0(String name, Context cx, VarScope scope) {
         Callable f = getNameFunctionAndThis(name, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, (VarScope) scope, thisObj, ScriptRuntime.emptyArgs);
@@ -82,7 +82,7 @@ public final class OptRuntime extends ScriptRuntime {
 
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
-    public static Object callName0Optional(String name, Context cx, Scriptable scope) {
+    public static Object callName0Optional(String name, Context cx, VarScope scope) {
         Callable f = getNameFunctionAndThisOptional(name, cx, scope);
         if (f == null) {
             return Undefined.instance;
@@ -94,7 +94,7 @@ public final class OptRuntime extends ScriptRuntime {
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
     /** Implement x.property() call shrinking optimizer code. */
-    public static Object callProp0(Object value, String property, Context cx, Scriptable scope) {
+    public static Object callProp0(Object value, String property, Context cx, VarScope scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);
         return f.call(cx, (VarScope) scope, thisObj, ScriptRuntime.emptyArgs);
@@ -103,7 +103,7 @@ public final class OptRuntime extends ScriptRuntime {
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
     public static Object callProp0Optional(
-            Object value, String property, Context cx, Scriptable scope) {
+            Object value, String property, Context cx, VarScope scope) {
         Callable f = getPropFunctionAndThisOptional(value, property, cx, scope);
         if (f == null) {
             return Undefined.instance;
@@ -133,7 +133,7 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #elemIncrDecr(Object, double, Context, Scriptable, int)} instead
+     * @deprecated Use {@link #elemIncrDecr(Object, double, Context, VarScope, int)} instead
      */
     @Deprecated
     public static Object elemIncrDecr(Object obj, double index, Context cx, int incrDecrMask) {
@@ -141,7 +141,7 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     public static Object elemIncrDecr(
-            Object obj, double index, Context cx, Scriptable scope, int incrDecrMask) {
+            Object obj, double index, Context cx, VarScope scope, int incrDecrMask) {
         return ScriptRuntime.elemIncrDecr(obj, Double.valueOf(index), cx, scope, incrDecrMask);
     }
 
@@ -151,7 +151,7 @@ public final class OptRuntime extends ScriptRuntime {
         return result;
     }
 
-    public static void initFunction(JSFunction fn, int functionType, Scriptable scope, Context cx) {
+    public static void initFunction(JSFunction fn, int functionType, VarScope scope, Context cx) {
         ScriptRuntime.initFunction(cx, scope, fn, functionType, false);
     }
 
@@ -183,7 +183,7 @@ public final class OptRuntime extends ScriptRuntime {
             Context cx,
             Object fun,
             Object[] args,
-            Scriptable scope,
+            VarScope scope,
             Scriptable callerThis,
             int callType) {
         return ScriptRuntime.newSpecial(cx, fun, args, scope, callType);
@@ -312,7 +312,7 @@ public final class OptRuntime extends ScriptRuntime {
 
     public static void spread(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             NewLiteralStorage store,
             Object source,
             int sourcePosition) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -17,7 +17,7 @@ interface Signatures {
     String PROP_GET =
             "(Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -26,7 +26,7 @@ interface Signatures {
      */
     String PROP_GET_NOWARN =
             "(Ljava/lang/Object;Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;";
+                    + "Lorg/mozilla/javascript/VarScope;)Ljava/lang/Object;";
 
     /**
      * PROP:GET_SUPER:{name}: Looks up the super property named "name". Falls back to
@@ -35,7 +35,7 @@ interface Signatures {
     String PROP_GET_SUPER =
             "(Ljava/lang/Object;" // superObj
                     + "Lorg/mozilla/javascript/Context;" // cx
-                    + "Lorg/mozilla/javascript/Scriptable;" // scope
+                    + "Lorg/mozilla/javascript/VarScope;" // scope
                     + "Ljava/lang/Object;" // thisObj
                     + "Z" // noWarn
                     + ")Ljava/lang/Object;";
@@ -47,7 +47,7 @@ interface Signatures {
     String PROP_GET_THIS =
             "(Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Lorg/mozilla/javascript/ScriptRuntime$LookupResult;";
 
     /**
@@ -58,7 +58,7 @@ interface Signatures {
             "(Ljava/lang/Object;"
                     + "D"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -69,7 +69,7 @@ interface Signatures {
             "(Ljava/lang/Object;"
                     + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -80,7 +80,7 @@ interface Signatures {
             "(Ljava/lang/Object;" // super
                     + "Ljava/lang/Object;" // elem
                     + "Lorg/mozilla/javascript/Context;" // cx
-                    + "Lorg/mozilla/javascript/Scriptable;" // scope
+                    + "Lorg/mozilla/javascript/VarScope;" // scope
                     + "Ljava/lang/Object;" // this
                     + ")Ljava/lang/Object;";
 
@@ -90,7 +90,7 @@ interface Signatures {
      */
     String PROP_SET =
             "(Ljava/lang/Object;Ljava/lang/Object;"
-                    + "Lorg/mozilla/javascript/Context;Lorg/mozilla/javascript/Scriptable;)Ljava/lang/Object;";
+                    + "Lorg/mozilla/javascript/Context;Lorg/mozilla/javascript/VarScope;)Ljava/lang/Object;";
 
     /**
      * PROP:SETSUPER:{name}: Sets the named property on super. Falls back to
@@ -101,7 +101,7 @@ interface Signatures {
                     + "Ljava/lang/Object;" // superObj
                     + "Ljava/lang/Object;" // value
                     + "Lorg/mozilla/javascript/Context;" // cx
-                    + "Lorg/mozilla/javascript/Scriptable;" // scope
+                    + "Lorg/mozilla/javascript/VarScope;" // scope
                     + "Ljava/lang/Object;" // thisObj
                     + ")Ljava/lang/Object;";
 
@@ -114,7 +114,7 @@ interface Signatures {
                     + "D"
                     + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -126,7 +126,7 @@ interface Signatures {
                     + "Ljava/lang/Object;"
                     + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**
@@ -138,7 +138,7 @@ interface Signatures {
                     + "Ljava/lang/Object;" // elem
                     + "Ljava/lang/Object;" // value
                     + "Lorg/mozilla/javascript/Context;" // cx
-                    + "Lorg/mozilla/javascript/Scriptable;" // scope
+                    + "Lorg/mozilla/javascript/VarScope;" // scope
                     + "Ljava/lang/Object;" // this
                     + ")Ljava/lang/Object;";
 
@@ -161,7 +161,7 @@ interface Signatures {
      * uses this same signature.
      */
     String NAME_GET_THIS =
-            "(Lorg/mozilla/javascript/Scriptable;"
+            "(Lorg/mozilla/javascript/VarScope;"
                     + "Lorg/mozilla/javascript/Context;"
                     + ")Lorg/mozilla/javascript/ScriptRuntime$LookupResult;";
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/StringLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/StringLinker.java
@@ -13,7 +13,7 @@ import jdk.dynalink.linker.TypeBasedGuardingDynamicLinker;
 import jdk.dynalink.linker.support.Guards;
 import org.mozilla.javascript.ConsString;
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This linker optimizes a few string operations:
@@ -104,7 +104,7 @@ class StringLinker implements TypeBasedGuardingDynamicLinker {
     }
 
     @SuppressWarnings("unused")
-    private static Object getLength(Object o, Context cx, Scriptable scope) {
+    private static Object getLength(Object o, Context cx, VarScope scope) {
         return ((String) o).length();
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -251,7 +251,7 @@ public class NativeRegExp extends ScriptableObject {
         NativeRegExp proto = NativeRegExpInstantiator.withLanguageVersion(cx.getLanguageVersion());
         proto.re = compileRE(cx, "", null, false);
 
-        return DESCRIPTOR.buildConstructor(cx, scope, proto, sealed);
+        return DESCRIPTOR.buildConstructor(cx, (VarScope) scope, proto, sealed);
     }
 
     static ClassDescriptor.Builder makeCtorBuilder() {
@@ -4371,8 +4371,7 @@ public class NativeRegExp extends ScriptableObject {
         return js_SymbolSplit(cx, s, thisObj, args);
     }
 
-    public static Object regExpExec(
-            Scriptable regexp, String string, Context cx, Scriptable scope) {
+    public static Object regExpExec(Scriptable regexp, String string, Context cx, VarScope scope) {
         // See ECMAScript spec 22.2.7.1
         Object execMethod = ScriptRuntime.getObjectProp(regexp, "exec", cx, scope);
         if (execMethod instanceof Callable) {
@@ -4383,7 +4382,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolMatch(
-            Context cx, Scriptable scope, Object thisScriptable, Object[] args) {
+            Context cx, VarScope scope, Object thisScriptable, Object[] args) {
         // See ECMAScript spec 22.2.6.8
         var thisObj = ScriptableObject.ensureScriptableObject(thisScriptable);
 
@@ -4416,7 +4415,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolSearch(
-            Context cx, Scriptable scope, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.2.6.12
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
@@ -4449,7 +4448,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolMatchAll(
-            Context cx, Scriptable scope, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.2.6.9
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
@@ -4477,7 +4476,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolReplace(
-            Context cx, Scriptable scope, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         if (thisObj instanceof NativeRegExp) {
             var regexp = (NativeRegExp) thisObj;
             var exec = ScriptableObject.getProperty(regexp, "exec");
@@ -4490,7 +4489,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private Object js_SymbolReplaceFast(
-            Context cx, Scriptable scope, NativeRegExp thisObj, Object[] args) {
+            Context cx, VarScope scope, NativeRegExp thisObj, Object[] args) {
         String s = ScriptRuntime.toString(args.length > 0 ? args[0] : Undefined.instance);
         int lengthS = s.length();
         Object replaceValue = args.length > 1 ? args[1] : Undefined.instance;
@@ -4607,7 +4606,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolReplaceSlow(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         // See ECMAScript spec 22.2.6.11
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
@@ -4725,7 +4724,7 @@ public class NativeRegExp extends ScriptableObject {
 
     private static String makeComplexReplacement(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String matched,
             List<?> captures,
             int position,
@@ -4754,7 +4753,7 @@ public class NativeRegExp extends ScriptableObject {
 
     private static String makeSimpleReplacement(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String matched,
             List<?> captures,
             int position,
@@ -4770,7 +4769,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Object js_SymbolSplit(
-            Context cx, Scriptable scope, Object thisObj, Object[] args) {
+            Context cx, VarScope scope, Object thisObj, Object[] args) {
         // See ECMAScript spec 22.2.6.14
         if (!ScriptRuntime.isObject(thisObj)) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(thisObj));
@@ -4817,7 +4816,7 @@ public class NativeRegExp extends ScriptableObject {
 
     private static Object js_SymbolSplitSlow(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Scriptable splitter,
             String s,
             long lim,

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 
 // See ECMAScript spec 22.2.9.1
 public final class NativeRegExpStringIterator extends ES6Iterator {
@@ -55,7 +56,7 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     }
 
     @Override
-    protected boolean isDone(Context cx, Scriptable scope) {
+    protected boolean isDone(Context cx, VarScope scope) {
         // The base class calls _first_ isDone and _then_ nextValue, so we'll just compute the next
         // value here and return it form "nextValue".
         // Also, for non-global regexp, we need to return the first match and then "done" on the
@@ -90,7 +91,7 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     }
 
     @Override
-    protected Object nextValue(Context cx, Scriptable scope) {
+    protected Object nextValue(Context cx, VarScope scope) {
         return next;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigInt64Array.java
@@ -41,7 +41,7 @@ public class NativeBigInt64Array extends NativeBigIntArrayView {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeBigUint64Array.java
@@ -41,7 +41,7 @@ public class NativeBigUint64Array extends NativeBigIntArrayView {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
@@ -40,7 +40,7 @@ public class NativeFloat16Array extends NativeTypedArrayView<Float> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat32Array.java
@@ -40,7 +40,7 @@ public class NativeFloat32Array extends NativeTypedArrayView<Float> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat64Array.java
@@ -40,7 +40,7 @@ public class NativeFloat64Array extends NativeTypedArrayView<Double> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt16Array.java
@@ -39,7 +39,7 @@ public class NativeInt16Array extends NativeTypedArrayView<Short> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt32Array.java
@@ -40,7 +40,7 @@ public class NativeInt32Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeInt8Array.java
@@ -38,7 +38,7 @@ public class NativeInt8Array extends NativeTypedArrayView<Byte> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -238,8 +238,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     // Actual functions
 
-    static void init(
-            Context cx, Scriptable scope, LambdaConstructor constructor, RealThis realThis) {
+    static void init(Context cx, VarScope scope, LambdaConstructor constructor, RealThis realThis) {
         ScopeObject s = (ScopeObject) scope;
         // Where do we store this prototype? Top level scope for now?
 
@@ -327,7 +326,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static void defineMethod(
             LambdaConstructor typedArray,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {
@@ -336,7 +335,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private static void defineMethod(
             LambdaConstructor typedArray,
-            Scriptable scope,
+            VarScope scope,
             SymbolKey key,
             int length,
             SerializableCallable target) {
@@ -383,7 +382,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static NativeArrayBuffer makeArrayBuffer(
-            Context cx, Scriptable scope, int len, int bytesPerElement) {
+            Context cx, VarScope scope, int len, int bytesPerElement) {
         return (NativeArrayBuffer)
                 cx.newObject(
                         scope,
@@ -401,7 +400,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     protected static NativeTypedArrayView<?> js_constructor(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Object[] args,
             TypedArrayConstructable constructable,
             int bytesPerElement) {
@@ -563,7 +562,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         }
     }
 
-    private void setRange(Context cx, Scriptable scope, Scriptable source, double dbloff) {
+    private void setRange(Context cx, VarScope scope, Scriptable source, double dbloff) {
         if (isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
         }
@@ -673,17 +672,17 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     private static String js_toString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         return js_toStringInternal(cx, scope, thisObj, args, false);
     }
 
     private static String js_toLocaleString(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         return js_toStringInternal(cx, scope, thisObj, args, true);
     }
 
     private static String js_toStringInternal(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args, boolean useLocale) {
+            Context cx, VarScope scope, Scriptable thisObj, Object[] args, boolean useLocale) {
         NativeTypedArrayView<?> self = realThis(thisObj);
         if (self.isTypedArrayOutOfBounds()) {
             throw ScriptRuntime.typeErrorById("msg.typed.array.out.of.bounds");
@@ -703,7 +702,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return builder.toString();
     }
 
-    private Object getElemForToString(Context cx, Scriptable scope, int index, boolean useLocale) {
+    private Object getElemForToString(Context cx, VarScope scope, int index, boolean useLocale) {
         var elem = js_get(index);
         if (useLocale) {
             var toLocaleString = ScriptRuntime.getPropAndThis(elem, "toLocaleString", cx, scope);
@@ -1087,7 +1086,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
         return self;
     }
 
-    private Object[] sortTemporaryArray(Context cx, Scriptable scope, Object[] args) {
+    private Object[] sortTemporaryArray(Context cx, VarScope scope, Object[] args) {
         Comparator<Object> comparator;
         if (args.length > 0 && Undefined.instance != args[0]) {
             comparator = ArrayLikeAbstractOperations.getSortComparator(cx, scope, args);

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint16Array.java
@@ -39,7 +39,7 @@ public class NativeUint16Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint32Array.java
@@ -39,7 +39,7 @@ public class NativeUint32Array extends NativeTypedArrayView<Long> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8Array.java
@@ -38,7 +38,7 @@ public class NativeUint8Array extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeUint8ClampedArray.java
@@ -40,7 +40,7 @@ public class NativeUint8ClampedArray extends NativeTypedArrayView<Integer> {
         return CLASS_NAME;
     }
 
-    public static Object init(Context cx, Scriptable scope, boolean sealed) {
+    public static Object init(Context cx, VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,

--- a/rhino/src/test/java/org/mozilla/javascript/NullableArgumentsConversionTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/NullableArgumentsConversionTest.java
@@ -54,16 +54,9 @@ public class NullableArgumentsConversionTest {
         initNullableArgumentsConversionTest(arg, typeTag, isNullable, expectedConvertedArg);
         Utils.runWithAllModes(
                 context -> {
-                    Scriptable scriptable =
-                            new ScriptableObject() {
-                                @Override
-                                public String getClassName() {
-                                    return "";
-                                }
-                            };
+                    var topLevel = context.initStandardObjects();
                     Object convertedArg =
-                            FunctionObject.convertArg(
-                                    context, scriptable, arg, typeTag, isNullable);
+                            FunctionObject.convertArg(context, topLevel, arg, typeTag, isNullable);
 
                     assertThat(convertedArg, is(expectedConvertedArg));
                     return null;

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeConsoleTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeConsoleTest.java
@@ -22,6 +22,7 @@ import org.mozilla.javascript.SecurityUtilities;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 
 /** Test NativeConsole */
 public class NativeConsoleTest {
@@ -81,7 +82,7 @@ public class NativeConsoleTest {
         @Override
         public void print(
                 Context cx,
-                Scriptable scope,
+                VarScope scope,
                 Level level,
                 Object[] args,
                 ScriptStackElement[] stack) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -268,7 +268,7 @@ public class Test262SuiteTest {
         }
 
         public static Object detachArrayBuffer(
-                Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+                Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
             Scriptable buf = ScriptRuntime.toObject(scope, args[0]);
             if (buf instanceof NativeArrayBuffer) {
                 ((NativeArrayBuffer) buf).detach();


### PR DESCRIPTION
Move more internal APIs over to `VarScope`. This is the next commit from #2330.