### PR TITLE
Make parameter type of `setParentScope` be `VarScope`.

### DIFF
--- a/examples/src/main/java/Matrix.java
+++ b/examples/src/main/java/Matrix.java
@@ -196,7 +196,7 @@ public class Matrix implements Scriptable {
 
     /** Set parent. */
     @Override
-    public void setParentScope(Scriptable parent) {
+    public void setParentScope(VarScope parent) {
         this.parent = (VarScope) parent;
     }
 

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/Namespace.java
@@ -46,7 +46,7 @@ class Namespace extends ScriptableObject {
 
     private Namespace() {}
 
-    static Namespace create(Scriptable scope, Namespace prototype, XmlNode.Namespace namespace) {
+    static Namespace create(VarScope scope, Namespace prototype, XmlNode.Namespace namespace) {
         Namespace rv = new Namespace();
         rv.setParentScope(scope);
         rv.prototype = prototype;

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/QName.java
@@ -68,7 +68,7 @@ final class QName extends ScriptableObject {
 
     private QName() {}
 
-    static QName create(XMLLibImpl lib, Scriptable scope, QName prototype, XmlNode.QName delegate) {
+    static QName create(XMLLibImpl lib, VarScope scope, QName prototype, XmlNode.QName delegate) {
         QName rv = new QName();
         rv.lib = lib;
         rv.setParentScope(scope);

--- a/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
+++ b/rhino-xml/src/main/java/org/mozilla/javascript/xmlimpl/XMLList.java
@@ -44,7 +44,7 @@ class XMLList extends XMLObjectImpl implements Function {
     }
 
     public static void init(
-            Context cx, Scriptable scope, XMLObjectImpl proto, boolean sealdd, XMLLibImpl lib) {
+            Context cx, VarScope scope, XMLObjectImpl proto, boolean sealdd, XMLLibImpl lib) {
         DESCRIPTOR.buildConstructor(
                 cx,
                 (VarScope) scope,

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -562,7 +562,7 @@ public class BaseFunction extends ScriptableObject implements Function {
                 }
             }
             if (result.getParentScope() == null) {
-                Scriptable parent = getParentScope();
+                VarScope parent = getParentScope();
                 if (result != parent) {
                     result.setParentScope(parent);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/Delegator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Delegator.java
@@ -211,7 +211,7 @@ public class Delegator implements Function, SymbolScriptable {
      * @see org.mozilla.javascript.Scriptable#setParentScope
      */
     @Override
-    public void setParentScope(Scriptable parent) {
+    public void setParentScope(VarScope parent) {
         getDelegee().setParentScope(parent);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdFunctionObject.java
@@ -36,7 +36,7 @@ public class IdFunctionObject extends BaseFunction {
         this.functionName = name;
     }
 
-    public void initFunction(String name, Scriptable scope) {
+    public void initFunction(String name, VarScope scope) {
         if (name == null) throw new IllegalArgumentException();
         if (scope == null) throw new IllegalArgumentException();
         this.functionName = name;
@@ -122,7 +122,7 @@ public class IdFunctionObject extends BaseFunction {
                 }
             }
             if (result.getParentScope() == null) {
-                Scriptable parent = getParentScope();
+                VarScope parent = getParentScope();
                 if (result != parent) {
                     result.setParentScope(parent);
                 }

--- a/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ImporterTopLevel.java
@@ -201,7 +201,7 @@ public class ImporterTopLevel extends TopLevel {
     // than a scope, and then we need to work out to how make the
     // import work on the correct thing.
     private static Scriptable js_construct(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         ImporterGlobalThis result = new ImporterGlobalThis(false);
         for (int i = 0; i != args.length; ++i) {
             Object arg = args[i];

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -605,7 +605,7 @@ public final class Interpreter extends Icode implements Evaluator {
         }
 
         @Override
-        public void setParentScope(Scriptable parent) {
+        public void setParentScope(VarScope parent) {
             // Do nothing.
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeBoolean.java
@@ -62,13 +62,13 @@ final class NativeBoolean extends ScriptableObject {
     }
 
     private static Object js_constructorFunc(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         boolean b = ScriptRuntime.toBoolean(args.length > 0 ? args[0] : Undefined.instance);
         return ScriptRuntime.wrapBoolean(b);
     }
 
     private static NativeBoolean js_constructor(
-            Context cx, JSFunction fun, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction fun, Object nt, VarScope s, Object thisObj, Object[] args) {
         boolean b = ScriptRuntime.toBoolean(args.length > 0 ? args[0] : Undefined.instance);
         var res = new NativeBoolean(b);
         res.setPrototype((Scriptable) fun.getPrototypeProperty());
@@ -77,17 +77,17 @@ final class NativeBoolean extends ScriptableObject {
     }
 
     private static String js_toString(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toValue(thisObj) ? "true" : "false";
     }
 
     private static Object js_valueOf(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return toValue(thisObj);
     }
 
     private static Object js_toSource(
-            Context cx, JSFunction f, Object nt, Scriptable s, Object thisObj, Object[] args) {
+            Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         return "(new Boolean(" + ScriptRuntime.toString(toValue(thisObj)) + "))";
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeCallSite.java
@@ -20,7 +20,7 @@ public class NativeCallSite extends IdScriptableObject {
         cs.exportAsJSClass(MAX_PROTOTYPE_ID, scope, sealed);
     }
 
-    static NativeCallSite make(Scriptable scope, Scriptable ctorObj) {
+    static NativeCallSite make(VarScope scope, Scriptable ctorObj) {
         NativeCallSite cs = new NativeCallSite();
         Scriptable proto = (Scriptable) ctorObj.get("prototype", ctorObj);
         cs.setParentScope(scope);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeError.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeError.java
@@ -99,7 +99,7 @@ final class NativeError extends ScriptableObject {
                 0);
     }
 
-    static NativeError makeProto(Scriptable scope, Function ctorObj) {
+    static NativeError makeProto(VarScope scope, Function ctorObj) {
         Scriptable proto = (Scriptable) ctorObj.get("prototype", ctorObj);
 
         NativeError obj = new NativeError();
@@ -108,7 +108,7 @@ final class NativeError extends ScriptableObject {
         return obj;
     }
 
-    static NativeError make(Context cx, Scriptable scope, Function ctorObj, Object[] args) {
+    static NativeError make(Context cx, VarScope scope, Function ctorObj, Object[] args) {
         NativeError obj = makeProto(scope, ctorObj);
 
         int arglen = args.length;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -172,8 +172,8 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     /** Sets the parent (enclosing) scope of the object. */
     @Override
-    public void setParentScope(Scriptable m) {
-        parent = (VarScope) m;
+    public void setParentScope(VarScope m) {
+        parent = m;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWith.java
@@ -141,8 +141,8 @@ public class NativeWith implements Scriptable, SymbolScriptable, IdFunctionCall,
     }
 
     @Override
-    public void setParentScope(Scriptable parent) {
-        this.parent = (VarScope) parent;
+    public void setParentScope(VarScope parent) {
+        this.parent = parent;
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
@@ -277,7 +277,7 @@ public interface Scriptable extends PropHolder<Scriptable> {
      *
      * @param parent the parent scope to set
      */
-    public void setParentScope(Scriptable parent);
+    public void setParentScope(VarScope parent);
 
     /**
      * Get an array of property ids.

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -601,8 +601,8 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
 
     /** Sets the parent (enclosing) scope of the object. */
     @Override
-    public void setParentScope(Scriptable m) {
-        parentScopeObject = (VarScope) m;
+    public void setParentScope(VarScope m) {
+        parentScopeObject = m;
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/Undefined.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Undefined.java
@@ -113,7 +113,7 @@ public class Undefined implements Serializable {
         }
 
         @Override
-        public void setParentScope(Scriptable parent) {}
+        public void setParentScope(VarScope parent) {}
 
         @Override
         public Object[] getIds() {

--- a/rhino/src/main/java/org/mozilla/javascript/VarScope.java
+++ b/rhino/src/main/java/org/mozilla/javascript/VarScope.java
@@ -33,7 +33,7 @@ public interface VarScope extends Scriptable, ConstProperties<Scriptable> {
     }
 
     @Override
-    default void setParentScope(Scriptable parent) {
+    default void setParentScope(VarScope parent) {
         Kit.codeBug("Attempt to change parent of scope.");
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/IterableTest.java
@@ -267,7 +267,7 @@ public class IterableTest {
         }
 
         @Override
-        public void setParentScope(Scriptable parent) {
+        public void setParentScope(VarScope parent) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 


### PR DESCRIPTION
Next commit from #2330.