### PR TITLE
Fourth round of conversions of `Scriptable` to `VarScope`.

### DIFF
--- a/examples/src/main/java/File.java
+++ b/examples/src/main/java/File.java
@@ -135,7 +135,7 @@ public class File extends ScriptableObject {
             list.add(s);
         }
         String[] lines = list.toArray(new String[list.size()]);
-        TopLevel scope = ScriptableObject.getTopLevelScope(this);
+        TopLevel scope = ScriptableObject.getTopLevelScope(getParentScope());
         Context cx = Context.getCurrentContext();
         return cx.newObject(scope, "Array", lines);
     }
@@ -279,7 +279,7 @@ public class File extends ScriptableObject {
         // Here we use javaToJS() to "wrap" the LineNumberReader object
         // in a Scriptable object so that it can be manipulated by
         // JavaScript.
-        VarScope parent = ScriptableObject.getTopLevelScope(this);
+        VarScope parent = ScriptableObject.getTopLevelScope(getParentScope());
         return Context.javaToJS(reader, parent);
     }
 
@@ -297,7 +297,7 @@ public class File extends ScriptableObject {
     @JSFunction
     public Object getWriter() {
         if (writer == null) return null;
-        VarScope parent = ScriptableObject.getTopLevelScope(this);
+        VarScope parent = ScriptableObject.getTopLevelScope(getParentScope());
         return Context.javaToJS(writer, parent);
     }
 

--- a/examples/src/main/java/Matrix.java
+++ b/examples/src/main/java/Matrix.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.VarScope;
 
 /**
@@ -136,7 +137,7 @@ public class Matrix implements Scriptable {
             result = m;
         } else {
             Context cx = Context.getCurrentContext();
-            Scriptable scope = ScriptableObject.getTopLevelScope(start);
+            TopLevel scope = ScriptableObject.getTopLevelScope(parent);
             result = cx.newArray(scope, 0);
         }
         list.set(index, result);

--- a/examples/src/main/java/Shell.java
+++ b/examples/src/main/java/Shell.java
@@ -71,7 +71,7 @@ public class Shell extends ScriptableObject {
                 array = new Object[length];
                 System.arraycopy(args, 1, array, 0, length);
             }
-            Scriptable argsObj = cx.newArray(shell, array);
+            Scriptable argsObj = cx.newArray(topLevel, array);
             shell.defineProperty("arguments", argsObj, ScriptableObject.DONTENUM);
 
             shell.processSource(cx, args.length == 0 ? null : args[0]);
@@ -205,7 +205,7 @@ public class Shell extends ScriptableObject {
      * @param funObj the function object of the invoked JavaScript function
      */
     public static void load(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
-        Shell shell = (Shell) getTopLevelScope(thisObj).getGlobalThis();
+        Shell shell = (Shell) getTopLevelScope(funObj.getDeclarationScope()).getGlobalThis();
         for (int i = 0; i < args.length; i++) {
             shell.processSource(cx, Context.toString(args[i]));
         }

--- a/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
+++ b/rhino-engine/src/main/java/org/mozilla/javascript/engine/Builtins.java
@@ -15,6 +15,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 
 /**
  * This class defines the following built-in functions for the RhinoScriptEngine.
@@ -47,7 +48,7 @@ public class Builtins {
                         ScriptableObject.DONTENUM | ScriptableObject.READONLY);
     }
 
-    private static Object print(Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+    private static Object print(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         try {
             Builtins self = getSelf(scope);
             for (Object arg : args) {
@@ -62,7 +63,7 @@ public class Builtins {
         return Undefined.instance;
     }
 
-    private static Builtins getSelf(Scriptable scope) {
+    private static Builtins getSelf(VarScope scope) {
         // Since this class is invoked as a set of anonymous functions, "this"
         // in JavaScript does not point to "this" in Java. We set a key on the
         // top-level scope to address this.

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ExecUtil.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ExecUtil.java
@@ -14,6 +14,7 @@ import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.Wrapper;
 
 /**
@@ -54,7 +55,7 @@ class ExecUtil {
             out = parseOutput(params, "output");
             err = parseOutput(params, "err");
             timeout = parseTimeout(params);
-            addArgs = parseAddArgs(params, thisObj);
+            addArgs = parseAddArgs(params, global);
             commandExecutor = parseCommandLauncher(params);
         }
 
@@ -188,7 +189,7 @@ class ExecUtil {
         return ScriptRuntime.toInt32(obj);
     }
 
-    private static Object[] parseAddArgs(Scriptable params, Scriptable scope) {
+    private static Object[] parseAddArgs(Scriptable params, VarScope scope) {
         Object obj = ScriptableObject.getProperty(params, "args");
         if (obj == Scriptable.NOT_FOUND) {
             return emptyArray;

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Timers.java
@@ -26,7 +26,7 @@ public class Timers {
      *
      * @param scope the scope where the functions should be defined
      */
-    public void install(Scriptable scope) {
+    public void install(VarScope scope) {
         LambdaFunction setTimeout =
                 new LambdaFunction(
                         scope,

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLObjectImpl.java
@@ -502,7 +502,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_appendChild(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -511,7 +511,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_addNamespace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -521,7 +521,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_childIndex(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -530,7 +530,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_inScopeNamespaces(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -539,7 +539,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_insertChildAfter(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -552,7 +552,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_insertChildBefore(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -565,7 +565,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_localName(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -574,7 +574,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_name(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -583,7 +583,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_namespace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -598,7 +598,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_namespaceDeclarations(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -608,7 +608,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_nodeKind(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -617,7 +617,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_prependChild(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -626,7 +626,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_removeNamespace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -636,7 +636,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_replace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -653,7 +653,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_setChildren(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -662,7 +662,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_setLocalName(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -679,7 +679,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_setName(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -691,7 +691,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_setNamespace(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -702,7 +702,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_attribute(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XML xml = realThis.getXML();
@@ -712,13 +712,13 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_attributes(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.getMatches(XMLName.create(XmlNode.QName.create(null, null), true, false));
     }
 
     private static Object js_child(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
 
         XMLName xmlName = realThis.lib.toXMLNameOrIndex(cx, arg(args, 0));
@@ -732,31 +732,31 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_children(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.children();
     }
 
     private static Object js_comments(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.comments();
     }
 
     private static Object js_contains(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return ScriptRuntime.wrapBoolean(realThis.contains(arg(args, 0)));
     }
 
     private static Object js_copy(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.copy();
     }
 
     private static Object js_descendants(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         XmlNode.QName qname =
                 (args.length == 0)
@@ -766,7 +766,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_elements(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         XMLName xmlName =
                 (args.length == 0) ? XMLName.formStar() : realThis.lib.toXMLName(cx, args[0]);
@@ -774,7 +774,7 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_hasOwnProperty(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         if (realThis.prototypeFlag) {
             return realThis.has((String) args[0], realThis);
@@ -784,38 +784,38 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_hasComplexContent(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return ScriptRuntime.wrapBoolean(realThis.hasComplexContent());
     }
 
     private static Object js_hasSimpleContent(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return ScriptRuntime.wrapBoolean(realThis.hasSimpleContent());
     }
 
     private static Object js_length(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return ScriptRuntime.wrapInt(realThis.length());
     }
 
     private static Object js_normalize(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         realThis.normalize();
         return Undefined.instance;
     }
 
     private static Object js_parent(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.parent();
     }
 
     private static Object js_processingInstructions(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         XMLName xmlName =
                 (args.length > 0) ? realThis.lib.toXMLName(cx, args[0]) : XMLName.formStar();
@@ -823,38 +823,38 @@ abstract class XMLObjectImpl extends XMLObject {
     }
 
     private static Object js_propertyIsEnumerable(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return ScriptRuntime.wrapBoolean(realThis.propertyIsEnumerable(arg(args, 0)));
     }
 
     private static Object js_text(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.text();
     }
 
     private static Object js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.toString();
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         int indent = ScriptRuntime.toInt32(args, 0);
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.toSource(indent);
     }
 
     private static Object js_toXMLString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.toXMLString();
     }
 
     private static Object js_valueOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         XMLObjectImpl realThis = realThis(thisObj, f.getFunctionName());
         return realThis.valueOf();
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -35,7 +35,7 @@ class Arguments extends ScriptableObject {
     public Arguments(NativeCall activation, Context cx) {
         this.activation = activation;
 
-        Scriptable parent = activation.getParentScope();
+        VarScope parent = activation.getParentScope();
         setParentScope(parent);
         setPrototype(ScriptableObject.getObjectPrototype(parent));
 

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -137,7 +137,7 @@ public class ArrayLikeAbstractOperations {
         Object callbackArg = args.length > 0 ? args[0] : Undefined.instance;
 
         Function f = getCallbackArg(cx, callbackArg);
-        TopLevel parent = ScriptableObject.getTopLevelScope(f);
+        TopLevel parent = ScriptableObject.getTopLevelScope(f.getDeclarationScope());
         Scriptable thisArg;
         if (args.length < 2 || args[1] == null || args[1] == Undefined.instance) {
             thisArg = Undefined.SCRIPTABLE_UNDEFINED;
@@ -335,7 +335,7 @@ public class ArrayLikeAbstractOperations {
             throw ScriptRuntime.notFunctionError(callbackArg);
         }
         Function f = (Function) callbackArg;
-        TopLevel parent = ScriptableObject.getTopLevelScope(f);
+        TopLevel parent = ScriptableObject.getTopLevelScope(f.getDeclarationScope());
         // hack to serve both reduce and reduceRight with the same loop
         boolean movingLeft = operation == ReduceOperation.REDUCE;
         Object value = args.length > 1 ? args[1] : NOT_FOUND;

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -90,7 +90,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static void defOnProto(
             LambdaConstructor constructor,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {
@@ -100,7 +100,7 @@ public class BaseFunction extends ScriptableObject implements Function {
     private static void defKnownBuiltInOnProto(
             LambdaConstructor constructor,
             Object tag,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {
@@ -110,7 +110,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
     private static void defOnProto(
             LambdaConstructor constructor,
-            Scriptable scope,
+            VarScope scope,
             SymbolKey name,
             int length,
             SerializableCallable target,
@@ -127,9 +127,9 @@ public class BaseFunction extends ScriptableObject implements Function {
         init(Context.getContext(), scope, sealed);
     }
 
-    static Object initAsGeneratorFunction(Scriptable scope, boolean sealed) {
+    static Object initAsGeneratorFunction(VarScope scope, boolean sealed) {
         var proto = new NativeObject();
-        Scriptable top = ScriptableObject.getTopLevelScope(scope);
+        VarScope top = ScriptableObject.getTopLevelScope(scope);
 
         var function = (Scriptable) ScriptableObject.getProperty(scope, FUNCTION_CLASS);
         var functionProto =
@@ -487,7 +487,7 @@ public class BaseFunction extends ScriptableObject implements Function {
         return js_gen_constructor(cx, scope, args);
     }
 
-    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
         return jsConstructor(cx, scope, args, false);
     }
 
@@ -496,7 +496,7 @@ public class BaseFunction extends ScriptableObject implements Function {
         return js_constructor(cx, scope, args);
     }
 
-    private static Scriptable js_gen_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_gen_constructor(Context cx, VarScope scope, Object[] args) {
         return jsConstructor(cx, scope, args, true);
     }
 
@@ -526,7 +526,7 @@ public class BaseFunction extends ScriptableObject implements Function {
         if (protoVal instanceof Scriptable) {
             return (Scriptable) protoVal;
         }
-        return ScriptableObject.getObjectPrototype(this);
+        return ScriptableObject.getObjectPrototype(getDeclarationScope());
     }
 
     /** Should be overridden. */
@@ -678,7 +678,7 @@ public class BaseFunction extends ScriptableObject implements Function {
         }
     }
 
-    protected synchronized Object setupDefaultPrototype(Scriptable scope) {
+    protected synchronized Object setupDefaultPrototype(VarScope scope) {
         if (!has(PROTOTYPE_PROPERTY_NAME, this)) {
             createPrototypeProperty();
         }
@@ -693,16 +693,16 @@ public class BaseFunction extends ScriptableObject implements Function {
         if (isGeneratorFunction()) {
             // For generator functions, the .prototype property's [[Prototype]]
             // should be %GeneratorPrototype%, not Object.prototype
-            Scriptable top = ScriptableObject.getTopLevelScope(scope);
+            VarScope top = ScriptableObject.getTopLevelScope(scope);
             Object generatorProto =
                     ScriptableObject.getTopScopeValue(top, ES6Generator.GENERATOR_TAG);
             if (generatorProto instanceof Scriptable) {
                 proto = (Scriptable) generatorProto;
             } else {
-                proto = getObjectPrototype(this); // fallback
+                proto = getObjectPrototype(getDeclarationScope()); // fallback
             }
         } else {
-            proto = getObjectPrototype(this);
+            proto = getObjectPrototype(getDeclarationScope());
         }
         if (proto != obj) {
             // not the one we just made, it must remain grounded
@@ -744,7 +744,7 @@ public class BaseFunction extends ScriptableObject implements Function {
     void setArguments(Object caller) {}
 
     private static Scriptable jsConstructor(
-            Context cx, Scriptable scope, Object[] args, boolean isGeneratorFunction) {
+            Context cx, VarScope scope, Object[] args, boolean isGeneratorFunction) {
         int arglen = args.length;
         StringBuilder sourceBuf = new StringBuilder();
 
@@ -779,7 +779,7 @@ public class BaseFunction extends ScriptableObject implements Function {
 
         String sourceURI = ScriptRuntime.makeUrlForGeneratedScript(false, filename, linep[0]);
 
-        Scriptable global = ScriptableObject.getTopLevelScope(scope);
+        TopLevel global = ScriptableObject.getTopLevelScope(scope);
 
         ErrorReporter reporter;
         reporter = DefaultErrorReporter.forEval(cx.getErrorReporter());

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -22,7 +22,7 @@ public class BoundFunction extends BaseFunction {
 
     public BoundFunction(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Callable targetFunction,
             Scriptable boundThis,
             Object[] boundArgs) {

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCache.java
@@ -72,7 +72,7 @@ public class ClassCache implements Serializable {
      *     ClassCache, and cannot have ClassCache associated due to the top scope not being a {@link
      *     ScriptableObject}
      */
-    public static ClassCache get(Scriptable scope) {
+    public static ClassCache get(VarScope scope) {
         ClassCache cache = (ClassCache) ScriptableObject.getTopScopeValue(scope, AKEY);
         if (cache == null) {
             // we expect this to not happen frequently, so computing top scope twice is acceptable

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -40,7 +40,7 @@ import org.mozilla.javascript.ScriptableObject.LambdaSetterFunction;
  *                       .withMethod(PROTO, "valueOf", 0, NativeBoolean::js_valueOf)
  *                       .build();
  *
- *   static void init(Scriptable scope, boolean sealed) {
+ *   static void init(VarScope scope, boolean sealed) {
  *       // Boolean is an unusual object in that the prototype is itself a Boolean
  *       var constructor = DESCRIPTOR.buildConstructor(scope, new NativeBoolean(false), sealed);
  *   }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1245,7 +1245,7 @@ public class Context implements Closeable {
     /**
      * Execute script that may pause execution by capturing a continuation. Caller must be prepared
      * to catch a ContinuationPending exception and resume execution by calling {@link
-     * #resumeContinuation(Object, Scriptable, Object)}.
+     * #resumeContinuation(Object, VarScope, Object)}.
      *
      * @param script The script to execute. Script must have been compiled with interpreted mode
      *     (optimization level -1)
@@ -1266,7 +1266,7 @@ public class Context implements Closeable {
         return callFunctionWithContinuations((JSScript) script, scope);
     }
 
-    public Object executeScriptWithContinuations(Callable callable, Scriptable scope)
+    public Object executeScriptWithContinuations(Callable callable, VarScope scope)
             throws ContinuationPending {
         if (!(callable instanceof JSFunction)
                 || !(((JSFunction) callable).getCode() instanceof InterpreterData)) {
@@ -1281,7 +1281,7 @@ public class Context implements Closeable {
     /**
      * Call function that may pause execution by capturing a continuation. Caller must be prepared
      * to catch a ContinuationPending exception and resume execution by calling {@link
-     * #resumeContinuation(Object, Scriptable, Object)}.
+     * #resumeContinuation(Object, VarScope, Object)}.
      *
      * @param script The script to call. The script must have been compiled with interpreted mode
      *     (optimization level -1)
@@ -1309,7 +1309,7 @@ public class Context implements Closeable {
         return ScriptRuntime.doTopCall(script, this, scope, scope, isStrict);
     }
 
-    public Object callFunctionWithContinuations(Callable callable, Scriptable scope, Object[] args)
+    public Object callFunctionWithContinuations(Callable callable, VarScope scope, Object[] args)
             throws ContinuationPending {
         if (!(callable instanceof JSFunction)
                 || !(((JSFunction) callable).getDescriptor().getCode()
@@ -1326,13 +1326,14 @@ public class Context implements Closeable {
         // Annotate so we can check later to ensure no java code in
         // intervening frames
         isContinuationsTopCall = true;
-        return ScriptRuntime.doTopCall((JSFunction) callable, this, scope, scope, args, isStrict);
+        return ScriptRuntime.doTopCall(
+                (JSFunction) callable, this, scope, Undefined.SCRIPTABLE_UNDEFINED, args, isStrict);
     }
 
     /**
      * Capture a continuation from the current execution. The execution must have been started via a
      * call to {@link #executeScriptWithContinuations(Script, VarScope)} or {@link
-     * #callFunctionWithContinuations(Callable, Scriptable, Object[])}. This implies that the code
+     * #callFunctionWithContinuations(Callable, VarScope, Object[])}. This implies that the code
      * calling this method must have been called as a function from the JavaScript script. Also,
      * there cannot be any non-JavaScript code between the JavaScript frames (e.g., a call to
      * eval()). The ContinuationPending exception returned must be thrown.
@@ -1357,7 +1358,7 @@ public class Context implements Closeable {
      * @throws ContinuationPending if another continuation is captured before the code terminates
      * @since 1.7 Release 2
      */
-    public Object resumeContinuation(Object continuation, Scriptable scope, Object functionResult)
+    public Object resumeContinuation(Object continuation, VarScope scope, Object functionResult)
             throws ContinuationPending {
         Object[] args = {functionResult};
         return Interpreter.restartContinuation(
@@ -1515,12 +1516,12 @@ public class Context implements Closeable {
      * @see org.mozilla.javascript.Function
      */
     public final Function compileFunction(
-            Scriptable scope, String source, String sourceName, int lineno, Object securityDomain) {
+            VarScope scope, String source, String sourceName, int lineno, Object securityDomain) {
         return compileFunction(scope, source, null, null, sourceName, lineno, securityDomain);
     }
 
     final Function compileFunction(
-            Scriptable scope,
+            VarScope scope,
             String source,
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
@@ -1655,7 +1656,7 @@ public class Context implements Closeable {
      *     dynamically).
      * @return the new array object
      */
-    public Scriptable newArray(Scriptable scope, int length) {
+    public Scriptable newArray(VarScope scope, int length) {
         NativeArray result = new NativeArray(length);
         ScriptRuntime.setBuiltinProtoAndParent(result, scope, TopLevel.Builtins.Array);
         return result;
@@ -1669,7 +1670,7 @@ public class Context implements Closeable {
      *     JavaScript type and type of array should be exactly Object[], not SomeObjectSubclass[].
      * @return the new array object.
      */
-    public Scriptable newArray(Scriptable scope, Object[] elements) {
+    public Scriptable newArray(VarScope scope, Object[] elements) {
         if (elements.getClass().getComponentType() != ScriptRuntime.ObjectClass)
             throw new IllegalArgumentException();
         NativeArray result = new NativeArray(elements);
@@ -2540,7 +2541,7 @@ public class Context implements Closeable {
     }
 
     protected Object compileImpl(
-            Scriptable scope,
+            VarScope scope,
             String sourceString,
             String sourceName,
             int lineno,

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Generator.java
@@ -60,11 +60,11 @@ public final class ES6Generator extends ScriptableObject {
     /** Only for constructing the prototype object. */
     private ES6Generator() {}
 
-    public ES6Generator(Scriptable scope, JSFunction function, Object savedState) {
+    public ES6Generator(VarScope scope, JSFunction function, Object savedState) {
         this.function = function;
         this.savedState = savedState;
         // Set parent and prototype properties.
-        Scriptable top = ScriptableObject.getTopLevelScope(scope);
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
         this.setParentScope(top);
         // Per ES6 spec, generator instance's [[Prototype]] should be
         // the generator function's .prototype property.

--- a/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ES6Iterator.java
@@ -52,12 +52,12 @@ public abstract class ES6Iterator extends ScriptableObject {
 
     protected ES6Iterator() {}
 
-    protected ES6Iterator(Scriptable scope, String tag) {
+    protected ES6Iterator(VarScope scope, String tag) {
         // Set parent and prototype properties. Since we don't have a
         // "Iterator" constructor in the top scope, we stash the
         // prototype in the top scope's associated value.
         this.tag = tag;
-        Scriptable top = ScriptableObject.getTopLevelScope(scope);
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
         this.setParentScope(top);
         ScriptableObject prototype = (ScriptableObject) ScriptableObject.getTopScopeValue(top, tag);
         setPrototype(prototype);

--- a/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
@@ -39,7 +39,7 @@ public interface Evaluator {
      * @return Function object that can be called
      */
     public Function createFunctionObject(
-            Context cx, Scriptable scope, Object bytecode, Object staticSecurityDomain);
+            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain);
 
     /**
      * Create a script object.

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionObject.java
@@ -293,7 +293,7 @@ public class FunctionObject extends BaseFunction {
      * @see org.mozilla.javascript.Scriptable#setPrototype
      * @see org.mozilla.javascript.Scriptable#getClassName
      */
-    public void addAsConstructor(Scriptable scope, Scriptable prototype) {
+    public void addAsConstructor(VarScope scope, Scriptable prototype) {
         initAsConstructor(
                 scope,
                 prototype,
@@ -315,12 +315,12 @@ public class FunctionObject extends BaseFunction {
      * @see org.mozilla.javascript.Scriptable#setPrototype
      * @see org.mozilla.javascript.Scriptable#getClassName
      */
-    public void addAsConstructor(Scriptable scope, Scriptable prototype, int attributes) {
+    public void addAsConstructor(VarScope scope, Scriptable prototype, int attributes) {
         initAsConstructor(scope, prototype, attributes);
         defineProperty(scope, prototype.getClassName(), this, ScriptableObject.DONTENUM);
     }
 
-    void initAsConstructor(Scriptable scope, Scriptable prototype, int attributes) {
+    void initAsConstructor(VarScope scope, Scriptable prototype, int attributes) {
         ScriptRuntime.setFunctionProtoAndParent(this, Context.getCurrentContext(), scope);
         setImmunePrototypeProperty(prototype);
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -132,7 +132,8 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
                                 + "initialize id="
                                 + constructorId);
             }
-            constructor.initFunction(obj.getClassName(), ScriptableObject.getTopLevelScope(obj));
+            constructor.initFunction(
+                    obj.getClassName(), ScriptableObject.getTopLevelScope(obj.getParentScope()));
             constructor.markAsConstructor(obj);
             return constructor;
         }
@@ -719,7 +720,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     public final IdFunctionObject exportAsJSClass(
-            int maxPrototypeId, Scriptable scope, boolean sealed) {
+            int maxPrototypeId, VarScope scope, boolean sealed) {
         // Set scope and prototype unless this is top level scope itself
         if (scope != this && scope != null) {
             setParentScope(scope);
@@ -757,7 +758,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 
     public final IdFunctionObject initPrototypeMethod(
             Object tag, int id, String propertyName, String functionName, int arity) {
-        VarScope scope = ScriptableObject.getTopLevelScope(this);
+        VarScope scope = ScriptableObject.getTopLevelScope(this.getParentScope());
         IdFunctionObject function =
                 newIdFunction(
                         tag, id, functionName != null ? functionName : propertyName, arity, scope);
@@ -767,7 +768,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 
     public final IdFunctionObject initPrototypeMethod(
             Object tag, int id, Symbol key, String functionName, int arity) {
-        VarScope scope = ScriptableObject.getTopLevelScope(this);
+        VarScope scope = ScriptableObject.getTopLevelScope(this.getParentScope());
         IdFunctionObject function = newIdFunction(tag, id, functionName, arity, scope);
         prototypeValues.initValue(id, key, function, DONTENUM);
         return function;
@@ -775,7 +776,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 
     public final IdFunctionObject initPrototypeMethod(
             Object tag, int id, Symbol key, String functionName, int arity, int attributes) {
-        VarScope scope = ScriptableObject.getTopLevelScope(this);
+        VarScope scope = ScriptableObject.getTopLevelScope(this.getParentScope());
         IdFunctionObject function = newIdFunction(tag, id, functionName, arity, scope);
         prototypeValues.initValue(id, key, function, attributes);
         return function;
@@ -815,7 +816,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
 
     protected void addIdFunctionProperty(
             Scriptable obj, Object tag, int id, String name, int arity) {
-        VarScope scope = ScriptableObject.getTopLevelScope(obj);
+        VarScope scope = ScriptableObject.getTopLevelScope(obj.getParentScope());
         IdFunctionObject f = newIdFunction(tag, id, name, arity, scope);
         f.addAsProperty(obj);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
@@ -225,7 +225,7 @@ public class ImporterTopLevel extends TopLevel {
     }
 
     private static Object js_importClass(
-            Context cx, Function f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, Function f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (Undefined.isUndefined(thisObj)) {
             thisObj = ScriptableObject.getTopLevelScope(s).getGlobalThis();
         }
@@ -240,7 +240,7 @@ public class ImporterTopLevel extends TopLevel {
     }
 
     private static Object js_importPackage(
-            Context cx, Function f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, Function f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (Undefined.isUndefined(thisObj)) {
             thisObj = ScriptableObject.getTopLevelScope(s).getGlobalThis();
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -755,7 +755,7 @@ public final class Interpreter extends Icode implements Evaluator {
     @Override
     @SuppressWarnings("unchecked")
     public Function createFunctionObject(
-            Context cx, Scriptable scope, Object bytecode, Object staticSecurityDomain) {
+            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain) {
         var compilerResult = (CompilationResult<JSFunction>) bytecode;
         return JSFunction.createFunction(
                 cx,
@@ -1164,7 +1164,7 @@ public final class Interpreter extends Icode implements Evaluator {
         return desc.getRawSource();
     }
 
-    private static void initFunction(Context cx, Scriptable scope, JSDescriptor parent, int index) {
+    private static void initFunction(Context cx, VarScope scope, JSDescriptor parent, int index) {
         JSFunction fn;
         fn = JSFunction.createFunction(cx, scope, parent, index, null);
         var desc = fn.getDescriptor();
@@ -1270,7 +1270,7 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     public static Object restartContinuation(
-            NativeContinuation c, Context cx, Scriptable scope, Object[] args) {
+            NativeContinuation c, Context cx, VarScope scope, Object[] args) {
         if (!ScriptRuntime.hasTopCall(cx)) {
             return ScriptRuntime.doTopCall(c, cx, scope, null, args, cx.isStrictMode());
         }

--- a/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
@@ -15,7 +15,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
 
     public JSFunction(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             JSDescriptor<JSFunction> descriptor,
             Scriptable lexicalThis,
             Scriptable homeObject) {
@@ -29,7 +29,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     }
 
     JSFunction(
-            Scriptable scope,
+            VarScope scope,
             JSDescriptor<JSFunction> descriptor,
             Scriptable lexicalThis,
             Scriptable homeObject) {
@@ -232,7 +232,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     /** Create function compiled from Function(...) constructor. */
     public static JSFunction createFunction(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             JSDescriptor<JSFunction> desc,
             Scriptable homeObject,
             Object staticSecurityDomain) {
@@ -243,11 +243,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
 
     /** Create function embedded in script or another function. */
     static JSFunction createFunction(
-            Context cx,
-            Scriptable scope,
-            JSDescriptor<?> parent,
-            int index,
-            Scriptable homeObject) {
+            Context cx, VarScope scope, JSDescriptor<?> parent, int index, Scriptable homeObject) {
         JSDescriptor<JSFunction> desc = parent.getFunction(index);
         JSFunction f = new JSFunction(cx, scope, desc, null, homeObject);
         return f;

--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -79,7 +79,7 @@ public final class JavaAdapter {
     }
 
     public static Scriptable createAdapterWrapper(Scriptable obj, Object adapter) {
-        Scriptable scope = ScriptableObject.getTopLevelScope(obj);
+        Scriptable scope = ScriptableObject.getTopLevelScope(obj.getParentScope());
         NativeJavaObject res = new NativeJavaObject(scope, adapter, TypeInfo.NONE, true);
         res.setPrototype(obj);
         return res;
@@ -91,7 +91,7 @@ public final class JavaAdapter {
         return self.get(adapter);
     }
 
-    static Scriptable js_createAdapter(Context cx, Scriptable scope, Object[] args) {
+    static Scriptable js_createAdapter(Context cx, VarScope scope, Object[] args) {
         int N = args.length;
         if (N == 0) {
             throw ScriptRuntime.typeErrorById("msg.adapter.zero.args");
@@ -261,7 +261,7 @@ public final class JavaAdapter {
         Scriptable delegee = (Scriptable) in.readObject();
         sig.names = getObjectFunctionNames(delegee);
 
-        Class<?> adapterClass = getAdapterClass(self, sig);
+        Class<?> adapterClass = getAdapterClass(self.getParentScope(), sig);
 
         Class<?>[] ctorParms = {
             ScriptRuntime.ContextFactoryClass,
@@ -299,7 +299,7 @@ public final class JavaAdapter {
         return map;
     }
 
-    private static Class<?> getAdapterClass(Scriptable scope, JavaAdapterSignature sig) {
+    private static Class<?> getAdapterClass(VarScope scope, JavaAdapterSignature sig) {
         ClassCache cache = ClassCache.get(scope);
         Map<JavaAdapterSignature, Class<?>> generated = cache.getInterfaceAdapterCacheMap();
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -146,7 +146,13 @@ class JavaMembers {
         return cx.getWrapFactory().wrap(cx, ScriptableObject.getTopLevelScope(scope), got, type);
     }
 
-    void put(Scriptable scope, String name, Object javaObject, Object value, boolean isStatic) {
+    void put(
+            Scriptable obj,
+            VarScope scope,
+            String name,
+            Object javaObject,
+            Object value,
+            boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = ht.get(name);
         if (!isStatic && member == null) {
@@ -165,18 +171,14 @@ class JavaMembers {
             if (bp.setter == null) {
                 throw reportMemberNotFound(name);
             }
-            bp.setter.call(
-                    Context.getContext(),
-                    ScriptableObject.getTopLevelScope(scope),
-                    scope,
-                    new Object[] {value});
+            bp.setter.call(Context.getContext(), scope, obj, new Object[] {value});
         } else if (member instanceof NativeJavaField) {
             var field = (NativeJavaField) member;
             var type = field.type();
-            if (scope instanceof NativeJavaObject) {
+            if (obj instanceof NativeJavaObject) {
                 type =
                         TypeInfoFactory.GLOBAL.consolidateType(
-                                type, ((NativeJavaObject) scope).staticType);
+                                type, ((NativeJavaObject) obj).staticType);
             }
             try {
                 field.set(javaObject, Context.jsToJava(value, type));
@@ -284,7 +286,7 @@ class JavaMembers {
     }
 
     private Object getExplicitFunction(
-            Scriptable scope, String name, Object javaObject, boolean isStatic) {
+            VarScope scope, String name, Object javaObject, boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = null;
         var methodOrCtor = findExplicitFunction(name, isStatic);
@@ -782,7 +784,7 @@ class JavaMembers {
     }
 
     Map<String, FieldAndMethods> getFieldAndMethodsObjects(
-            Scriptable scope, Object javaObject, boolean isStatic) {
+            VarScope scope, Object javaObject, boolean isStatic) {
         var ht = isStatic ? staticFieldAndMethods : fieldAndMethods;
 
         var expectedCapacity = (int) Math.ceil(ht.size() / 0.75);
@@ -797,7 +799,7 @@ class JavaMembers {
     }
 
     static JavaMembers lookupClass(
-            Scriptable scope, Class<?> dynamicType, Class<?> staticType, boolean includeProtected) {
+            VarScope scope, Class<?> dynamicType, Class<?> staticType, boolean includeProtected) {
         JavaMembers members;
         ClassCache cache = ClassCache.get(scope);
         Map<ClassCache.CacheKey, JavaMembers> ct = cache.getClassCacheMap();
@@ -913,7 +915,7 @@ final class BeanProperty {
 class FieldAndMethods extends NativeJavaMethod {
     private static final long serialVersionUID = -9222428244284796755L;
 
-    FieldAndMethods(Scriptable scope, ExecutableOverload.WithField withField) {
+    FieldAndMethods(VarScope scope, ExecutableOverload.WithField withField) {
         super(withField.methods, withField.name);
         this.field = withField.field;
         setParentScope(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/KnownBuiltInFunction.java
@@ -29,7 +29,7 @@ public class KnownBuiltInFunction extends LambdaFunction {
      */
     public KnownBuiltInFunction(
             Object tag,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -129,7 +129,7 @@ public class LambdaAccessorSlot extends Slot<Scriptable> {
         return super.getValue(owner);
     }
 
-    public void setGetter(Scriptable scope, ScriptableObject.LambdaGetterFunction getter) {
+    public void setGetter(VarScope scope, ScriptableObject.LambdaGetterFunction getter) {
         this.getter = getter;
         if (getter != null) {
             this.getterFunction =
@@ -142,7 +142,7 @@ public class LambdaAccessorSlot extends Slot<Scriptable> {
         }
     }
 
-    public void setSetter(Scriptable scope, ScriptableObject.LambdaSetterFunction setter) {
+    public void setSetter(VarScope scope, ScriptableObject.LambdaSetterFunction setter) {
         this.setter = setter;
         if (setter != null) {
             this.setterFunction =

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaConstructor.java
@@ -49,7 +49,7 @@ public class LambdaConstructor extends LambdaFunction {
      *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
-            Scriptable scope, String name, int length, SerializableConstructable target) {
+            VarScope scope, String name, int length, SerializableConstructable target) {
         super(scope, name, length, null);
         this.targetConstructor = target;
         this.flags = CONSTRUCTOR_DEFAULT;
@@ -70,11 +70,7 @@ public class LambdaConstructor extends LambdaFunction {
      *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
-            Scriptable scope,
-            String name,
-            int length,
-            int flags,
-            SerializableConstructable target) {
+            VarScope scope, String name, int length, int flags, SerializableConstructable target) {
         super(scope, name, length, null);
         this.targetConstructor = target;
         this.flags = flags;
@@ -96,7 +92,7 @@ public class LambdaConstructor extends LambdaFunction {
      *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaConstructor(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -109,7 +105,7 @@ public class LambdaConstructor extends LambdaFunction {
     }
 
     public LambdaConstructor(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,
@@ -159,7 +155,7 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope, String name, int length, SerializableCallable target) {
+            VarScope scope, String name, int length, SerializableCallable target) {
         definePrototypeMethod(scope, name, length, target, DONTENUM, DONTENUM | READONLY);
     }
 
@@ -168,7 +164,7 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -185,12 +181,12 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope, SymbolKey name, int length, SerializableCallable target) {
+            VarScope scope, SymbolKey name, int length, SerializableCallable target) {
         definePrototypeMethod(scope, name, length, target, DONTENUM, DONTENUM | READONLY);
     }
 
     public void definePrototypeMethod(
-            Scriptable scope,
+            VarScope scope,
             SymbolKey name,
             int length,
             SerializableCallable target,
@@ -203,7 +199,7 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope,
+            VarScope scope,
             SymbolKey name,
             int length,
             SerializableCallable target,
@@ -221,7 +217,7 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,
@@ -240,7 +236,7 @@ public class LambdaConstructor extends LambdaFunction {
      */
     public void defineKnownBuiltInPrototypeMethod(
             Object tag,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,
@@ -259,7 +255,7 @@ public class LambdaConstructor extends LambdaFunction {
      * the covers.
      */
     public void definePrototypeMethod(
-            Scriptable scope,
+            VarScope scope,
             SymbolKey name,
             int length,
             Object prototype,
@@ -395,7 +391,7 @@ public class LambdaConstructor extends LambdaFunction {
      * @param target the target to call when the method is invoked
      */
     public void defineConstructorMethod(
-            Scriptable scope, String name, int length, SerializableCallable target) {
+            VarScope scope, String name, int length, SerializableCallable target) {
         defineConstructorMethod(scope, name, length, target, DONTENUM, DONTENUM | READONLY);
     }
 
@@ -409,7 +405,7 @@ public class LambdaConstructor extends LambdaFunction {
      * @param target the target to call when the method is invoked
      */
     public void defineConstructorMethod(
-            Scriptable scope, Symbol key, String name, int length, SerializableCallable target) {
+            VarScope scope, Symbol key, String name, int length, SerializableCallable target) {
         defineConstructorMethod(scope, name, length, target);
     }
 
@@ -419,7 +415,7 @@ public class LambdaConstructor extends LambdaFunction {
      * properties.
      */
     public void defineConstructorMethod(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -436,7 +432,7 @@ public class LambdaConstructor extends LambdaFunction {
      * "protoyupe" properties.
      */
     public void defineConstructorMethod(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,
@@ -456,7 +452,7 @@ public class LambdaConstructor extends LambdaFunction {
     public void setPrototypeScriptable(ScriptableObject proto) {
         proto.setParentScope(getDeclarationScope());
         setPrototypeProperty(proto);
-        Scriptable objectProto = getObjectPrototype(this);
+        Scriptable objectProto = getObjectPrototype(getDeclarationScope());
         if (proto != objectProto) {
             // not the one we just made, it must remain grounded
             proto.setPrototype(objectProto);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaFunction.java
@@ -33,7 +33,7 @@ public class LambdaFunction extends BaseFunction {
      * @param defaultPrototype set up a prototype on the new function
      */
     public LambdaFunction(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -57,7 +57,7 @@ public class LambdaFunction extends BaseFunction {
      * @param target an object that implements the function in Java. Since Callable is a
      *     single-function interface this will typically be implemented as a lambda.
      */
-    public LambdaFunction(Scriptable scope, String name, int length, SerializableCallable target) {
+    public LambdaFunction(VarScope scope, String name, int length, SerializableCallable target) {
         this(scope, name, length, target, true);
     }
 
@@ -73,7 +73,7 @@ public class LambdaFunction extends BaseFunction {
      *     single-function interface this will typically be implemented as a lambda.
      */
     public LambdaFunction(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             Object prototype,
@@ -86,7 +86,7 @@ public class LambdaFunction extends BaseFunction {
     }
 
     /** Create a new built-in function, with no name, and no default prototype. */
-    public LambdaFunction(Scriptable scope, int length, SerializableCallable target) {
+    public LambdaFunction(VarScope scope, int length, SerializableCallable target) {
         this.target = target;
         this.length = length;
         this.name = "";

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
@@ -35,7 +35,7 @@ final class NativeBoolean extends ScriptableObject {
 
     private final boolean booleanValue;
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
+    static void init(Context cx, VarScope scope, boolean sealed) {
         // Boolean is an unusual object in that the prototype is itself a Boolean
         DESCRIPTOR.buildConstructor(cx, (VarScope) scope, new NativeBoolean(false), sealed);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
@@ -15,7 +15,7 @@ public class NativeCallSite extends IdScriptableObject {
     private static final String CALLSITE_TAG = "CallSite";
     private ScriptStackElement element;
 
-    static void init(Scriptable scope, boolean sealed) {
+    static void init(VarScope scope, boolean sealed) {
         NativeCallSite cs = new NativeCallSite();
         cs.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCollectionIterator.java
@@ -29,7 +29,7 @@ public class NativeCollectionIterator extends ES6Iterator {
     }
 
     public NativeCollectionIterator(
-            Scriptable scope, String className, Type type, Iterator<Hashtable.Entry> iterator) {
+            VarScope scope, String className, Type type, Iterator<Hashtable.Entry> iterator) {
         super(scope, className);
         this.className = className;
         this.iterator = iterator;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeConsole.java
@@ -42,7 +42,7 @@ public class NativeConsole extends ScriptableObject {
                 Context cx, VarScope scope, Level level, Object[] args, ScriptStackElement[] stack);
     }
 
-    public static void init(Scriptable scope, boolean sealed, ConsolePrinter printer) {
+    public static void init(VarScope scope, boolean sealed, ConsolePrinter printer) {
         NativeConsole obj = new NativeConsole(printer);
         obj.setPrototype(getObjectPrototype(scope));
         obj.setParentScope(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -80,8 +80,8 @@ final class NativeError extends ScriptableObject {
         return js_isError(args);
     }
 
-    static void init(Context cx, Scriptable scope, boolean sealed) {
-        var ctor = DESCRIPTOR.buildConstructor(cx, (VarScope) scope, new NativeObject(), sealed);
+    static void init(Context cx, VarScope scope, boolean sealed) {
+        var ctor = DESCRIPTOR.buildConstructor(cx, scope, new NativeObject(), sealed);
         NativeCallSite.init(scope, sealed);
 
         ProtoProps protoProps = new ProtoProps();

--- a/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeFunction.java
@@ -21,7 +21,7 @@ public abstract class NativeFunction extends BaseFunction {
     private boolean isShorthand;
 
     public final void initScriptFunction(
-            Context cx, Scriptable scope, boolean es6GeneratorFunction, boolean isShorthand) {
+            Context cx, VarScope scope, boolean es6GeneratorFunction, boolean isShorthand) {
         ScriptRuntime.setFunctionProtoAndParent(this, cx, scope, es6GeneratorFunction);
         if (!isShorthand) { // Methods don't have the prototype property!
             setupDefaultPrototype(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGenerator.java
@@ -46,13 +46,13 @@ public final class NativeGenerator extends IdScriptableObject {
     /** Only for constructing the prototype object. */
     private NativeGenerator() {}
 
-    public NativeGenerator(Scriptable scope, JSFunction function, Object savedState) {
+    public NativeGenerator(VarScope scope, JSFunction function, Object savedState) {
         this.function = function;
         this.savedState = savedState;
         // Set parent and prototype properties. Since we don't have a
         // "Generator" constructor in the top scope, we stash the
         // prototype in the top scope's associated value.
-        Scriptable top = ScriptableObject.getTopLevelScope(scope);
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
         this.setParentScope(top);
         NativeGenerator prototype =
                 (NativeGenerator) ScriptableObject.getTopScopeValue(top, GENERATOR_TAG);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -70,7 +70,7 @@ public class NativeGlobal implements Serializable {
                 continue;
             }
             String name = error.name();
-            Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+            TopLevel topLevelScope = ScriptableObject.getTopLevelScope(scope);
             Function builtinErrorCtor =
                     TopLevel.getBuiltinCtor(cx, topLevelScope, TopLevel.Builtins.Error);
             ScriptableObject errorProto = NativeError.makeProto(topLevelScope, builtinErrorCtor);
@@ -138,7 +138,7 @@ public class NativeGlobal implements Serializable {
     }
 
     private static void defineGlobalFunction(
-            Scriptable scope,
+            VarScope scope,
             boolean sealed,
             String name,
             int length,
@@ -156,7 +156,7 @@ public class NativeGlobal implements Serializable {
     }
 
     // Eval is special because we need to "recognize" it in isEvalFunction
-    private static void defineGlobalFunctionEval(Scriptable scope, boolean sealed) {
+    private static void defineGlobalFunctionEval(VarScope scope, boolean sealed) {
         LambdaFunction evalFun = new EvalLambdaFunction(scope);
         registerGlobalFunction(scope, sealed, "eval", evalFun);
     }
@@ -746,7 +746,7 @@ public class NativeGlobal implements Serializable {
      * in {@link NativeGlobal#isEvalFunction}
      */
     private static class EvalLambdaFunction extends LambdaFunction {
-        public EvalLambdaFunction(Scriptable scope) {
+        public EvalLambdaFunction(VarScope scope) {
             super(
                     scope,
                     "eval",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeIterator.java
@@ -80,8 +80,8 @@ public final class NativeIterator extends ScriptableObject {
      * @param scope a scope whose parent chain reaches a top-level scope
      * @return the StopIteration object
      */
-    public static Object getStopIterationObject(Scriptable scope) {
-        Scriptable top = ScriptableObject.getTopLevelScope(scope);
+    public static Object getStopIterationObject(VarScope scope) {
+        TopLevel top = ScriptableObject.getTopLevelScope(scope);
         return ScriptableObject.getTopScopeValue(top, ITERATOR_TAG);
     }
 
@@ -196,7 +196,7 @@ public final class NativeIterator extends ScriptableObject {
         return LambdaConstructor.convertThisObject(thisObj, NativeIterator.class);
     }
 
-    private Object next(Context cx, Scriptable scope) {
+    private Object next(Context cx, VarScope scope) {
         Boolean b = ScriptRuntime.enumNext(this.objectIterator, cx);
         if (!b) {
             // Out of values. Throw StopIteration.
@@ -222,9 +222,9 @@ public final class NativeIterator extends ScriptableObject {
 
     public static class WrappedJavaIterator {
         private final Iterator<?> iterator;
-        private final Scriptable scope;
+        private final VarScope scope;
 
-        WrappedJavaIterator(Iterator<?> iterator, Scriptable scope) {
+        WrappedJavaIterator(Iterator<?> iterator, VarScope scope) {
             this.iterator = iterator;
             this.scope = scope;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -43,7 +43,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     protected void initMembers() {
         Class<?> cl = (Class<?>) javaObject;
         members = JavaMembers.lookupClass(parent, cl, cl, isAdapter);
-        staticFieldAndMethods = members.getFieldAndMethodsObjects(this, cl, true);
+        staticFieldAndMethods = members.getFieldAndMethodsObjects(parent, cl, true);
     }
 
     @Override
@@ -74,7 +74,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         }
 
         Context cx = Context.getContext();
-        VarScope scope = ScriptableObject.getTopLevelScope(start);
+        VarScope scope = ScriptableObject.getTopLevelScope(parent);
         WrapFactory wrapFactory = cx.getWrapFactory();
 
         if (javaClassPropertyName.equals(name)) {
@@ -95,7 +95,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
 
     @Override
     public void put(String name, Scriptable start, Object value) {
-        members.put(this, name, javaObject, value, true);
+        members.put(this, parent, name, javaObject, value, true);
     }
 
     @Override
@@ -153,7 +153,7 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         if (args.length == 0) {
             throw Context.reportRuntimeErrorById("msg.adapter.zero.args");
         }
-        VarScope topLevel = ScriptableObject.getTopLevelScope(this);
+        VarScope topLevel = ScriptableObject.getTopLevelScope(parent);
         String msg = "";
         try {
             // When running on Android create an InterfaceAdapter since our

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMap.java
@@ -35,7 +35,7 @@ public class NativeJavaMap extends NativeJavaObject {
     }
 
     @SuppressWarnings("unchecked")
-    public NativeJavaMap(Scriptable scope, Object map, TypeInfo staticType) {
+    public NativeJavaMap(VarScope scope, Object map, TypeInfo staticType) {
         super(scope, map, staticType);
         assert map instanceof Map;
         this.map = (Map<Object, Object>) map;
@@ -180,7 +180,7 @@ public class NativeJavaMap extends NativeJavaObject {
             super();
         }
 
-        NativeJavaMapIterator(Scriptable scope, NativeJavaMap map) {
+        NativeJavaMapIterator(VarScope scope, NativeJavaMap map) {
             super(scope, ITERATOR_TAG);
             this.iterator = map.map.entrySet().iterator();
             this.keyType = map.keyType;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -112,7 +112,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         // prototype. Since we can't add a property to a Java object,
         // we modify it in the prototype rather than copy it down.
         if (prototype == null || members.has(name, false))
-            members.put(this, name, javaObject, value, false);
+            members.put(this, parent, name, javaObject, value, false);
         else prototype.put(name, prototype, value);
     }
 
@@ -123,7 +123,7 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
         // we modify it in the prototype rather than copy it down.
         String name = symbol.toString();
         if (prototype == null || members.has(name, false)) {
-            members.put(this, name, javaObject, value, false);
+            members.put(this, parent, name, javaObject, value, false);
         } else if (prototype instanceof SymbolScriptable) {
             ((SymbolScriptable) prototype).put(symbol, prototype, value);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaPackage.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaPackage.java
@@ -83,7 +83,7 @@ public class NativeJavaPackage extends ScriptableObject {
 
     // set up a name which is known to be a package so we don't
     // need to look for a class by that name
-    NativeJavaPackage forcePackage(String name, Scriptable scope) {
+    NativeJavaPackage forcePackage(String name, VarScope scope) {
         Object cached = super.get(name, this);
         if (cached != null && cached instanceof NativeJavaPackage) {
             return (NativeJavaPackage) cached;
@@ -116,7 +116,7 @@ public class NativeJavaPackage extends ScriptableObject {
             }
             if (cl != null) {
                 WrapFactory wrapFactory = cx.getWrapFactory();
-                newValue = wrapFactory.wrapJavaClass(cx, getTopLevelScope(this), cl);
+                newValue = wrapFactory.wrapJavaClass(cx, getTopLevelScope(getParentScope()), cl);
                 newValue.setPrototype(getPrototype());
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeMap.java
@@ -167,7 +167,7 @@ public class NativeMap extends ScriptableObject {
         return realThis(thisObj, "entries").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
     }
 
-    private Object js_iterator(Scriptable scope, NativeCollectionIterator.Type type) {
+    private Object js_iterator(VarScope scope, NativeCollectionIterator.Type type) {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -36,7 +36,7 @@ final class NativeNumber extends ScriptableObject {
 
     private final double doubleValue;
 
-    static void init(Scriptable scope, boolean sealed) {
+    static void init(VarScope scope, boolean sealed) {
         LambdaConstructor constructor =
                 new LambdaConstructor(
                         scope,
@@ -91,11 +91,11 @@ final class NativeNumber extends ScriptableObject {
                 DONTENUM,
                 DONTENUM | READONLY);
 
-        Object parseFloat = ScriptRuntime.getTopLevelProp(constructor, "parseFloat");
+        Object parseFloat = ScriptRuntime.getTopLevelProp(scope, "parseFloat");
         if (parseFloat instanceof Function) {
             constructor.defineProperty("parseFloat", parseFloat, DONTENUM);
         }
-        Object parseInt = ScriptRuntime.getTopLevelProp(constructor, "parseInt");
+        Object parseInt = ScriptRuntime.getTopLevelProp(scope, "parseInt");
         if (parseInt instanceof Function) {
             constructor.defineProperty("parseInt", parseInt, DONTENUM);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -94,7 +94,7 @@ public class NativeObject extends ScriptableObject implements Map {
                         .build();
     }
 
-    static JSFunction init(Context cx, Scriptable s, boolean sealed) {
+    static JSFunction init(Context cx, VarScope s, boolean sealed) {
         var desc = cx.version >= Context.VERSION_ES6 ? ES6_DESCRIPTOR : LEGACY_DESCRIPTOR;
         return desc.buildConstructor(cx, (VarScope) s, new NativeObject(), sealed);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativePromise.java
@@ -585,7 +585,7 @@ public class NativePromise extends ScriptableObject {
         LambdaFunction resolve;
         LambdaFunction reject;
 
-        ResolvingFunctions(Scriptable topScope, NativePromise promise) {
+        ResolvingFunctions(VarScope topScope, NativePromise promise) {
             resolve =
                     new LambdaFunction(
                             topScope,

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -1224,7 +1224,7 @@ class NativeProxy extends ScriptableObject {
         target.setPrototype(prototype);
     }
 
-    private static NativeProxy constructor(Context cx, Scriptable scope, Object[] args) {
+    private static NativeProxy constructor(Context cx, VarScope scope, Object[] args) {
         if (args.length < 2) {
             throw ScriptRuntime.typeErrorById(
                     "msg.method.missing.parameter",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeScript.java
@@ -57,7 +57,7 @@ class NativeScript extends BaseFunction {
 
     private static void defineMethod(
             LambdaConstructor typedArray,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {
@@ -139,7 +139,7 @@ class NativeScript extends BaseFunction {
         return js_constructor(cx, scope, args);
     }
 
-    private static Scriptable js_constructor(Context cx, Scriptable scope, Object[] args) {
+    private static Scriptable js_constructor(Context cx, VarScope scope, Object[] args) {
         String source = (args.length == 0) ? "" : ScriptRuntime.toString(args[0]);
         Script script = compile(cx, source);
         NativeScript nscript = new NativeScript(script);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeSet.java
@@ -172,7 +172,7 @@ public class NativeSet extends ScriptableObject {
         return realThis(thisObj, "values").js_iterator(scope, NativeCollectionIterator.Type.BOTH);
     }
 
-    private Object js_iterator(Scriptable scope, NativeCollectionIterator.Type type) {
+    private Object js_iterator(VarScope scope, NativeCollectionIterator.Type type) {
         return new NativeCollectionIterator(scope, ITERATOR_TAG, type, entries.iterator());
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -39,7 +39,7 @@ final class NativeString extends ScriptableObject {
 
     private final CharSequence string;
 
-    static void init(Scriptable scope, boolean sealed) {
+    static void init(VarScope scope, boolean sealed) {
         LambdaConstructor c =
                 new LambdaConstructor(
                         scope,
@@ -155,7 +155,7 @@ final class NativeString extends ScriptableObject {
 
     private static void defConsMethod(
             LambdaConstructor c,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {
@@ -164,7 +164,7 @@ final class NativeString extends ScriptableObject {
 
     private static void defProtoMethod(
             LambdaConstructor c,
-            Scriptable scope,
+            VarScope scope,
             SymbolKey key,
             int length,
             SerializableCallable target) {
@@ -173,7 +173,7 @@ final class NativeString extends ScriptableObject {
 
     private static void defProtoMethod(
             LambdaConstructor c,
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeStringIterator.java
@@ -19,7 +19,7 @@ public final class NativeStringIterator extends ES6Iterator {
         super();
     }
 
-    NativeStringIterator(Scriptable scope, Object stringLike) {
+    NativeStringIterator(VarScope scope, Object stringLike) {
         super(scope, ITERATOR_TAG);
         this.index = 0;
         this.string = ScriptRuntime.toString(stringLike);

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -24,13 +24,13 @@ public interface RegExpProxy {
 
     public Object compileRegExp(Context cx, String source, String flags);
 
-    public Scriptable wrapRegExp(Context cx, Scriptable scope, Object compiled);
+    public Scriptable wrapRegExp(Context cx, VarScope scope, Object compiled);
 
     public Object action(Context cx, VarScope scope, Object thisObj, Object[] args, int actionType);
 
     public int find_split(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String target,
             String separator,
             Scriptable re,
@@ -39,5 +39,5 @@ public interface RegExpProxy {
             boolean[] matched,
             String[][] parensp);
 
-    public Object js_split(Context _cx, Scriptable _scope, String thisString, Object[] _args);
+    public Object js_split(Context _cx, VarScope _scope, String thisString, Object[] _args);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -79,7 +79,7 @@ public class ScriptRuntime {
     static final class ThrowTypeError extends BaseFunction {
         private static final long serialVersionUID = -5891740962154902286L;
 
-        ThrowTypeError(Scriptable scope) {
+        ThrowTypeError(VarScope scope) {
             setPrototype(ScriptableObject.getFunctionPrototype(scope));
 
             setAttributes("length", DONTENUM | PERMANENT | READONLY);
@@ -335,7 +335,7 @@ public class ScriptRuntime {
                 : new String[] {"java", "javax", "org", "com", "edu", "net"};
     }
 
-    public static ScopeObject getLibraryScopeOrNull(Scriptable scope) {
+    public static ScopeObject getLibraryScopeOrNull(VarScope scope) {
         return (ScopeObject) ScriptableObject.getTopScopeValue(scope, LIBRARY_SCOPE_KEY);
     }
 
@@ -883,7 +883,7 @@ public class ScriptRuntime {
      * length, if necessary. Also the rest parameter array construction is done here.
      */
     public static Object[] padAndRestArguments(
-            Context cx, Scriptable scope, Object[] args, int argCount) {
+            Context cx, VarScope scope, Object[] args, int argCount) {
         Object[] result = new Object[argCount];
         int paramCount = argCount - 1;
         if (args.length < paramCount) {
@@ -1626,12 +1626,12 @@ public class ScriptRuntime {
         return nsObject;
     }
 
-    public static Object getTopLevelProp(Scriptable scope, String id) {
+    public static Object getTopLevelProp(VarScope scope, String id) {
         scope = ScriptableObject.getTopLevelScope(scope);
         return ScriptableObject.getProperty(scope, id);
     }
 
-    public static Function getExistingCtor(Context cx, Scriptable scope, String constructorName) {
+    public static Function getExistingCtor(Context cx, VarScope scope, String constructorName) {
         Object ctorVal = ScriptableObject.getProperty(scope, constructorName);
         if (ctorVal instanceof Function) {
             return (Function) ctorVal;
@@ -2325,8 +2325,8 @@ public class ScriptRuntime {
     }
 
     /** Looks up a name in the scope chain and returns its value. */
-    public static Object name(Context cx, Scriptable scope, String name) {
-        Scriptable parent = scope.getParentScope();
+    public static Object name(Context cx, VarScope scope, String name) {
+        VarScope parent = scope.getParentScope();
         if (parent == null) {
             Object result = topScopeName(cx, scope, name);
             if (result == Scriptable.NOT_FOUND) {
@@ -2341,7 +2341,7 @@ public class ScriptRuntime {
     private static Object nameOrFunction(
             Context cx,
             Scriptable scope,
-            Scriptable parentScope,
+            VarScope parentScope,
             String name,
             boolean asFunctionCall,
             boolean isOptionalChainingCall) {
@@ -2569,7 +2569,7 @@ public class ScriptRuntime {
     }
 
     public static Object setName(
-            Scriptable bound, Object value, Context cx, Scriptable scope, String id) {
+            Scriptable bound, Object value, Context cx, VarScope scope, String id) {
         if (bound != null) {
             // TODO: we used to special-case XMLObject here, but putProperty
             // seems to work for E4X and it's better to optimize  the common case
@@ -2850,7 +2850,8 @@ public class ScriptRuntime {
             case ENUMERATE_ARRAY:
             case ENUMERATE_ARRAY_NO_ITERATOR:
                 Object[] elements = {x.currentId, enumValue(enumObj, cx)};
-                return cx.newArray(ScriptableObject.getTopLevelScope(x.obj), elements);
+                return cx.newArray(
+                        ScriptableObject.getTopLevelScope(x.obj.getParentScope()), elements);
             default:
                 throw Kit.codeBug();
         }
@@ -2964,7 +2965,7 @@ public class ScriptRuntime {
 
     private static Callable getNameFunctionAndThisInner(
             String name, Context cx, VarScope scope, boolean isOptionalChainingCall) {
-        Scriptable parent = scope.getParentScope();
+        VarScope parent = scope.getParentScope();
         if (parent == null) {
             Object result = topScopeName(cx, scope, name);
             if (!(result instanceof Callable)) {
@@ -3334,20 +3335,7 @@ public class ScriptRuntime {
         }
 
         Callable f = (Callable) value;
-        Scriptable thisObj = null;
-        if (f instanceof Function) {
-            thisObj = ((Function) f).getDeclarationScope();
-        }
-        if (thisObj == null) {
-            if (cx.topCallScope == null) throw new IllegalStateException();
-            thisObj = cx.topCallScope;
-        }
-        if (thisObj instanceof NativeCall) {
-            // nested functions should have top scope as their thisObj
-            thisObj = ScriptableObject.getTopLevelScope(thisObj);
-        }
-
-        storeScriptable(cx, thisObj);
+        storeScriptable(cx, Undefined.SCRIPTABLE_UNDEFINED);
         return f;
     }
 
@@ -3376,9 +3364,7 @@ public class ScriptRuntime {
         }
 
         Callable f = (Callable) value;
-        Scriptable thisObj = Undefined.SCRIPTABLE_UNDEFINED;
-
-        return new LookupResult(f, thisObj, value);
+        return new LookupResult(f, Undefined.SCRIPTABLE_UNDEFINED, value);
     }
 
     /**
@@ -4856,12 +4842,12 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #doTopCall(Callable, Context, Scriptable, Scriptable, Object[],
+     * @deprecated Use {@link #doTopCall(Callable, Context, VarScope, Scriptable, Object[],
      *     boolean)} instead
      */
     @Deprecated
     public static Object doTopCall(
-            Callable callable, Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+            Callable callable, Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
         return doTopCall(callable, cx, scope, thisObj, args, cx.isStrictMode());
     }
 
@@ -4873,7 +4859,7 @@ public class ScriptRuntime {
     public static Object doTopCall(
             Callable callable,
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Scriptable thisObj,
             Object[] args,
             boolean isTopLevelStrict) {
@@ -5316,20 +5302,20 @@ public class ScriptRuntime {
     }
 
     /**
-     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, Scriptable)} instead
+     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, VarScope)} instead
      */
     @Deprecated
-    public static void setFunctionProtoAndParent(BaseFunction fn, Scriptable scope) {
+    public static void setFunctionProtoAndParent(BaseFunction fn, VarScope scope) {
         setFunctionProtoAndParent(fn, Context.getCurrentContext(), scope, false);
     }
 
-    public static void setFunctionProtoAndParent(BaseFunction fn, Context cx, Scriptable scope) {
+    public static void setFunctionProtoAndParent(BaseFunction fn, Context cx, VarScope scope) {
         setFunctionProtoAndParent(fn, cx, scope, false);
     }
 
     /**
-     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, Scriptable,
-     *     boolean)} instead
+     * @deprecated Use {@link #setFunctionProtoAndParent(BaseFunction, Context, VarScope, boolean)}
+     *     instead
      */
     @Deprecated
     public static void setFunctionProtoAndParent(
@@ -5338,7 +5324,7 @@ public class ScriptRuntime {
     }
 
     public static void setFunctionProtoAndParent(
-            BaseFunction fn, Context cx, Scriptable scope, boolean es6GeneratorFunction) {
+            BaseFunction fn, Context cx, VarScope scope, boolean es6GeneratorFunction) {
         fn.setParentScope(scope);
         if (es6GeneratorFunction) {
             fn.setPrototype(ScriptableObject.getGeneratorFunctionPrototype(scope));
@@ -5351,7 +5337,7 @@ public class ScriptRuntime {
         }
     }
 
-    public static void setObjectProtoAndParent(ScriptableObject object, Scriptable scope) {
+    public static void setObjectProtoAndParent(ScriptableObject object, VarScope scope) {
         // Compared with function it always sets the scope to top scope
         scope = ScriptableObject.getTopLevelScope(scope);
         object.setParentScope(scope);
@@ -5360,7 +5346,7 @@ public class ScriptRuntime {
     }
 
     public static void setBuiltinProtoAndParent(
-            ScriptableObject object, Scriptable scope, TopLevel.Builtins type) {
+            ScriptableObject object, VarScope scope, TopLevel.Builtins type) {
         TopLevel top = ScriptableObject.getTopLevelScope(scope);
         object.setParentScope(top);
         object.setPrototype(TopLevel.getBuiltinPrototype(top, type));
@@ -5403,7 +5389,7 @@ public class ScriptRuntime {
     }
 
     public static Scriptable newArrayLiteral(
-            Object[] objects, int[] skipIndices, Context cx, Scriptable scope) {
+            Object[] objects, int[] skipIndices, Context cx, VarScope scope) {
         final int SKIP_DENSITY = 2;
         int count = objects.length;
         int skipCount = 0;
@@ -5908,12 +5894,12 @@ public class ScriptRuntime {
         return result;
     }
 
-    public static Scriptable wrapRegExp(Context cx, Scriptable scope, Object compiled) {
+    public static Scriptable wrapRegExp(Context cx, VarScope scope, Object compiled) {
         return cx.getRegExpProxy().wrapRegExp(cx, scope, compiled);
     }
 
     public static Scriptable getTemplateLiteralCallSite(
-            Context cx, Scriptable scope, Object[] strings, int index) {
+            Context cx, VarScope scope, Object[] strings, int index) {
         Object callsite = strings[index];
 
         if (callsite instanceof Scriptable) return (Scriptable) callsite;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -30,9 +30,8 @@ public class ScriptRuntimeES6 {
     }
 
     /** Registers the symbol {@code [Symbol.species]} on the given constructor function. */
-    public static void addSymbolSpecies(
-            Context cx, Scriptable scope, ScriptableObject constructor) {
-        DescriptorInfo desc = symbolSpecies(cx, (VarScope) scope, constructor);
+    public static void addSymbolSpecies(Context cx, VarScope scope, ScriptableObject constructor) {
+        DescriptorInfo desc = symbolSpecies(cx, scope, constructor);
         constructor.defineOwnProperty(cx, SymbolKey.SPECIES, desc, false);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1229,7 +1229,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      *     of the internal LambdaFunction, which differ for many * native objects.
      */
     public void defineProperty(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -1241,17 +1241,17 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     }
 
     public void defineProperty(
-            Scriptable scope, String name, int length, SerializableCallable target) {
+            VarScope scope, String name, int length, SerializableCallable target) {
         defineProperty(scope, name, length, target, DONTENUM, DONTENUM | READONLY);
     }
 
     public void defineBuiltinProperty(
-            Scriptable scope, String name, int length, SerializableCallable target) {
+            VarScope scope, String name, int length, SerializableCallable target) {
         defineBuiltinProperty(scope, name, length, target, DONTENUM, DONTENUM | READONLY);
     }
 
     public void defineBuiltinProperty(
-            Scriptable scope,
+            VarScope scope,
             String name,
             int length,
             SerializableCallable target,
@@ -1611,7 +1611,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
             configurable = (attributes & PERMANENT) == 0;
         }
 
-        Scriptable toObject(Scriptable scope) {
+        Scriptable toObject(VarScope scope) {
             ScriptableObject desc = new NativeObject();
             ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
             if (hasValue()) desc.defineProperty("value", value, EMPTY);
@@ -1852,7 +1852,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      */
     public void defineProperty(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String name,
             LambdaGetterFunction getter,
             LambdaSetterFunction setter,
@@ -1866,17 +1866,13 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     }
 
     public void defineProperty(
-            Context cx,
-            Scriptable scope,
-            String name,
-            LambdaGetterFunction getter,
-            int attributes) {
+            Context cx, VarScope scope, String name, LambdaGetterFunction getter, int attributes) {
         defineProperty(cx, scope, name, getter, null, attributes);
     }
 
     public void defineProperty(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Symbol key,
             LambdaGetterFunction getter,
             LambdaSetterFunction setter,
@@ -1930,7 +1926,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
             LambdaGetterFunction getter,
             LambdaSetterFunction setter,
             int attributes,
-            Scriptable scope) {
+            VarScope scope) {
         LambdaAccessorSlot slot = new LambdaAccessorSlot(name, index);
         slot.setGetter(scope, getter);
         slot.setSetter(scope, setter);
@@ -2180,7 +2176,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      *
      * @param scope an object in the scope chain
      */
-    public static Scriptable getObjectPrototype(Scriptable scope) {
+    public static Scriptable getObjectPrototype(VarScope scope) {
         return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Object);
     }
 
@@ -2189,16 +2185,16 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      *
      * @param scope an object in the scope chain
      */
-    public static Scriptable getFunctionPrototype(Scriptable scope) {
+    public static Scriptable getFunctionPrototype(VarScope scope) {
         return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Function);
     }
 
-    public static Scriptable getGeneratorFunctionPrototype(Scriptable scope) {
+    public static Scriptable getGeneratorFunctionPrototype(VarScope scope) {
         return TopLevel.getBuiltinPrototype(
                 getTopLevelScope(scope), TopLevel.Builtins.GeneratorFunction);
     }
 
-    public static Scriptable getArrayPrototype(Scriptable scope) {
+    public static Scriptable getArrayPrototype(VarScope scope) {
         return TopLevel.getBuiltinPrototype(getTopLevelScope(scope), TopLevel.Builtins.Array);
     }
 
@@ -2214,7 +2210,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @param className the name of the constructor
      * @return the prototype for the named class, or null if it cannot be found.
      */
-    public static Scriptable getClassPrototype(Scriptable scope, String className) {
+    public static Scriptable getClassPrototype(VarScope scope, String className) {
         scope = getTopLevelScope(scope);
         Object ctor = getProperty(scope, className);
         Object proto;
@@ -2241,9 +2237,9 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @param obj a JavaScript object
      * @return the corresponding global scope
      */
-    public static TopLevel getTopLevelScope(Scriptable obj) {
+    public static TopLevel getTopLevelScope(VarScope obj) {
         for (; ; ) {
-            Scriptable parent = obj.getParentScope();
+            VarScope parent = obj.getParentScope();
             if (parent == null) {
                 if (obj instanceof TopLevel) {
                     return (TopLevel) obj;
@@ -2726,7 +2722,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         // and use ScriptableObject.getTopLevelScope(fun) if the flag is not
         // set. But that require access to Context and messy code
         // so for now it is not checked.
-        VarScope scope = ScriptableObject.getTopLevelScope(obj);
+        VarScope scope = fun.getDeclarationScope();
         if (cx != null) {
             return fun.call(cx, scope, obj, args);
         }
@@ -2766,7 +2762,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
 
     /**
      * Get arbitrary application-specific value associated with the top scope of the given scope.
-     * The method first calls {@link #getTopLevelScope(Scriptable scope)} and then searches the
+     * The method first calls {@link #getTopLevelScope(VarScope scope)} and then searches the
      * prototype chain of the top scope for the first object containing the associated value with
      * the given key.
      *
@@ -2774,7 +2770,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @param key key object to select particular value.
      * @see #getAssociatedValue(Object key)
      */
-    public static Object getTopScopeValue(Scriptable scope, Object key) {
+    public static Object getTopScopeValue(VarScope scope, Object key) {
         var topScope = ScriptableObject.getTopLevelScope(scope);
         return topScope.getAssociatedValue(key);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TopLevel.java
@@ -233,7 +233,7 @@ public class TopLevel extends ScopeObject {
      * @param type the built-in type
      * @return the built-in constructor
      */
-    public static Function getBuiltinCtor(Context cx, Scriptable scope, Builtins type) {
+    public static Function getBuiltinCtor(Context cx, VarScope scope, Builtins type) {
         // must be called with top level scope
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {
@@ -265,7 +265,7 @@ public class TopLevel extends ScopeObject {
      * @param type the native error type
      * @return the native error constructor
      */
-    static Function getNativeErrorCtor(Context cx, Scriptable scope, NativeErrors type) {
+    static Function getNativeErrorCtor(Context cx, VarScope scope, NativeErrors type) {
         // must be called with top level scope
         assert scope.getParentScope() == null;
         if (scope instanceof TopLevel) {

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeInfoFactory.java
@@ -24,6 +24,7 @@ import java.util.function.Supplier;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.lc.type.impl.factory.ClassValueCacheFactory;
 import org.mozilla.javascript.lc.type.impl.factory.LegacyCacheFactory;
 
@@ -54,7 +55,7 @@ public interface TypeInfoFactory extends Serializable {
      * types from being unloaded
      *
      * <p>For actions with scope available, the TypeInfoFactory can be obtained via {@link
-     * #get(Scriptable)}.
+     * #get(VarScope)}.
      */
     TypeInfoFactory GLOBAL = createGlobalFactory();
 
@@ -365,7 +366,7 @@ public interface TypeInfoFactory extends Serializable {
      *     TypeInfoFactory.
      * @see #associate(ScriptableObject topScope)
      */
-    static TypeInfoFactory get(Scriptable scope) {
+    static TypeInfoFactory get(VarScope scope) {
         var got = getOrElse(scope, null);
         if (got == null) {
             throw new IllegalArgumentException("top scope have no associated TypeInfoFactory");
@@ -382,7 +383,7 @@ public interface TypeInfoFactory extends Serializable {
      * @see #get(Scriptable)
      * @see #associate(ScriptableObject topScope)
      */
-    static TypeInfoFactory getOrElse(Scriptable scope, TypeInfoFactory fallback) {
+    static TypeInfoFactory getOrElse(VarScope scope, TypeInfoFactory fallback) {
         var got = (TypeInfoFactory) ScriptableObject.getTopScopeValue(scope, "TypeInfoFactory");
         if (got == null) {
             return fallback;

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -151,7 +151,7 @@ class BodyCodegen {
         addOptRuntimeInvoke(
                 "createNativeGenerator",
                 "(Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + "Lorg/mozilla/javascript/Scriptable;"
                         + "Lorg/mozilla/javascript/JSFunction;II"
                         + ")Lorg/mozilla/javascript/Scriptable;");
@@ -335,7 +335,7 @@ class BodyCodegen {
                             "padAndRestArguments",
                             "("
                                     + "Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "[Ljava/lang/Object;"
                                     + "I"
                                     + ")[Ljava/lang/Object;");
@@ -1199,7 +1199,7 @@ class BodyCodegen {
                             "org/mozilla/javascript/ScriptRuntime",
                             "wrapRegExp",
                             "(Lorg/mozilla/javascript/Context;"
-                                    + "Lorg/mozilla/javascript/Scriptable;"
+                                    + "Lorg/mozilla/javascript/VarScope;"
                                     + "Ljava/lang/Object;"
                                     + ")Lorg/mozilla/javascript/Scriptable;");
                 }
@@ -1996,7 +1996,7 @@ class BodyCodegen {
                 "org/mozilla/javascript/ScriptRuntime",
                 "getTemplateLiteralCallSite",
                 "(Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + "[Ljava/lang/Object;I"
                         + ")Lorg/mozilla/javascript/Scriptable;");
     }
@@ -2269,7 +2269,7 @@ class BodyCodegen {
                         + "Ljava/lang/String;"
                         + "I"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + ")Lorg/mozilla/javascript/Scriptable;");
     }
 
@@ -2389,7 +2389,7 @@ class BodyCodegen {
                 "([Ljava/lang/Object;"
                         + "[I"
                         + "Lorg/mozilla/javascript/Context;"
-                        + "Lorg/mozilla/javascript/Scriptable;"
+                        + "Lorg/mozilla/javascript/VarScope;"
                         + ")Lorg/mozilla/javascript/Scriptable;");
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -32,9 +32,9 @@ import org.mozilla.javascript.JSScript;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptOrFn;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.SecurityController;
 import org.mozilla.javascript.Token;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Name;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -133,7 +133,7 @@ public class Codegen implements Evaluator {
     @Override
     @SuppressWarnings("unchecked")
     public Function createFunctionObject(
-            Context cx, Scriptable scope, Object bytecode, Object staticSecurityDomain) {
+            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain) {
         JSDescriptor<JSFunction> desc =
                 defineClass((CompilationResult<JSFunction>) bytecode, staticSecurityDomain);
         return JSFunction.createFunction(cx, scope, desc, null, staticSecurityDomain);
@@ -962,7 +962,7 @@ public class Codegen implements Evaluator {
     static final String JSFUNCTION_CONSTRUCTOR_SIGNATURE =
             "("
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + "Lorg/mozilla/javascript/JSDescriptor;"
                     + "Lorg/mozilla/javascript/Scriptable;"
                     + "Lorg/mozilla/javascript/Scriptable;"

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/DefaultLinker.java
@@ -146,7 +146,7 @@ class DefaultLinker implements GuardingDynamicLinker {
             mh = MethodHandles.insertArguments(mh, 2, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);
         } else if (op.isOperation(StandardOperation.GET)) {
-            tt = MethodType.methodType(Object.class, Context.class, Scriptable.class, String.class);
+            tt = MethodType.methodType(Object.class, Context.class, VarScope.class, String.class);
             mh = lookup.findStatic(ScriptRuntime.class, "name", tt);
             mh = MethodHandles.insertArguments(mh, 2, name);
             mh = MethodHandles.permuteArguments(mh, mType, 1, 0);

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -231,7 +231,7 @@ public final class OptRuntime extends ScriptRuntime {
     }
 
     public static Scriptable newArrayLiteral(
-            Object[] objects, String encodedInts, int skipCount, Context cx, Scriptable scope) {
+            Object[] objects, String encodedInts, int skipCount, Context cx, VarScope scope) {
         int[] skipIndexes = decodeIntArray(encodedInts, skipCount);
         return newArrayLiteral(objects, skipIndexes, cx, scope);
     }
@@ -264,14 +264,14 @@ public final class OptRuntime extends ScriptRuntime {
         Object value = getGeneratorReturnValue(genState);
         Object si =
                 (value == Undefined.instance)
-                        ? NativeIterator.getStopIterationObject((Scriptable) scope)
+                        ? NativeIterator.getStopIterationObject((VarScope) scope)
                         : new NativeIterator.StopIteration(value);
         throw new JavaScriptException(si, "", 0);
     }
 
     public static Scriptable createNativeGenerator(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             Scriptable thisObj,
             JSFunction funObj,
             int maxLocals,

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Signatures.java
@@ -149,7 +149,7 @@ interface Signatures {
      * they can always assume that the "receiver" of an operation is the first argument.
      */
     String NAME_GET =
-            "(Lorg/mozilla/javascript/Scriptable;"
+            "(Lorg/mozilla/javascript/VarScope;"
                     + "Lorg/mozilla/javascript/Context;"
                     + ")Ljava/lang/Object;";
 
@@ -170,7 +170,7 @@ interface Signatures {
             "(Lorg/mozilla/javascript/Scriptable;"
                     + "Ljava/lang/Object;"
                     + "Lorg/mozilla/javascript/Context;"
-                    + "Lorg/mozilla/javascript/Scriptable;"
+                    + "Lorg/mozilla/javascript/VarScope;"
                     + ")Ljava/lang/Object;";
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -328,7 +328,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Scriptable js_constructCall(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         if (args.length > 0
                 && args[0] instanceof NativeRegExp
                 && (args.length == 1 || args[1] == Undefined.instance)) {
@@ -338,7 +338,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static Scriptable js_construct(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeRegExp re = NativeRegExpInstantiator.withLanguageVersion(cx.getLanguageVersion());
         re.compile(cx, s, args);
         ScriptRuntime.setBuiltinProtoAndParent(re, s, TopLevel.Builtins.RegExp);
@@ -358,7 +358,7 @@ public class NativeRegExp extends ScriptableObject {
         return (RegExpImpl) ScriptRuntime.getRegExpProxy(cx);
     }
 
-    NativeRegExp(Scriptable scope, RECompiled regexpCompiled) {
+    NativeRegExp(VarScope scope, RECompiled regexpCompiled) {
         this.re = regexpCompiled;
         // This needs to be built in.
         createLastIndexProp();
@@ -414,7 +414,7 @@ public class NativeRegExp extends ScriptableObject {
         return "object";
     }
 
-    Scriptable compile(Context cx, Scriptable scope, Object[] args) {
+    Scriptable compile(Context cx, VarScope scope, Object[] args) {
         if (args.length >= 1
                 && args[0] instanceof NativeRegExp
                 && (args.length == 1 || args[1] == Undefined.instance)) {
@@ -508,7 +508,7 @@ public class NativeRegExp extends ScriptableObject {
         return s;
     }
 
-    Object execSub(Context cx, Scriptable scopeObj, Object[] args, int matchType) {
+    Object execSub(Context cx, VarScope scopeObj, Object[] args, int matchType) {
         RegExpImpl reImpl = getImpl(cx);
         String str;
         if (args.length == 0) {
@@ -4128,7 +4128,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     Object executeRegExp(
-            Context cx, Scriptable scope, RegExpImpl res, String str, int[] indexp, int matchType) {
+            Context cx, VarScope scope, RegExpImpl res, String str, int[] indexp, int matchType) {
         var result = executeRegExpInternal(cx, scope, res, str, indexp, matchType);
 
         if (result == null) {
@@ -4171,7 +4171,7 @@ public class NativeRegExp extends ScriptableObject {
      * indexp is assumed to be an array of length 1
      */
     ExecResult executeRegExpInternal(
-            Context cx, Scriptable scope, RegExpImpl res, String str, int[] indexp, int matchType) {
+            Context cx, VarScope scope, RegExpImpl res, String str, int[] indexp, int matchType) {
         REGlobalData gData = new REGlobalData();
 
         int start = indexp[0];
@@ -4442,7 +4442,7 @@ public class NativeRegExp extends ScriptableObject {
         }
     }
 
-    static Object js_exec(Context cx, Scriptable scope, Object thisObj, Object[] args) {
+    static Object js_exec(Context cx, VarScope scope, Object thisObj, Object[] args) {
         return realThis(thisObj, "exec").execSub(cx, scope, args, MATCH);
     }
 
@@ -4457,7 +4457,7 @@ public class NativeRegExp extends ScriptableObject {
 
         String s = ScriptRuntime.toString(args.length > 0 ? args[0] : Undefined.instance);
 
-        Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+        TopLevel topLevelScope = ScriptableObject.getTopLevelScope(scope);
         Function defaultConstructor = ScriptRuntime.getExistingCtor(cx, topLevelScope, "RegExp");
         Constructable c =
                 AbstractEcmaObjectOperations.speciesConstructor(cx, realThis, defaultConstructor);
@@ -4778,7 +4778,7 @@ public class NativeRegExp extends ScriptableObject {
 
         String s = ScriptRuntime.toString(args.length > 0 ? args[0] : Undefined.instance);
 
-        Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+        TopLevel topLevelScope = ScriptableObject.getTopLevelScope(scope);
         Function defaultConstructor = ScriptRuntime.getExistingCtor(cx, topLevelScope, "RegExp");
         Constructable c =
                 AbstractEcmaObjectOperations.speciesConstructor(cx, rx, defaultConstructor);
@@ -4879,7 +4879,7 @@ public class NativeRegExp extends ScriptableObject {
 
     private static Object js_SymbolSplitFast(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             NativeRegExp splitter,
             String s,
             long lim,

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpCallable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpCallable.java
@@ -10,7 +10,7 @@ import org.mozilla.javascript.VarScope;
  */
 class NativeRegExpCallable extends NativeRegExp implements Function {
 
-    NativeRegExpCallable(Scriptable scope, RECompiled compiled) {
+    NativeRegExpCallable(VarScope scope, RECompiled compiled) {
         super(scope, compiled);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpInstantiator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpInstantiator.java
@@ -1,7 +1,7 @@
 package org.mozilla.javascript.regexp;
 
 import org.mozilla.javascript.Context;
-import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.VarScope;
 
 public class NativeRegExpInstantiator {
 
@@ -16,7 +16,7 @@ public class NativeRegExpInstantiator {
     }
 
     static NativeRegExp withLanguageVersionScopeCompiled(
-            int languageVersion, Scriptable scope, RECompiled compiled) {
+            int languageVersion, VarScope scope, RECompiled compiled) {
         if (languageVersion < Context.VERSION_ES6) {
             return new NativeRegExpCallable(scope, compiled);
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExpStringIterator.java
@@ -36,11 +36,7 @@ public final class NativeRegExpStringIterator extends ES6Iterator {
     }
 
     public NativeRegExpStringIterator(
-            Scriptable scope,
-            Scriptable regexp,
-            String string,
-            boolean global,
-            boolean fullUnicode) {
+            VarScope scope, Scriptable regexp, String string, boolean global, boolean fullUnicode) {
         super(scope, ITERATOR_TAG);
 
         this.regexp = regexp;

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -38,7 +38,7 @@ public class RegExpImpl implements RegExpProxy {
     }
 
     @Override
-    public Scriptable wrapRegExp(Context cx, Scriptable scope, Object compiled) {
+    public Scriptable wrapRegExp(Context cx, VarScope scope, Object compiled) {
         return NativeRegExpInstantiator.withLanguageVersionScopeCompiled(
                 cx.getLanguageVersion(), scope, (RECompiled) compiled);
     }
@@ -175,9 +175,9 @@ public class RegExpImpl implements RegExpProxy {
     }
 
     private static NativeRegExp createRegExp(
-            Context cx, Scriptable scope, Object[] args, int optarg, boolean forceFlat) {
+            Context cx, VarScope scope, Object[] args, int optarg, boolean forceFlat) {
         NativeRegExp re;
-        Scriptable topScope = ScriptableObject.getTopLevelScope(scope);
+        VarScope topScope = ScriptableObject.getTopLevelScope(scope);
         if (args.length == 0 || args[0] == Undefined.instance) {
             RECompiled compiled = NativeRegExp.compileRE(cx, "", "", false);
             re =
@@ -256,7 +256,7 @@ public class RegExpImpl implements RegExpProxy {
     @Override
     public int find_split(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String target,
             String separator,
             Scriptable reObj,
@@ -339,7 +339,7 @@ public class RegExpImpl implements RegExpProxy {
      * Analog of match_glob() in jsstr.c
      */
     private static void match_glob(
-            GlobData mdata, Context cx, Scriptable scope, int count, RegExpImpl reImpl) {
+            GlobData mdata, Context cx, VarScope scope, int count, RegExpImpl reImpl) {
         if (mdata.arrayobj == null) {
             mdata.arrayobj = cx.newArray(scope, 0);
         }
@@ -521,7 +521,7 @@ public class RegExpImpl implements RegExpProxy {
      * argument.
      */
     @Override
-    public Object js_split(Context cx, Scriptable scope, String target, Object[] args) {
+    public Object js_split(Context cx, VarScope scope, String target, Object[] args) {
         // create an empty Array to return;
         Scriptable result = cx.newArray(scope, 0);
 
@@ -616,7 +616,7 @@ public class RegExpImpl implements RegExpProxy {
      */
     private static int find_split(
             Context cx,
-            Scriptable scope,
+            VarScope scope,
             String target,
             String separator,
             int version,

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -38,6 +38,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SerializableCallable;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.Wrapper;
@@ -1229,7 +1230,7 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
 
     private NativeTypedArrayView<?> typedArraySpeciesCreate(
             Context cx, VarScope scope, Object[] args, String methodName) {
-        Scriptable topLevelScope = ScriptableObject.getTopLevelScope(scope);
+        TopLevel topLevelScope = ScriptableObject.getTopLevelScope(scope);
         Function defaultConstructor =
                 ScriptRuntime.getExistingCtor(cx, topLevelScope, getClassName());
         Constructable constructable =

--- a/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
+++ b/rhino/src/main/java/org/mozilla/javascript/xml/XMLLib.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ScopeObject;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
 
 public abstract class XMLLib {
     private static final Object XML_LIB_KEY = new Object();
@@ -38,7 +39,7 @@ public abstract class XMLLib {
         public abstract String getImplementationClassName();
     }
 
-    public static XMLLib extractFromScopeOrNull(Scriptable scope) {
+    public static XMLLib extractFromScopeOrNull(VarScope scope) {
         ScopeObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
         if (so == null) {
             // If library is not yet initialized, return null
@@ -52,7 +53,7 @@ public abstract class XMLLib {
         return (XMLLib) so.getAssociatedValue(XML_LIB_KEY);
     }
 
-    public static XMLLib extractFromScope(Scriptable scope) {
+    public static XMLLib extractFromScope(VarScope scope) {
         XMLLib lib = extractFromScopeOrNull(scope);
         if (lib != null) {
             return lib;
@@ -61,7 +62,7 @@ public abstract class XMLLib {
         throw Context.reportRuntimeError(msg);
     }
 
-    protected final XMLLib bindToScope(Scriptable scope) {
+    protected final XMLLib bindToScope(VarScope scope) {
         ScopeObject so = ScriptRuntime.getLibraryScopeOrNull(scope);
         if (so == null) {
             // standard library should be initialized at this point

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ContinuationsApiTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ContinuationsApiTest.java
@@ -21,7 +21,6 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContinuationPending;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Script;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.WrappedException;
 import org.mozilla.javascript.serialize.ScriptableInputStream;
@@ -291,12 +290,12 @@ public class ContinuationsApiTest {
 
         {
             try (Context cx = Context.enter()) {
-                Scriptable globalScope;
+                TopLevel globalScope;
 
                 // deserialize
                 try (ByteArrayInputStream bais = new ByteArrayInputStream(serializedData);
                         ObjectInputStream sis = new ObjectInputStream(bais)) {
-                    globalScope = (Scriptable) sis.readObject();
+                    globalScope = (TopLevel) sis.readObject();
                     Object continuation = sis.readObject();
                     sis.close();
                     bais.close();

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -99,7 +99,7 @@ public abstract class ScriptTestsBase {
      * <p>PerformMicrotaskCheckpoint ensures that all the pending microtasks are executed
      * immediately.
      */
-    private void loadNatives(Scriptable scope) {
+    private void loadNatives(VarScope scope) {
         ScriptableObject.putProperty(
                 scope,
                 "AbortJS",

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaAccessorSlotTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 
 public class LambdaAccessorSlotTest {
@@ -550,7 +551,7 @@ public class LambdaAccessorSlotTest {
         private String status;
         private final String hiddenStatus;
 
-        static LambdaConstructor init(Scriptable scope) {
+        static LambdaConstructor init(VarScope scope) {
             LambdaConstructor constructor =
                     new LambdaConstructor(
                             scope,

--- a/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/commonjs/module/ComplianceTest.java
@@ -82,7 +82,7 @@ public class ComplianceTest {
     }
 
     private static class Print extends ScriptableObject implements Function {
-        Print(Scriptable scope) {
+        Print(VarScope scope) {
             setPrototype(ScriptableObject.getFunctionPrototype(scope));
         }
 


### PR DESCRIPTION
Next round of internal API conversion. This is the next commit from https://github.com/mozilla/rhino/pull/2330.