### PR TITLE
Add abstraction layer for file lookups

### DIFF
--- a/rhino-engine/src/test/java/org/mozilla/javascript/tests/scriptengine/InvocableTest.java
+++ b/rhino-engine/src/test/java/org/mozilla/javascript/tests/scriptengine/InvocableTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.engine.RhinoScriptEngineFactory;
+import org.mozilla.javascript.testutils.TestSource;
 
 public class InvocableTest {
 
@@ -61,7 +62,7 @@ public class InvocableTest {
 
     @Test
     public void invokeMethodTest() throws Exception {
-        try (FileReader reader = new FileReader("../tests/testsrc/assert.js")) {
+        try (FileReader reader = new FileReader(TestSource.resolve("testsrc/assert.js"))) {
             engine.eval(reader);
             engine.eval(
                     "function FooObj() { this.x = 0; }\n"
@@ -82,7 +83,7 @@ public class InvocableTest {
 
     @Test
     public void interfaceFunctionTest() throws Exception {
-        try (FileReader reader = new FileReader("../tests/testsrc/assert.js")) {
+        try (FileReader reader = new FileReader(TestSource.resolve("testsrc/assert.js"))) {
             engine.eval(reader);
 
             engine.eval(
@@ -100,7 +101,7 @@ public class InvocableTest {
 
     @Test
     public void interfaceMethodTest() throws Exception {
-        try (FileReader reader = new FileReader("../tests/testsrc/assert.js")) {
+        try (FileReader reader = new FileReader(TestSource.resolve("testsrc/assert.js"))) {
             engine.eval(reader);
 
             Object foo =

--- a/rhino-engine/src/test/java/org/mozilla/javascript/tests/scriptengine/ScriptEngineTest.java
+++ b/rhino-engine/src/test/java/org/mozilla/javascript/tests/scriptengine/ScriptEngineTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.engine.RhinoScriptEngine;
 import org.mozilla.javascript.engine.RhinoScriptEngineFactory;
+import org.mozilla.javascript.testutils.TestSource;
 
 public class ScriptEngineTest {
 
@@ -82,7 +83,7 @@ public class ScriptEngineTest {
         engine.put("actuallyNull", null);
 
         // Ensure that stuff we just stuck in bindings made it to a global
-        engine.eval(new FileReader("../tests/testsrc/assert.js"));
+        engine.eval(new FileReader(TestSource.resolve("testsrc/assert.js")));
         engine.eval(
                 "assertEquals(string, 'Hello');\n"
                         + "assertEquals(integer, 123);\n"
@@ -109,7 +110,7 @@ public class ScriptEngineTest {
     public void engineScope() throws IOException, ScriptException {
         engine.put("string", "Hello");
         engine.put("integer", 123);
-        engine.eval(new FileReader("../tests/testsrc/assert.js"));
+        engine.eval(new FileReader(TestSource.resolve("testsrc/assert.js")));
         engine.eval("assertEquals(string, 'Hello');" + "assertEquals(integer, 123);");
 
         // Additional things added to the context but old stuff still there
@@ -137,7 +138,7 @@ public class ScriptEngineTest {
         gb.put("global", Boolean.TRUE);
         gb.put("level", 0);
 
-        engine.eval(new FileReader("../tests/testsrc/assert.js"), sc);
+        engine.eval(new FileReader(TestSource.resolve("testsrc/assert.js")), sc);
         engine.eval("assertTrue(engine);" + "assertTrue(global);" + "assertEquals(level, 2);", sc);
     }
 
@@ -155,7 +156,8 @@ public class ScriptEngineTest {
 
     @Test
     public void compiled() throws ScriptException, IOException {
-        CompiledScript asserts = cEngine.compile(new FileReader("../tests/testsrc/assert.js"));
+        CompiledScript asserts =
+                cEngine.compile(new FileReader(TestSource.resolve("testsrc/assert.js")));
         CompiledScript tests = cEngine.compile("assertEquals(compiled, true);");
 
         // Fails because asserts have not been loaded
@@ -171,7 +173,8 @@ public class ScriptEngineTest {
 
     @Test
     public void compiled2() throws ScriptException, IOException {
-        CompiledScript asserts = cEngine.compile(new FileReader("../tests/testsrc/assert.js"));
+        CompiledScript asserts =
+                cEngine.compile(new FileReader(TestSource.resolve("testsrc/assert.js")));
         CompiledScript init = cEngine.compile("value = 0;");
         CompiledScript tests =
                 cEngine.compile("assertEquals(value, expectedValue);" + "value += 1;");
@@ -261,7 +264,7 @@ public class ScriptEngineTest {
 
     @Test
     public void javaObject() throws ScriptException {
-        File f = new File("testsrc/assert.js");
+        File f = new File(TestSource.resolve("testsrc/assert.js"));
         String absVal = f.getAbsolutePath();
         engine.put("file", f);
         Object result = engine.eval("file.getAbsolutePath();");

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/Global.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +96,7 @@ public class Global extends ImporterTopLevel {
     private boolean sealedStdLib = false;
     boolean initialized;
     private QuitAction quitAction;
+    private String fileLoadPrefix;
     private static final String[] prompts = {"js> ", "  > "};
     private HashMap<String, String> doctestCanonicalizations;
 
@@ -125,6 +127,15 @@ public class Global extends ImporterTopLevel {
                     init(cx);
                     return null;
                 });
+    }
+
+    /**
+     * Set a path that should be prefixed to every "load" call from the script. This is used in our
+     * different test environments and tools so that we can write scripts that load files using a
+     * relative location (usually starting with "testsrc") and have them always find the file
+     */
+    public void setFileLoadPrefix(String prefix) {
+        this.fileLoadPrefix = prefix;
     }
 
     public void init(Context cx) {
@@ -264,6 +275,9 @@ public class Global extends ImporterTopLevel {
     public static void load(Context cx, Scriptable thisObj, Object[] args, Function funObj) {
         for (Object arg : args) {
             String file = Context.toString(arg);
+            if (getInstance(funObj).fileLoadPrefix != null) {
+                file = Path.of(getInstance(funObj).fileLoadPrefix, file).toString();
+            }
             try {
                 Main.processFile(cx, funObj.getDeclarationScope(), file);
             } catch (IOException ioex) {

--- a/rhino/src/test/java/org/mozilla/javascript/tests/Issue176Test.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/Issue176Test.java
@@ -21,7 +21,7 @@ public class Issue176Test {
         cx = Context.enter();
         try {
             InputStreamReader in =
-                    new InputStreamReader(Bug482203Test.class.getResourceAsStream("Issue176.js"));
+                    new InputStreamReader(Issue176Test.class.getResourceAsStream("Issue176.js"));
             Script script = cx.compileReader(in, "Issue176.js", 1, null);
             scope = cx.initStandardObjects();
             scope.put("host", scope, this);

--- a/rhino/src/test/java/org/mozilla/javascript/tests/RhinoPropertiesTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/RhinoPropertiesTest.java
@@ -1,13 +1,15 @@
 package org.mozilla.javascript.tests;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.config.RhinoConfig;
 import org.mozilla.javascript.config.RhinoProperties;
-import org.mozilla.javascript.config.RhinoPropertiesLoader;
+import org.mozilla.javascript.testutils.TestSource;
 
 /**
  * Testcase for various property loading mechanism. <br>
@@ -26,40 +28,6 @@ public class RhinoPropertiesTest {
         valueA,
         VALUEB,
         valuec
-    }
-
-    /** This loader is used for all tests in this maven module! */
-    public static class Loader implements RhinoPropertiesLoader {
-
-        /**
-         * this loader will add some explicitly typed values to the configuration. After that, it
-         * will also load the defaults.
-         */
-        @Override
-        public void load(RhinoProperties properties) {
-
-            properties.addConfig(Map.of("test.foo.bar", "baz1"));
-            properties.addConfig(
-                    Map.of(
-                            "test.foo.bar", "baz2",
-                            "test.foo.someBoolean1", "true",
-                            "test.foo.someBoolean2", "TRUE",
-                            "test.foo.someBoolean3", "1",
-                            "test.foo.someInteger1", "42",
-                            "test.foo.someInteger2", 42,
-                            "test.foo.someAValue", true,
-                            "TEST_FOO_SOME_BVALUE", 42,
-                            "TEST_FOO_ENUM1", "valuea"));
-            properties.addConfig(
-                    Map.of(
-                            "TEST_FOO_ENUM1", "valuea",
-                            "TEST_FOO_ENUM2", "VALUEA",
-                            "TEST_FOO_ENUM3", "VALUEB",
-                            "TEST_FOO_ENUM4", "VALUEC",
-                            "TEST_FOO_ENUM5", "VALUED"));
-            // also load defaults, so that users can use rhino-test.config here!
-            properties.loadDefaults();
-        }
     }
 
     /** Tests the loader initialization and all methods in RhinoConfig. */
@@ -114,7 +82,7 @@ public class RhinoPropertiesTest {
     @Test
     void testFileLoad() {
         RhinoProperties properties = new RhinoProperties();
-        properties.loadFromFile(new File("src/test/resources/rhino-explicit.config"));
+        properties.loadFromFile(new File(TestSource.resolve("testsrc/rhino-explicit.config")));
         assertEquals("value1", properties.get("test.config.foo"));
         assertEquals("value2", properties.get("test.config.bar"));
     }

--- a/rhino/src/test/java/org/mozilla/javascript/tests/RhinoPropertiesTestLoader.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/RhinoPropertiesTestLoader.java
@@ -1,0 +1,39 @@
+package org.mozilla.javascript.tests;
+
+import java.util.Map;
+import org.mozilla.javascript.config.RhinoProperties;
+import org.mozilla.javascript.config.RhinoPropertiesLoader;
+
+/** This loader is used for all tests in this maven module! */
+public class RhinoPropertiesTestLoader implements RhinoPropertiesLoader {
+
+    /**
+     * this loader will add some explicitly typed values to the configuration. After that, it will
+     * also load the defaults.
+     */
+    @Override
+    public void load(RhinoProperties properties) {
+
+        properties.addConfig(Map.of("test.foo.bar", "baz1"));
+        properties.addConfig(
+                Map.of(
+                        "test.foo.bar", "baz2",
+                        "test.foo.someBoolean1", "true",
+                        "test.foo.someBoolean2", "TRUE",
+                        "test.foo.someBoolean3", "1",
+                        "test.foo.someInteger1", "42",
+                        "test.foo.someInteger2", 42,
+                        "test.foo.someAValue", true,
+                        "TEST_FOO_SOME_BVALUE", 42,
+                        "TEST_FOO_ENUM1", "valuea"));
+        properties.addConfig(
+                Map.of(
+                        "TEST_FOO_ENUM1", "valuea",
+                        "TEST_FOO_ENUM2", "VALUEA",
+                        "TEST_FOO_ENUM3", "VALUEB",
+                        "TEST_FOO_ENUM4", "VALUEC",
+                        "TEST_FOO_ENUM5", "VALUED"));
+        // also load defaults, so that users can use rhino-test.config here!
+        properties.loadDefaults();
+    }
+}

--- a/rhino/src/test/resources/META-INF/services/org.mozilla.javascript.config.RhinoPropertiesLoader
+++ b/rhino/src/test/resources/META-INF/services/org.mozilla.javascript.config.RhinoPropertiesLoader
@@ -1,1 +1,1 @@
-org.mozilla.javascript.tests.RhinoPropertiesTest$Loader
+org.mozilla.javascript.tests.RhinoPropertiesTestLoader

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ScriptTestsBase.java
@@ -4,7 +4,9 @@
 
 package org.mozilla.javascript.drivers;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -23,6 +25,7 @@ import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -50,7 +53,8 @@ public abstract class ScriptTestsBase {
             if (!"".equals(anno.value())) {
                 script =
                         new InputStreamReader(
-                                new FileInputStream(anno.value()), StandardCharsets.UTF_8);
+                                new FileInputStream(TestSource.resolve(anno.value())),
+                                StandardCharsets.UTF_8);
                 suiteName = anno.value();
             } else if (!"".equals(anno.inline())) {
                 script =
@@ -66,6 +70,7 @@ public abstract class ScriptTestsBase {
             cx.setLanguageVersion(jsVersion);
 
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             loadNatives(global);
 
             var scope = TopLevel.createIsolate(global);

--- a/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/drivers/ShellTest.java
@@ -22,6 +22,7 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.Main;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
@@ -34,7 +35,7 @@ public class ShellTest {
     private static Script frameworkScript;
 
     public static void cacheFramework() {
-        frameworkFile = new File("testsrc/tests/shell.js");
+        frameworkFile = new File(TestSource.resolve("testsrc/tests/shell.js"));
         if (!frameworkFile.exists()) {
             throw new AssertionError("Can't find test framework file " + frameworkFile);
         }

--- a/tests/src/test/java/org/mozilla/javascript/tests/BracelessIfElseWithCommentsParseTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/BracelessIfElseWithCommentsParseTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstRoot;
+import org.mozilla.javascript.testutils.TestSource;
 
 /**
  * Tests that braceless if/else statements with inline comments parse correctly when {@code
@@ -29,7 +30,9 @@ public class BracelessIfElseWithCommentsParseTest {
         String source;
         try (BufferedReader reader =
                 new BufferedReader(
-                        new FileReader("testsrc/jstests/braceless-if-else-with-comments.js"))) {
+                        new FileReader(
+                                TestSource.resolve(
+                                        "testsrc/jstests/braceless-if-else-with-comments.js")))) {
             source = reader.lines().collect(Collectors.joining(System.lineSeparator()));
         }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ComparatorTest.java
@@ -1,17 +1,18 @@
 package org.mozilla.javascript.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mozilla.javascript.ArrayLikeAbstractOperations.*;
 
 import java.io.FileReader;
 import java.io.IOException;
 import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.ArrayLikeAbstractOperations.ElementComparator;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class ComparatorTest {
@@ -76,8 +77,11 @@ public class ComparatorTest {
     public void customComparator() throws IOException {
         try (Context cx = Context.enter()) {
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             VarScope root = cx.newVarEnv(global);
-            FileReader fr = new FileReader("testsrc/jstests/extensions/custom-comparators.js");
+            FileReader fr =
+                    new FileReader(
+                            TestSource.resolve("testsrc/jstests/extensions/custom-comparators.js"));
 
             cx.evaluateReader(root, fr, "custom-comparators.js", 1, null);
         } catch (RhinoException re) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DoctestFeature18EnabledTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -20,7 +21,7 @@ public class DoctestFeature18EnabledTest extends DoctestsTest {
 
     public static Collection<Object[]> singleDoctest() throws IOException {
         List<Object[]> result = new ArrayList<Object[]>();
-        File f = new File(DoctestsTest.baseDirectory, "feature18enabled.doctest");
+        File f = new File(TestSource.resolve("testsrc/doctests/feature18enabled.doctest"));
         String contents = DoctestsTest.loadFile(f);
         result.add(new Object[] {f.getName(), contents, false});
         return result;

--- a/tests/src/test/java/org/mozilla/javascript/tests/DoctestsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/DoctestsTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.drivers.TestUtils;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -43,7 +44,9 @@ public class DoctestsTest {
 
     public static File[] getDoctestFiles() {
         return TestUtils.recursiveListFiles(
-                new File(baseDirectory),
+                // For most portability resolvedirectory needs to start with the name
+                // of a well-known file.
+                new File(TestSource.resolveDirectory("testsrc/doctests/arguments.doctest")),
                 new FileFilter() {
                     @Override
                     public boolean accept(File f) {
@@ -90,6 +93,7 @@ public class DoctestsTest {
             cx.setLanguageVersion(Context.VERSION_DEFAULT);
             cx.setInterpretedMode(interpretedMode);
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             // global.runDoctest throws an exception on any failure
             int testsPassed = global.runDoctest(cx, global, source, name, 1);
             assertTrue(testsPassed > 0);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ExternalArrayTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ExternalArrayData;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.typedarrays.NativeFloat64Array;
 import org.mozilla.javascript.typedarrays.NativeInt16Array;
@@ -28,6 +29,7 @@ public class ExternalArrayTest {
         cx.setGeneratingDebug(true);
 
         Global global = new Global(cx);
+        global.setFileLoadPrefix(TestSource.getPrefix());
         root = cx.newVarEnv(global);
     }
 
@@ -125,7 +127,7 @@ public class ExternalArrayTest {
     private void runScript(String script, boolean interpretedMode) {
         try {
             cx.setInterpretedMode(interpretedMode);
-            try (FileReader rdr = new FileReader(script)) {
+            try (FileReader rdr = new FileReader(TestSource.resolve(script))) {
                 cx.evaluateReader(root, rdr, script, 1, null);
             }
         } catch (IOException ioe) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/HashCollisionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/HashCollisionTest.java
@@ -6,6 +6,7 @@ import java.io.StringWriter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class HashCollisionTest {
@@ -16,7 +17,7 @@ public class HashCollisionTest {
     public static void loadFile() throws IOException {
         StringWriter out = new StringWriter();
 
-        try (FileReader in = new FileReader(mediumInput)) {
+        try (FileReader in = new FileReader(TestSource.resolve(mediumInput))) {
             char[] buf = new char[16392];
             int rc;
             do {
@@ -37,7 +38,8 @@ public class HashCollisionTest {
      */
     @Test
     public void mediumCollisions() throws IOException {
-        try (FileReader scriptIn = new FileReader("testsrc/jstests/hash-collisions.js")) {
+        try (FileReader scriptIn =
+                new FileReader(TestSource.resolve("testsrc/jstests/hash-collisions.js"))) {
             try (Context cx = Context.enter()) {
                 Global glob = new Global(cx);
                 glob.put("collisions", glob, collisions);

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaFunctionTest.java
@@ -16,6 +16,7 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 
 public class LambdaFunctionTest {
@@ -28,7 +29,7 @@ public class LambdaFunctionTest {
         cx = Context.enter();
         cx.setLanguageVersion(Context.VERSION_ES6);
         root = cx.initStandardObjects();
-        try (FileReader rdr = new FileReader("testsrc/assert.js")) {
+        try (FileReader rdr = new FileReader(TestSource.resolve("testsrc/assert.js"))) {
             cx.evaluateReader(root, rdr, "assert.js", 1, null);
         }
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/LambdaPropertyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/LambdaPropertyTest.java
@@ -1,6 +1,6 @@
 package org.mozilla.javascript.tests;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -11,6 +11,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptableObject;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 
 public class LambdaPropertyTest {
     private Context cx;
@@ -18,7 +19,7 @@ public class LambdaPropertyTest {
 
     @BeforeEach
     public void init() throws IOException {
-        try (FileReader rdr = new FileReader("testsrc/assert.js")) {
+        try (FileReader rdr = new FileReader(TestSource.resolve("testsrc/assert.js"))) {
             cx = Context.enter();
             cx.setLanguageVersion(Context.VERSION_ES6);
             cx.setGeneratingDebug(true);

--- a/tests/src/test/java/org/mozilla/javascript/tests/MozillaSuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/MozillaSuiteTest.java
@@ -22,6 +22,7 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.drivers.JsTestsBase;
 import org.mozilla.javascript.drivers.ShellTest;
 import org.mozilla.javascript.drivers.TestUtils;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
 
 /**
@@ -55,22 +56,25 @@ public class MozillaSuiteTest {
         if (System.getProperty("mozilla.js.tests") != null) {
             testDir = new File(System.getProperty("mozilla.js.tests"));
         } else {
-            URL url = JsTestsBase.class.getResource(".");
-            String path = url.getFile();
+            testDir = new File(TestSource.resolveDirectory("testsrc/tests/test.sh"));
+            if (!testDir.exists()) {
+                URL url = JsTestsBase.class.getResource(".");
+                String path = url.getFile();
 
-            // support running from eclipse
-            if (new File(path + "../../../../../testsrc/tests").exists()) {
-                testDir = new File(path + "../../../../../testsrc/tests").getCanonicalFile();
-            } else {
-                int jsIndex = path.lastIndexOf("/js");
-                if (jsIndex == -1) {
-                    throw new IllegalStateException(
-                            "You aren't running the tests "
-                                    + "from within the standard mozilla/js directory structure");
+                // support running from eclipse
+                if (new File(path + "../../../../../testsrc/tests").exists()) {
+                    testDir = new File(path + "../../../../../testsrc/tests").getCanonicalFile();
+                } else {
+                    int jsIndex = path.lastIndexOf("/js");
+                    if (jsIndex == -1) {
+                        throw new IllegalStateException(
+                                "You aren't running the tests "
+                                        + "from within the standard mozilla/js directory structure");
+                    }
+                    path = path.substring(0, jsIndex + 3).replace('/', File.separatorChar);
+                    path = path.replace("%20", " ");
+                    testDir = new File(path, "tests");
                 }
-                path = path.substring(0, jsIndex + 3).replace('/', File.separatorChar);
-                path = path.replace("%20", " ");
-                testDir = new File(path, "tests");
             }
         }
         if (!testDir.isDirectory()) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeSerializationTest.java
@@ -12,19 +12,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.serialize.ScriptableInputStream;
 import org.mozilla.javascript.serialize.ScriptableOutputStream;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class NativeSerializationTest {
     private Context cx;
-    private VarScope scope;
+    private Global scope;
 
     @BeforeEach
     public void init() {
         cx = Context.enter();
         scope = new Global(cx);
+        scope.setFileLoadPrefix(TestSource.getPrefix());
     }
 
     @AfterEach

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeWrappedArrayTest.java
@@ -16,8 +16,8 @@ import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
-import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 /**
@@ -27,7 +27,7 @@ import org.mozilla.javascript.tools.shell.Global;
 public class NativeWrappedArrayTest {
 
     private Context cx;
-    private TopLevel global;
+    private Global global;
 
     @BeforeEach
     public void init() {
@@ -35,6 +35,7 @@ public class NativeWrappedArrayTest {
         cx.setLanguageVersion(Context.VERSION_ES6);
         cx.getWrapFactory().setJavaPrimitiveWrap(false);
         global = new Global(cx);
+        global.setFileLoadPrefix(TestSource.getPrefix());
     }
 
     @AfterEach
@@ -48,7 +49,9 @@ public class NativeWrappedArrayTest {
         cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
 
         try (InputStreamReader rdr =
-                new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+                new InputStreamReader(
+                        new FileInputStream(
+                                TestSource.resolve("testsrc/jstests/wrapped-arrays.js")))) {
             Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
             assertEquals("success", ret);
         } catch (RhinoException re) {
@@ -62,7 +65,9 @@ public class NativeWrappedArrayTest {
         cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
 
         try (InputStreamReader rdr =
-                new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+                new InputStreamReader(
+                        new FileInputStream(
+                                TestSource.resolve("testsrc/jstests/wrapped-arrays.js")))) {
             Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
             assertEquals("success", ret);
         } catch (RhinoException re) {
@@ -76,7 +81,9 @@ public class NativeWrappedArrayTest {
         cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
 
         try (InputStreamReader rdr =
-                new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+                new InputStreamReader(
+                        new FileInputStream(
+                                TestSource.resolve("testsrc/jstests/wrapped-arrays.js")))) {
             Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
             assertEquals("success", ret);
         } catch (RhinoException re) {
@@ -94,7 +101,9 @@ public class NativeWrappedArrayTest {
         cx.evaluateString(global, setFunc, "setfunc.js", 1, null);
 
         try (InputStreamReader rdr =
-                new InputStreamReader(new FileInputStream("testsrc/jstests/wrapped-arrays.js"))) {
+                new InputStreamReader(
+                        new FileInputStream(
+                                TestSource.resolve("testsrc/jstests/wrapped-arrays.js")))) {
             Object ret = cx.evaluateReader(global, rdr, "wrapped-arrays.js", 1, null);
             assertEquals("success", ret);
         } catch (RhinoException re) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/ReadCommentsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ReadCommentsTest.java
@@ -11,6 +11,7 @@ import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.ScriptNode;
+import org.mozilla.javascript.testutils.TestSource;
 
 public class ReadCommentsTest {
 
@@ -25,7 +26,8 @@ public class ReadCommentsTest {
         Parser p = new Parser(compilerEnv);
         String testJs;
         try (BufferedReader scriptIn =
-                new BufferedReader(new FileReader("testsrc/jstests/withcomments.js"))) {
+                new BufferedReader(
+                        new FileReader(TestSource.resolve("testsrc/jstests/withcomments.js")))) {
             testJs = scriptIn.lines().collect(Collectors.joining(System.lineSeparator()));
         }
         AstRoot ast = p.parse(testJs, "test", 1);

--- a/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ShellTimerTest.java
@@ -1,6 +1,6 @@
 package org.mozilla.javascript.tests;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
-import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 import org.mozilla.javascript.tools.shell.Timers;
@@ -19,7 +19,7 @@ import org.mozilla.javascript.tools.shell.Timers;
 public class ShellTimerTest {
     int optLevel;
     private Context cx;
-    private TopLevel global;
+    private Global global;
     private final Timers timers = new Timers();
 
     public void initShellTimerTest(int optLevel) {
@@ -31,6 +31,7 @@ public class ShellTimerTest {
         cx = Context.enter();
         cx.setLanguageVersion(Context.VERSION_ES6);
         global = new Global(cx);
+        global.setFileLoadPrefix(TestSource.getPrefix());
         timers.install(global);
         global.put("TestsComplete", global, false);
     }

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaLfTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaLfTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,10 +37,13 @@ public class StackTraceExtensionMozillaLfTest {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             VarScope root = cx.newVarEnv(global);
 
             try (FileReader rdr =
-                    new FileReader("testsrc/jstests/extensions/stack-traces-mozilla-lf.js")) {
+                    new FileReader(
+                            TestSource.resolve(
+                                    "testsrc/jstests/extensions/stack-traces-mozilla-lf.js"))) {
                 cx.evaluateReader(root, rdr, "stack-traces-mozilla-lf.js", 1, null);
             }
         } catch (IOException ioe) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionMozillaTest.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,10 +37,13 @@ public class StackTraceExtensionMozillaTest {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             VarScope root = cx.newVarEnv(global);
 
             try (FileReader rdr =
-                    new FileReader("testsrc/jstests/extensions/stack-traces-mozilla.js")) {
+                    new FileReader(
+                            TestSource.resolve(
+                                    "testsrc/jstests/extensions/stack-traces-mozilla.js"))) {
                 cx.evaluateReader(root, rdr, "stack-traces-mozilla.js", 1, null);
             }
         } catch (IOException ioe) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionRhinoTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionRhinoTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -25,11 +26,14 @@ public class StackTraceExtensionRhinoTest {
             cx.setGeneratingDebug(debug);
 
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             VarScope root = cx.newVarEnv(global);
             root.put("ExpectFileNames", global, interpretedMode || debug);
 
             try (FileReader rdr =
-                    new FileReader("testsrc/jstests/extensions/stack-traces-rhino.js")) {
+                    new FileReader(
+                            TestSource.resolve(
+                                    "testsrc/jstests/extensions/stack-traces-rhino.js"))) {
                 cx.evaluateReader(root, rdr, "stack-traces-rhino.js", 1, null);
             }
         } catch (IOException ioe) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionV8Test.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/StackTraceExtensionV8Test.java
@@ -12,6 +12,7 @@ import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.StackStyle;
 import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
 
@@ -36,9 +37,12 @@ public class StackTraceExtensionV8Test {
             cx.setGeneratingDebug(true);
 
             Global global = new Global(cx);
+            global.setFileLoadPrefix(TestSource.getPrefix());
             VarScope root = cx.newVarEnv(global);
 
-            try (FileReader rdr = new FileReader("testsrc/jstests/extensions/stack-traces-v8.js")) {
+            try (FileReader rdr =
+                    new FileReader(
+                            TestSource.resolve("testsrc/jstests/extensions/stack-traces-v8.js"))) {
                 cx.evaluateReader(root, rdr, "stack-traces-v8.js", 1, null);
             }
         } catch (IOException ioe) {

--- a/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java
@@ -54,6 +54,7 @@ import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.drivers.TestUtils;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.SourceReader;
 import org.mozilla.javascript.tools.shell.ShellContextFactory;
 import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
@@ -75,8 +76,8 @@ public class Test262SuiteTest {
     /** The test must be executed just once--in non-strict mode, only. */
     private static final String FLAG_NO_STRICT = "noStrict";
 
-    private static final File testDir = new File("test262/test");
-    private static final String testHarnessDir = "test262/harness/";
+    private static final File testDir;
+    private static final String testHarnessDir;
     private static final String testProperties;
 
     private static final boolean updateTest262Properties;
@@ -116,9 +117,17 @@ public class Test262SuiteTest {
                             "u180e"));
 
     static {
+        // For portability on all platforms, find the location of the test262 tree
+        // by starting with a well-known file and walking from there.
+        testHarnessDir = TestSource.resolveDirectory("test262/harness/assert.js");
+        var testBase = Path.of(testHarnessDir).getParent();
+        testDir = Path.of(testBase.toString(), "test").toFile();
+
         String propFile = System.getProperty("test262properties");
         testProperties =
-                propFile != null && !propFile.equals("") ? propFile : "testsrc/test262.properties";
+                propFile != null && !propFile.equals("")
+                        ? propFile
+                        : TestSource.resolve("testsrc/test262.properties");
 
         String updateProps = System.getProperty("updateTest262properties");
 
@@ -295,7 +304,7 @@ public class Test262SuiteTest {
                     HARNESS_SCRIPT_CACHE.computeIfAbsent(
                             harnessKey,
                             k -> {
-                                String harnessPath = testHarnessDir + harnessFile;
+                                String harnessPath = testHarnessDir + '/' + harnessFile;
                                 try (Reader reader = new FileReader(harnessPath)) {
                                     String script = Kit.readReader(reader);
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/TryCatchWithCommentsParseTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/TryCatchWithCommentsParseTest.java
@@ -10,6 +10,7 @@ import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.Comment;
+import org.mozilla.javascript.testutils.TestSource;
 
 /**
  * Tests if comments between try/catch tokens or blocks makes the parsing go wrong. See {@link
@@ -27,7 +28,9 @@ public class TryCatchWithCommentsParseTest {
         Parser p = new Parser(compilerEnv);
         String testJs;
         try (BufferedReader scriptIn =
-                new BufferedReader(new FileReader("testsrc/jstests/trycatchwithcomments.js"))) {
+                new BufferedReader(
+                        new FileReader(
+                                TestSource.resolve("testsrc/jstests/trycatchwithcomments.js")))) {
             testJs = scriptIn.lines().collect(Collectors.joining(System.lineSeparator()));
         }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/UndefinedTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/UndefinedTest.java
@@ -1,6 +1,8 @@
 package org.mozilla.javascript.tests;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,18 +11,19 @@ import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Undefined;
-import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class UndefinedTest {
     private Context cx;
-    private VarScope global;
+    private Global global;
 
     @BeforeEach
     public void init() {
         cx = Context.enter();
         cx.setLanguageVersion(Context.VERSION_ES6);
         global = new Global(cx);
+        global.setFileLoadPrefix(TestSource.getPrefix());
     }
 
     @AfterEach

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/UnhandledPromiseTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/UnhandledPromiseTest.java
@@ -1,6 +1,8 @@
 package org.mozilla.javascript.tests.es6;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.AfterEach;
@@ -8,12 +10,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Undefined;
-import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.testutils.TestSource;
 import org.mozilla.javascript.tools.shell.Global;
 
 public class UnhandledPromiseTest {
     private Context cx;
-    private VarScope scope;
+    private Global scope;
 
     @BeforeEach
     public void init() {
@@ -22,6 +24,7 @@ public class UnhandledPromiseTest {
         cx.setLanguageVersion(Context.VERSION_ES6);
         cx.setTrackUnhandledPromiseRejections(true);
         scope = new Global(cx);
+        scope.setFileLoadPrefix(TestSource.getPrefix());
     }
 
     @AfterEach

--- a/tests/testsrc/rhino-explicit.config
+++ b/tests/testsrc/rhino-explicit.config
@@ -1,0 +1,6 @@
+# This file is loaded by some testcases in RhinoPropertiesTest
+
+test.rhino-explicit.loaded=true
+
+test.config.foo=value1
+test.config.bar=value2

--- a/testutils/src/main/java/org/mozilla/javascript/testutils/TestSource.java
+++ b/testutils/src/main/java/org/mozilla/javascript/testutils/TestSource.java
@@ -1,0 +1,107 @@
+package org.mozilla.javascript.testutils;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * This class is used to locate the "testsrc" directory and other testing-related resources in the
+ * different test environments where Rhino runs.
+ */
+public class TestSource {
+    private final Resolver resolver;
+
+    private static final TestSource SELF = new TestSource();
+
+    private TestSource() {
+        resolver = new Resolver();
+    }
+
+    /**
+     * Return the actual location of the specified file, or throw an AssertionError if the file
+     * cannot be found. This method must be used so that file lookup is portable across platforms
+     * and build systems, rather than referring directly to files.
+     *
+     * <p>Typically, "path" in this case will start with either "testsrc" or "test262". This class
+     * will locate the "testsrc" directory, which will typically be in a separate location on
+     * different modules and build systems.
+     */
+    public static String resolve(String path) {
+        return SELF.resolver.resolve(path);
+    }
+
+    /**
+     * Return an optional prefix that should be inserted when trying to find files in the "testsrc"
+     * directory specifically. This allows scripts to reference files like "testsrc/foo" in all
+     * cases and have them resolve.
+     *
+     * @return the prefix that must be prepended to all file lookups in the "testsrc" directory, or
+     *     null if no prefix is necessary.
+     */
+    public static String getPrefix() {
+        return SELF.resolver.getPrefix();
+    }
+
+    /**
+     * Return the parent directory of the specified file, or throw an AssertionError if the file
+     * cannot be found. Because of the way that Bazel works, this is preferable to another way.
+     * Callers should use this method by resolving a well-known file, and then this method will
+     * return the directory that contains the file. The directory may then be safely traversed to
+     * find other files that are known to resolve there.
+     */
+    public static String resolveDirectory(String path) {
+        return Path.of(SELF.resolver.resolve(path)).getParent().toString();
+    }
+
+    /**
+     * Like resolveDirectory, but go up "lvl" levels to get the parent of a well-known file multiple
+     * levels up.
+     */
+    public static String resolveDirectories(String path, int lvl) {
+        var p = Path.of(SELF.resolver.resolve(path));
+        for (int i = 0; p != null && i < lvl; i++) {
+            p = p.getParent();
+        }
+        return p == null ? "" : p.toString();
+    }
+
+    /**
+     * A class to do the actual resolution. Is is abstracted out to support additional test
+     * environments in the future.
+     */
+    private static class Resolver {
+        private final String prefix;
+
+        Resolver() {
+            // Look where Gradle will put the files in the "tests" module
+            var testSrc = Path.of("./testsrc");
+            if (Files.isDirectory(testSrc)) {
+                prefix = null;
+                return;
+            }
+            // Look where Bazel will eventually put the files
+            testSrc = Path.of("./tests/testsrc");
+            if (Files.isDirectory(testSrc)) {
+                prefix = "./tests";
+                return;
+            }
+            // Look where Gradle will put the files in other modules
+            testSrc = Path.of("../tests/testsrc");
+            if (Files.isDirectory(testSrc)) {
+                prefix = "../tests";
+                return;
+            }
+            prefix = "NOTFOUND";
+        }
+
+        String resolve(String path) {
+            if (prefix == null) {
+                return path;
+            }
+            return prefix + '/' + path;
+        }
+
+        String getPrefix() {
+            return prefix;
+        }
+    }
+}

--- a/testutils/src/test/java/org/mozilla/javascript/testutils/tests/TestSourceTest.java
+++ b/testutils/src/test/java/org/mozilla/javascript/testutils/tests/TestSourceTest.java
@@ -1,0 +1,35 @@
+package org.mozilla.javascript.testutils.tests;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.TestSource;
+
+public class TestSourceTest {
+    @Test
+    public void testPrefixTestFile() {
+        String path = TestSource.resolve("testsrc/assert.js");
+        assertNotNull(path);
+        assertTrue(Files.exists(Path.of(path)));
+        assertTrue(Files.isRegularFile(Path.of(path)));
+    }
+
+    @Test
+    public void testPrefixTestDirectory() {
+        String path = TestSource.resolveDirectory("testsrc/assert.js");
+        assertNotNull(path);
+        assertTrue(Files.exists(Path.of(path)));
+        assertTrue(Files.isDirectory(Path.of(path)));
+    }
+
+    @Test
+    public void testPrefixTestDirectories() {
+        String path = TestSource.resolveDirectories("testsrc/assert.js", 2);
+        assertNotNull(path);
+        assertTrue(Files.exists(Path.of(path)));
+        assertTrue(Files.isDirectory(Path.of(path)));
+    }
+}


### PR DESCRIPTION
Different build systems that we may use in the future handle test files
differently. Introduce an abstraction layer to locate test files (especially
the "testsrc" directory and its contents) that we can extend for these later,
and ensure that all tests use them.

Also fix two class path problems that will cause problems for more complex 
build systems like Bazel.
