### PR TITLE
Created request classes for Context.compile and eval

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1191,6 +1191,26 @@ public class Context implements Closeable {
     }
 
     /**
+     * Compile and execute a script described by {@code spec} in the given scope.
+     *
+     * @return the result of evaluating the source, or null if compilation produced no script
+     */
+    public final Object evaluateScript(ScriptCompileSpec spec, VarScope scope) {
+        Script script = compileScript(spec);
+        if (script != null) {
+            return script.exec(this, scope, scope);
+        }
+        return null;
+    }
+
+    /**
+     * @see #evaluateScript(ScriptCompileSpec, VarScope)
+     */
+    public final Object evaluateScript(ScriptCompileSpec.Builder spec, VarScope scope) {
+        return evaluateScript(spec.build(), scope);
+    }
+
+    /**
      * Evaluate a JavaScript source string.
      *
      * <p>The provided source name and line number are used for error messages and for producing
@@ -1208,12 +1228,13 @@ public class Context implements Closeable {
      */
     public final Object evaluateString(
             VarScope scope, String source, String sourceName, int lineno, Object securityDomain) {
-        Script script = compileString(source, sourceName, lineno, securityDomain);
-        if (script != null) {
-            return script.exec(
-                    this, scope, ScriptableObject.getTopLevelScope(scope).getGlobalThis());
-        }
-        return null;
+        return evaluateScript(
+                ScriptCompileSpec.fromSource(source)
+                        .sourceName(sourceName)
+                        .lineno(lineno)
+                        .securityDomain(securityDomain)
+                        .build(),
+                scope);
     }
 
     /**
@@ -1234,12 +1255,13 @@ public class Context implements Closeable {
     public final Object evaluateReader(
             VarScope scope, Reader in, String sourceName, int lineno, Object securityDomain)
             throws IOException {
-        Script script = compileReader(in, sourceName, lineno, securityDomain);
-        if (script != null) {
-            return script.exec(
-                    this, scope, ScriptableObject.getTopLevelScope(scope).getGlobalThis());
-        }
-        return null;
+        return evaluateScript(
+                ScriptCompileSpec.fromReader(in)
+                        .sourceName(sourceName)
+                        .lineno(lineno)
+                        .securityDomain(securityDomain)
+                        .build(),
+                scope);
     }
 
     /**
@@ -1436,22 +1458,13 @@ public class Context implements Closeable {
             Object securityDomain,
             Consumer<CompilerEnvirons> compilerEnvironsProcessor)
             throws IOException {
-        if (lineno < 0) {
-            // For compatibility IllegalArgumentException can not be thrown here
-            lineno = 0;
-        }
-
-        return (Script)
-                compileImpl(
-                        null,
-                        Kit.readReader(in),
-                        sourceName,
-                        lineno,
-                        securityDomain,
-                        false,
-                        null,
-                        null,
-                        compilerEnvironsProcessor);
+        return compileScript(
+                ScriptCompileSpec.fromReader(in)
+                        .sourceName(sourceName)
+                        .lineno(lineno)
+                        .securityDomain(securityDomain)
+                        .compilerEnvironsProcessor(compilerEnvironsProcessor)
+                        .build());
     }
 
     /**
@@ -1471,10 +1484,6 @@ public class Context implements Closeable {
      */
     public final Script compileString(
             String source, String sourceName, int lineno, Object securityDomain) {
-        if (lineno < 0) {
-            // For compatibility IllegalArgumentException can not be thrown here
-            lineno = 0;
-        }
         return compileString(source, null, null, sourceName, lineno, securityDomain, null);
     }
 
@@ -1486,17 +1495,15 @@ public class Context implements Closeable {
             int lineno,
             Object securityDomain,
             Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-        return (Script)
-                compileImpl(
-                        null,
-                        source,
-                        sourceName,
-                        lineno,
-                        securityDomain,
-                        false,
-                        compiler,
-                        compilationErrorReporter,
-                        compilerEnvironsProcessor);
+        return compileScript(
+                ScriptCompileSpec.fromSource(source)
+                        .sourceName(sourceName)
+                        .lineno(lineno)
+                        .securityDomain(securityDomain)
+                        .compiler(compiler)
+                        .compilationErrorReporter(compilationErrorReporter)
+                        .compilerEnvironsProcessor(compilerEnvironsProcessor)
+                        .build());
     }
 
     /**
@@ -1528,17 +1535,38 @@ public class Context implements Closeable {
             String sourceName,
             int lineno,
             Object securityDomain) {
-        return (Function)
-                compileImpl(
-                        scope,
-                        source,
-                        sourceName,
-                        lineno,
-                        securityDomain,
-                        true,
-                        compiler,
-                        compilationErrorReporter,
-                        null);
+        return compileFunction(
+                FunctionCompileSpec.fromSource(source, scope)
+                        .sourceName(sourceName)
+                        .lineno(lineno)
+                        .securityDomain(securityDomain)
+                        .compiler(compiler)
+                        .compilationErrorReporter(compilationErrorReporter)
+                        .build());
+    }
+
+    /** Compile a script described by {@code spec}. */
+    public final Script compileScript(ScriptCompileSpec spec) {
+        return compileScriptImpl(spec);
+    }
+
+    /**
+     * @see #compileScript(ScriptCompileSpec)
+     */
+    public final Script compileScript(ScriptCompileSpec.Builder spec) {
+        return compileScriptImpl(spec.build());
+    }
+
+    /** Compile a function described by {@code spec}. */
+    public final Function compileFunction(FunctionCompileSpec spec) {
+        return compileFunctionImpl(spec);
+    }
+
+    /**
+     * @see #compileFunction(FunctionCompileSpec)
+     */
+    public final Function compileFunction(FunctionCompileSpec.Builder spec) {
+        return compileFunctionImpl(spec.build());
     }
 
     /**
@@ -2540,19 +2568,48 @@ public class Context implements Closeable {
         return cx;
     }
 
-    protected Object compileImpl(
-            VarScope scope,
+    protected Script compileScriptImpl(ScriptCompileSpec spec) {
+        return (Script)
+                compileImpl(
+                        spec.source(),
+                        spec.sourceName(),
+                        spec.lineno(),
+                        spec.securityDomain(),
+                        spec.compiler(),
+                        spec.compilationErrorReporter(),
+                        spec.compilerEnvironsProcessor(),
+                        null,
+                        false);
+    }
+
+    protected Function compileFunctionImpl(FunctionCompileSpec spec) {
+        return (Function)
+                compileImpl(
+                        spec.source(),
+                        spec.sourceName(),
+                        spec.lineno(),
+                        spec.securityDomain(),
+                        spec.compiler(),
+                        spec.compilationErrorReporter(),
+                        spec.compilerEnvironsProcessor(),
+                        spec.scope(),
+                        true);
+    }
+
+    private Object compileImpl(
             String sourceString,
             String sourceName,
             int lineno,
             Object securityDomain,
-            boolean returnFunction,
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironProcessor) {
+            Consumer<CompilerEnvirons> compilerEnvironProcessor,
+            VarScope scope,
+            boolean returnFunction) {
         if (sourceName == null) {
             sourceName = "unnamed script";
         }
+
         if (securityDomain != null && getSecurityController() == null) {
             throw new IllegalArgumentException(
                     "securityDomain should be null if setSecurityController() was never called");
@@ -2564,9 +2621,11 @@ public class Context implements Closeable {
         CompilerEnvirons compilerEnv = new CompilerEnvirons();
         compilerEnv.initFromContext(this);
         compilerEnv.setSecurityDomain(securityDomain);
+
         if (compilationErrorReporter == null) {
             compilationErrorReporter = compilerEnv.getErrorReporter();
         }
+
         if (compilerEnvironProcessor != null) {
             compilerEnvironProcessor.accept(compilerEnv);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2571,13 +2571,13 @@ public class Context implements Closeable {
     protected Script compileScriptImpl(ScriptCompileSpec spec) {
         return (Script)
                 compileImpl(
-                        spec.source(),
-                        spec.sourceName(),
-                        spec.lineno(),
-                        spec.securityDomain(),
-                        spec.compiler(),
-                        spec.compilationErrorReporter(),
-                        spec.compilerEnvironsProcessor(),
+                        spec.getSource(),
+                        spec.getSourceName(),
+                        spec.getLineno(),
+                        spec.getSecurityDomain(),
+                        spec.getCompiler(),
+                        spec.getCompilationErrorReporter(),
+                        spec.getCompilerEnvironsProcessor(),
                         null,
                         false);
     }
@@ -2585,14 +2585,14 @@ public class Context implements Closeable {
     protected Function compileFunctionImpl(FunctionCompileSpec spec) {
         return (Function)
                 compileImpl(
-                        spec.source(),
-                        spec.sourceName(),
-                        spec.lineno(),
-                        spec.securityDomain(),
-                        spec.compiler(),
-                        spec.compilationErrorReporter(),
-                        spec.compilerEnvironsProcessor(),
-                        spec.scope(),
+                        spec.getSource(),
+                        spec.getSourceName(),
+                        spec.getLineno(),
+                        spec.getSecurityDomain(),
+                        spec.getCompiler(),
+                        spec.getCompilationErrorReporter(),
+                        spec.getCompilerEnvironsProcessor(),
+                        spec.getScope(),
                         true);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -1,0 +1,101 @@
+package org.mozilla.javascript;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.function.Consumer;
+
+/**
+ * Parameters for compiling a JavaScript function (a single function definition). The parent scope
+ * is required, so it must be supplied to {@link #fromSource(String, VarScope)} or {@link
+ * #fromReader(Reader, VarScope)}. Pass instances to {@link
+ * Context#compileFunction(FunctionCompileSpec)}.
+ *
+ * @see ScriptCompileSpec
+ */
+public record FunctionCompileSpec(
+        String source,
+        VarScope scope,
+        String sourceName,
+        int lineno,
+        Object securityDomain,
+        Evaluator compiler,
+        ErrorReporter compilationErrorReporter,
+        Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+
+    public FunctionCompileSpec {
+        if (scope == null) {
+            throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+        }
+    }
+
+    public static Builder fromSource(String source, VarScope scope) {
+        return new Builder(source, scope);
+    }
+
+    public static Builder fromReader(Reader reader, VarScope scope) throws IOException {
+        return new Builder(Kit.readReader(reader), scope);
+    }
+
+    public static final class Builder {
+        private final String source;
+        private final VarScope scope;
+        private String sourceName;
+        private int lineno = 0;
+        private Object securityDomain;
+        private Evaluator compiler;
+        private ErrorReporter compilationErrorReporter;
+        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+
+        private Builder(String source, VarScope scope) {
+            if (scope == null) {
+                throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+            }
+            this.source = source;
+            this.scope = scope;
+        }
+
+        public Builder sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            return this;
+        }
+
+        public Builder lineno(int lineno) {
+            this.lineno = lineno;
+            return this;
+        }
+
+        public Builder securityDomain(Object securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
+
+        public Builder compiler(Evaluator compiler) {
+            this.compiler = compiler;
+            return this;
+        }
+
+        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+            this.compilationErrorReporter = compilationErrorReporter;
+            return this;
+        }
+
+        public Builder compilerEnvironsProcessor(
+                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+            return this;
+        }
+
+        public FunctionCompileSpec build() {
+            int normalizedLineno = Math.max(lineno, 0);
+            return new FunctionCompileSpec(
+                    source,
+                    scope,
+                    sourceName,
+                    normalizedLineno,
+                    securityDomain,
+                    compiler,
+                    compilationErrorReporter,
+                    compilerEnvironsProcessor);
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -2,6 +2,7 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -12,90 +13,130 @@ import java.util.function.Consumer;
  *
  * @see ScriptCompileSpec
  */
-public record FunctionCompileSpec(
-        String source,
-        VarScope scope,
-        String sourceName,
-        int lineno,
-        Object securityDomain,
-        Evaluator compiler,
-        ErrorReporter compilationErrorReporter,
-        Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+public final class FunctionCompileSpec {
+	private final String source;
+	private final VarScope scope;
+	private final String sourceName;
+	private final int lineno;
+	private final Object securityDomain;
+	private final Evaluator compiler;
+	private final ErrorReporter compilationErrorReporter;
+	private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-    public FunctionCompileSpec {
-        if (scope == null) {
-            throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
-        }
-    }
+	public FunctionCompileSpec(String source, VarScope scope, String sourceName, int lineno, Object securityDomain, Evaluator compiler, ErrorReporter compilationErrorReporter, Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+		if (scope == null) {
+			throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+		}
+		this.source = source;
+		this.scope = scope;
+		this.sourceName = sourceName;
+		this.lineno = lineno;
+		this.securityDomain = securityDomain;
+		this.compiler = compiler;
+		this.compilationErrorReporter = compilationErrorReporter;
+		this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+	}
 
-    public static Builder fromSource(String source, VarScope scope) {
-        return new Builder(source, scope);
-    }
+	public static Builder fromSource(String source, VarScope scope) {
+		return new Builder(source, scope);
+	}
 
-    public static Builder fromReader(Reader reader, VarScope scope) throws IOException {
-        return new Builder(Kit.readReader(reader), scope);
-    }
+	public static Builder fromReader(Reader reader, VarScope scope) throws IOException {
+		return new Builder(Kit.readReader(reader), scope);
+	}
 
-    public static final class Builder {
-        private final String source;
-        private final VarScope scope;
-        private String sourceName;
-        private int lineno = 0;
-        private Object securityDomain;
-        private Evaluator compiler;
-        private ErrorReporter compilationErrorReporter;
-        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+	public String getSource() {
+		return source;
+	}
 
-        private Builder(String source, VarScope scope) {
-            if (scope == null) {
-                throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
-            }
-            this.source = source;
-            this.scope = scope;
-        }
+	public VarScope getScope() {
+		return scope;
+	}
 
-        public Builder sourceName(String sourceName) {
-            this.sourceName = sourceName;
-            return this;
-        }
+	public String getSourceName() {
+		return sourceName;
+	}
 
-        public Builder lineno(int lineno) {
-            this.lineno = lineno;
-            return this;
-        }
+	public int getLineno() {
+		return lineno;
+	}
 
-        public Builder securityDomain(Object securityDomain) {
-            this.securityDomain = securityDomain;
-            return this;
-        }
+	public Object getSecurityDomain() {
+		return securityDomain;
+	}
 
-        public Builder compiler(Evaluator compiler) {
-            this.compiler = compiler;
-            return this;
-        }
+	public Evaluator getCompiler() {
+		return compiler;
+	}
 
-        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-            this.compilationErrorReporter = compilationErrorReporter;
-            return this;
-        }
+	public ErrorReporter getCompilationErrorReporter() {
+		return compilationErrorReporter;
+	}
 
-        public Builder compilerEnvironsProcessor(
-                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-            return this;
-        }
+	public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
+		return compilerEnvironsProcessor;
+	}
 
-        public FunctionCompileSpec build() {
-            int normalizedLineno = Math.max(lineno, 0);
-            return new FunctionCompileSpec(
-                    source,
-                    scope,
-                    sourceName,
-                    normalizedLineno,
-                    securityDomain,
-                    compiler,
-                    compilationErrorReporter,
-                    compilerEnvironsProcessor);
-        }
-    }
+	public static final class Builder {
+		private final String source;
+		private final VarScope scope;
+		private String sourceName;
+		private int lineno = 0;
+		private Object securityDomain;
+		private Evaluator compiler;
+		private ErrorReporter compilationErrorReporter;
+		private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+
+		private Builder(String source, VarScope scope) {
+			if (scope == null) {
+				throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+			}
+			this.source = source;
+			this.scope = scope;
+		}
+
+		public Builder sourceName(String sourceName) {
+			this.sourceName = sourceName;
+			return this;
+		}
+
+		public Builder lineno(int lineno) {
+			this.lineno = lineno;
+			return this;
+		}
+
+		public Builder securityDomain(Object securityDomain) {
+			this.securityDomain = securityDomain;
+			return this;
+		}
+
+		public Builder compiler(Evaluator compiler) {
+			this.compiler = compiler;
+			return this;
+		}
+
+		public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+			this.compilationErrorReporter = compilationErrorReporter;
+			return this;
+		}
+
+		public Builder compilerEnvironsProcessor(
+				Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+			this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+			return this;
+		}
+
+		public FunctionCompileSpec build() {
+			int normalizedLineno = Math.max(lineno, 0);
+			return new FunctionCompileSpec(
+					source,
+					scope,
+					sourceName,
+					normalizedLineno,
+					securityDomain,
+					compiler,
+					compilationErrorReporter,
+					compilerEnvironsProcessor);
+		}
+	}
 }

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -2,7 +2,6 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -14,129 +13,137 @@ import java.util.function.Consumer;
  * @see ScriptCompileSpec
  */
 public final class FunctionCompileSpec {
-	private final String source;
-	private final VarScope scope;
-	private final String sourceName;
-	private final int lineno;
-	private final Object securityDomain;
-	private final Evaluator compiler;
-	private final ErrorReporter compilationErrorReporter;
-	private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    private final String source;
+    private final VarScope scope;
+    private final String sourceName;
+    private final int lineno;
+    private final Object securityDomain;
+    private final Evaluator compiler;
+    private final ErrorReporter compilationErrorReporter;
+    private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-	public FunctionCompileSpec(String source, VarScope scope, String sourceName, int lineno, Object securityDomain, Evaluator compiler, ErrorReporter compilationErrorReporter, Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-		if (scope == null) {
-			throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
-		}
-		this.source = source;
-		this.scope = scope;
-		this.sourceName = sourceName;
-		this.lineno = lineno;
-		this.securityDomain = securityDomain;
-		this.compiler = compiler;
-		this.compilationErrorReporter = compilationErrorReporter;
-		this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-	}
+    public FunctionCompileSpec(
+            String source,
+            VarScope scope,
+            String sourceName,
+            int lineno,
+            Object securityDomain,
+            Evaluator compiler,
+            ErrorReporter compilationErrorReporter,
+            Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+        if (scope == null) {
+            throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+        }
+        this.source = source;
+        this.scope = scope;
+        this.sourceName = sourceName;
+        this.lineno = lineno;
+        this.securityDomain = securityDomain;
+        this.compiler = compiler;
+        this.compilationErrorReporter = compilationErrorReporter;
+        this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+    }
 
-	public static Builder fromSource(String source, VarScope scope) {
-		return new Builder(source, scope);
-	}
+    public static Builder fromSource(String source, VarScope scope) {
+        return new Builder(source, scope);
+    }
 
-	public static Builder fromReader(Reader reader, VarScope scope) throws IOException {
-		return new Builder(Kit.readReader(reader), scope);
-	}
+    public static Builder fromReader(Reader reader, VarScope scope) throws IOException {
+        return new Builder(Kit.readReader(reader), scope);
+    }
 
-	public String getSource() {
-		return source;
-	}
+    public String getSource() {
+        return source;
+    }
 
-	public VarScope getScope() {
-		return scope;
-	}
+    public VarScope getScope() {
+        return scope;
+    }
 
-	public String getSourceName() {
-		return sourceName;
-	}
+    public String getSourceName() {
+        return sourceName;
+    }
 
-	public int getLineno() {
-		return lineno;
-	}
+    public int getLineno() {
+        return lineno;
+    }
 
-	public Object getSecurityDomain() {
-		return securityDomain;
-	}
+    public Object getSecurityDomain() {
+        return securityDomain;
+    }
 
-	public Evaluator getCompiler() {
-		return compiler;
-	}
+    public Evaluator getCompiler() {
+        return compiler;
+    }
 
-	public ErrorReporter getCompilationErrorReporter() {
-		return compilationErrorReporter;
-	}
+    public ErrorReporter getCompilationErrorReporter() {
+        return compilationErrorReporter;
+    }
 
-	public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
-		return compilerEnvironsProcessor;
-	}
+    public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
+        return compilerEnvironsProcessor;
+    }
 
-	public static final class Builder {
-		private final String source;
-		private final VarScope scope;
-		private String sourceName;
-		private int lineno = 0;
-		private Object securityDomain;
-		private Evaluator compiler;
-		private ErrorReporter compilationErrorReporter;
-		private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    public static final class Builder {
+        private final String source;
+        private final VarScope scope;
+        private String sourceName;
+        private int lineno = 0;
+        private Object securityDomain;
+        private Evaluator compiler;
+        private ErrorReporter compilationErrorReporter;
+        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-		private Builder(String source, VarScope scope) {
-			if (scope == null) {
-				throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
-			}
-			this.source = source;
-			this.scope = scope;
-		}
+        private Builder(String source, VarScope scope) {
+            if (scope == null) {
+                throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
+            }
+            this.source = source;
+            this.scope = scope;
+        }
 
-		public Builder sourceName(String sourceName) {
-			this.sourceName = sourceName;
-			return this;
-		}
+        public Builder sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            return this;
+        }
 
-		public Builder lineno(int lineno) {
-			this.lineno = lineno;
-			return this;
-		}
+        public Builder lineno(int lineno) {
+            this.lineno = lineno;
+            return this;
+        }
 
-		public Builder securityDomain(Object securityDomain) {
-			this.securityDomain = securityDomain;
-			return this;
-		}
+        public Builder securityDomain(Object securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
 
-		public Builder compiler(Evaluator compiler) {
-			this.compiler = compiler;
-			return this;
-		}
+        public Builder compiler(Evaluator compiler) {
+            this.compiler = compiler;
+            return this;
+        }
 
-		public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-			this.compilationErrorReporter = compilationErrorReporter;
-			return this;
-		}
+        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+            this.compilationErrorReporter = compilationErrorReporter;
+            return this;
+        }
 
-		public Builder compilerEnvironsProcessor(
-				Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-			this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-			return this;
-		}
+        public Builder compilerEnvironsProcessor(
+                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+            return this;
+        }
 
-		public FunctionCompileSpec build() {
-			int normalizedLineno = Math.max(lineno, 0);
-			return new FunctionCompileSpec(
-					source,
-					scope,
-					sourceName,
-					normalizedLineno,
-					securityDomain,
-					compiler,
-					compilationErrorReporter,
-					compilerEnvironsProcessor);
-		}
-	}
+        public FunctionCompileSpec build() {
+            int normalizedLineno = Math.max(lineno, 0);
+            return new FunctionCompileSpec(
+                    source,
+                    scope,
+                    sourceName,
+                    normalizedLineno,
+                    securityDomain,
+                    compiler,
+                    compilationErrorReporter,
+                    compilerEnvironsProcessor);
+        }
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -2,7 +2,6 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -14,121 +13,121 @@ import java.util.function.Consumer;
  * @see FunctionCompileSpec
  */
 public final class ScriptCompileSpec {
-	private final String source;
-	private final String sourceName;
-	private final int lineno;
-	private final Object securityDomain;
-	private final Evaluator compiler;
-	private final ErrorReporter compilationErrorReporter;
-	private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    private final String source;
+    private final String sourceName;
+    private final int lineno;
+    private final Object securityDomain;
+    private final Evaluator compiler;
+    private final ErrorReporter compilationErrorReporter;
+    private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-	public ScriptCompileSpec(
-			String source,
-			String sourceName,
-			int lineno,
-			Object securityDomain,
-			Evaluator compiler,
-			ErrorReporter compilationErrorReporter,
-			Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-		this.source = source;
-		this.sourceName = sourceName;
-		this.lineno = lineno;
-		this.securityDomain = securityDomain;
-		this.compiler = compiler;
-		this.compilationErrorReporter = compilationErrorReporter;
-		this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-	}
+    public ScriptCompileSpec(
+            String source,
+            String sourceName,
+            int lineno,
+            Object securityDomain,
+            Evaluator compiler,
+            ErrorReporter compilationErrorReporter,
+            Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+        this.source = source;
+        this.sourceName = sourceName;
+        this.lineno = lineno;
+        this.securityDomain = securityDomain;
+        this.compiler = compiler;
+        this.compilationErrorReporter = compilationErrorReporter;
+        this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+    }
 
-	public static Builder fromSource(String source) {
-		return new Builder(source);
-	}
+    public static Builder fromSource(String source) {
+        return new Builder(source);
+    }
 
-	public static Builder fromReader(Reader reader) throws IOException {
-		return new Builder(Kit.readReader(reader));
-	}
+    public static Builder fromReader(Reader reader) throws IOException {
+        return new Builder(Kit.readReader(reader));
+    }
 
-	public String getSource() {
-		return source;
-	}
+    public String getSource() {
+        return source;
+    }
 
-	public String getSourceName() {
-		return sourceName;
-	}
+    public String getSourceName() {
+        return sourceName;
+    }
 
-	public int getLineno() {
-		return lineno;
-	}
+    public int getLineno() {
+        return lineno;
+    }
 
-	public Object getSecurityDomain() {
-		return securityDomain;
-	}
+    public Object getSecurityDomain() {
+        return securityDomain;
+    }
 
-	public Evaluator getCompiler() {
-		return compiler;
-	}
+    public Evaluator getCompiler() {
+        return compiler;
+    }
 
-	public ErrorReporter getCompilationErrorReporter() {
-		return compilationErrorReporter;
-	}
+    public ErrorReporter getCompilationErrorReporter() {
+        return compilationErrorReporter;
+    }
 
-	public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
-		return compilerEnvironsProcessor;
-	}
+    public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
+        return compilerEnvironsProcessor;
+    }
 
-	public static final class Builder {
-		private final String source;
-		private String sourceName;
-		private int lineno = 0;
-		private Object securityDomain;
-		private Evaluator compiler;
-		private ErrorReporter compilationErrorReporter;
-		private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    public static final class Builder {
+        private final String source;
+        private String sourceName;
+        private int lineno = 0;
+        private Object securityDomain;
+        private Evaluator compiler;
+        private ErrorReporter compilationErrorReporter;
+        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-		private Builder(String source) {
-			this.source = source;
-		}
+        private Builder(String source) {
+            this.source = source;
+        }
 
-		public Builder sourceName(String sourceName) {
-			this.sourceName = sourceName;
-			return this;
-		}
+        public Builder sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            return this;
+        }
 
-		public Builder lineno(int lineno) {
-			this.lineno = lineno;
-			return this;
-		}
+        public Builder lineno(int lineno) {
+            this.lineno = lineno;
+            return this;
+        }
 
-		public Builder securityDomain(Object securityDomain) {
-			this.securityDomain = securityDomain;
-			return this;
-		}
+        public Builder securityDomain(Object securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
 
-		public Builder compiler(Evaluator compiler) {
-			this.compiler = compiler;
-			return this;
-		}
+        public Builder compiler(Evaluator compiler) {
+            this.compiler = compiler;
+            return this;
+        }
 
-		public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-			this.compilationErrorReporter = compilationErrorReporter;
-			return this;
-		}
+        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+            this.compilationErrorReporter = compilationErrorReporter;
+            return this;
+        }
 
-		public Builder compilerEnvironsProcessor(
-				Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-			this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-			return this;
-		}
+        public Builder compilerEnvironsProcessor(
+                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+            return this;
+        }
 
-		public ScriptCompileSpec build() {
-			int normalizedLineno = Math.max(lineno, 0);
-			return new ScriptCompileSpec(
-					source,
-					sourceName,
-					normalizedLineno,
-					securityDomain,
-					compiler,
-					compilationErrorReporter,
-					compilerEnvironsProcessor);
-		}
-	}
+        public ScriptCompileSpec build() {
+            int normalizedLineno = Math.max(lineno, 0);
+            return new ScriptCompileSpec(
+                    source,
+                    sourceName,
+                    normalizedLineno,
+                    securityDomain,
+                    compiler,
+                    compilationErrorReporter,
+                    compilerEnvironsProcessor);
+        }
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -2,6 +2,7 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 /**
@@ -12,77 +13,122 @@ import java.util.function.Consumer;
  *
  * @see FunctionCompileSpec
  */
-public record ScriptCompileSpec(
-        String source,
-        String sourceName,
-        int lineno,
-        Object securityDomain,
-        Evaluator compiler,
-        ErrorReporter compilationErrorReporter,
-        Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+public final class ScriptCompileSpec {
+	private final String source;
+	private final String sourceName;
+	private final int lineno;
+	private final Object securityDomain;
+	private final Evaluator compiler;
+	private final ErrorReporter compilationErrorReporter;
+	private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
 
-    public static Builder fromSource(String source) {
-        return new Builder(source);
-    }
+	public ScriptCompileSpec(
+			String source,
+			String sourceName,
+			int lineno,
+			Object securityDomain,
+			Evaluator compiler,
+			ErrorReporter compilationErrorReporter,
+			Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+		this.source = source;
+		this.sourceName = sourceName;
+		this.lineno = lineno;
+		this.securityDomain = securityDomain;
+		this.compiler = compiler;
+		this.compilationErrorReporter = compilationErrorReporter;
+		this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+	}
 
-    public static Builder fromReader(Reader reader) throws IOException {
-        return new Builder(Kit.readReader(reader));
-    }
+	public static Builder fromSource(String source) {
+		return new Builder(source);
+	}
 
-    public static final class Builder {
-        private final String source;
-        private String sourceName;
-        private int lineno = 0;
-        private Object securityDomain;
-        private Evaluator compiler;
-        private ErrorReporter compilationErrorReporter;
-        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+	public static Builder fromReader(Reader reader) throws IOException {
+		return new Builder(Kit.readReader(reader));
+	}
 
-        private Builder(String source) {
-            this.source = source;
-        }
+	public String getSource() {
+		return source;
+	}
 
-        public Builder sourceName(String sourceName) {
-            this.sourceName = sourceName;
-            return this;
-        }
+	public String getSourceName() {
+		return sourceName;
+	}
 
-        public Builder lineno(int lineno) {
-            this.lineno = lineno;
-            return this;
-        }
+	public int getLineno() {
+		return lineno;
+	}
 
-        public Builder securityDomain(Object securityDomain) {
-            this.securityDomain = securityDomain;
-            return this;
-        }
+	public Object getSecurityDomain() {
+		return securityDomain;
+	}
 
-        public Builder compiler(Evaluator compiler) {
-            this.compiler = compiler;
-            return this;
-        }
+	public Evaluator getCompiler() {
+		return compiler;
+	}
 
-        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-            this.compilationErrorReporter = compilationErrorReporter;
-            return this;
-        }
+	public ErrorReporter getCompilationErrorReporter() {
+		return compilationErrorReporter;
+	}
 
-        public Builder compilerEnvironsProcessor(
-                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-            return this;
-        }
+	public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
+		return compilerEnvironsProcessor;
+	}
 
-        public ScriptCompileSpec build() {
-            int normalizedLineno = Math.max(lineno, 0);
-            return new ScriptCompileSpec(
-                    source,
-                    sourceName,
-                    normalizedLineno,
-                    securityDomain,
-                    compiler,
-                    compilationErrorReporter,
-                    compilerEnvironsProcessor);
-        }
-    }
+	public static final class Builder {
+		private final String source;
+		private String sourceName;
+		private int lineno = 0;
+		private Object securityDomain;
+		private Evaluator compiler;
+		private ErrorReporter compilationErrorReporter;
+		private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+
+		private Builder(String source) {
+			this.source = source;
+		}
+
+		public Builder sourceName(String sourceName) {
+			this.sourceName = sourceName;
+			return this;
+		}
+
+		public Builder lineno(int lineno) {
+			this.lineno = lineno;
+			return this;
+		}
+
+		public Builder securityDomain(Object securityDomain) {
+			this.securityDomain = securityDomain;
+			return this;
+		}
+
+		public Builder compiler(Evaluator compiler) {
+			this.compiler = compiler;
+			return this;
+		}
+
+		public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+			this.compilationErrorReporter = compilationErrorReporter;
+			return this;
+		}
+
+		public Builder compilerEnvironsProcessor(
+				Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+			this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+			return this;
+		}
+
+		public ScriptCompileSpec build() {
+			int normalizedLineno = Math.max(lineno, 0);
+			return new ScriptCompileSpec(
+					source,
+					sourceName,
+					normalizedLineno,
+					securityDomain,
+					compiler,
+					compilationErrorReporter,
+					compilerEnvironsProcessor);
+		}
+	}
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -1,0 +1,88 @@
+package org.mozilla.javascript;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.function.Consumer;
+
+/**
+ * Parameters for compiling a JavaScript script (i.e. top-level program source). Build instances via
+ * {@link #fromSource(String)} or {@link #fromReader(Reader)} and pass them to {@link
+ * Context#compileScript(ScriptCompileSpec)} or {@link Context#evaluateScript(ScriptCompileSpec,
+ * VarScope)}.
+ *
+ * @see FunctionCompileSpec
+ */
+public record ScriptCompileSpec(
+        String source,
+        String sourceName,
+        int lineno,
+        Object securityDomain,
+        Evaluator compiler,
+        ErrorReporter compilationErrorReporter,
+        Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+
+    public static Builder fromSource(String source) {
+        return new Builder(source);
+    }
+
+    public static Builder fromReader(Reader reader) throws IOException {
+        return new Builder(Kit.readReader(reader));
+    }
+
+    public static final class Builder {
+        private final String source;
+        private String sourceName;
+        private int lineno = 0;
+        private Object securityDomain;
+        private Evaluator compiler;
+        private ErrorReporter compilationErrorReporter;
+        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+
+        private Builder(String source) {
+            this.source = source;
+        }
+
+        public Builder sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            return this;
+        }
+
+        public Builder lineno(int lineno) {
+            this.lineno = lineno;
+            return this;
+        }
+
+        public Builder securityDomain(Object securityDomain) {
+            this.securityDomain = securityDomain;
+            return this;
+        }
+
+        public Builder compiler(Evaluator compiler) {
+            this.compiler = compiler;
+            return this;
+        }
+
+        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+            this.compilationErrorReporter = compilationErrorReporter;
+            return this;
+        }
+
+        public Builder compilerEnvironsProcessor(
+                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+            return this;
+        }
+
+        public ScriptCompileSpec build() {
+            int normalizedLineno = Math.max(lineno, 0);
+            return new ScriptCompileSpec(
+                    source,
+                    sourceName,
+                    normalizedLineno,
+                    securityDomain,
+                    compiler,
+                    compilationErrorReporter,
+                    compilerEnvironsProcessor);
+        }
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
@@ -62,14 +62,14 @@ public class FunctionCompileSpecTest {
     public void testBuilderDefaults() {
         FunctionCompileSpec spec = FunctionCompileSpec.fromSource("function f() {}", scope).build();
 
-        assertEquals("function f() {}", spec.source());
-        assertSame(scope, spec.scope());
-        assertNull(spec.sourceName());
-        assertEquals(0, spec.lineno());
-        assertNull(spec.securityDomain());
-        assertNull(spec.compiler());
-        assertNull(spec.compilationErrorReporter());
-        assertNull(spec.compilerEnvironsProcessor());
+        assertEquals("function f() {}", spec.getSource());
+        assertSame(scope, spec.getScope());
+        assertNull(spec.getSourceName());
+        assertEquals(0, spec.getLineno());
+        assertNull(spec.getSecurityDomain());
+        assertNull(spec.getCompiler());
+        assertNull(spec.getCompilationErrorReporter());
+        assertNull(spec.getCompilerEnvironsProcessor());
     }
 
     @Test
@@ -77,7 +77,7 @@ public class FunctionCompileSpecTest {
         FunctionCompileSpec spec =
                 FunctionCompileSpec.fromSource("function f() {}", scope).lineno(-5).build();
 
-        assertEquals(0, spec.lineno());
+        assertEquals(0, spec.getLineno());
     }
 
     @Test

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
@@ -1,0 +1,189 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class FunctionCompileSpecTest {
+    private Context cx;
+    private TopLevel scope;
+
+    @BeforeEach
+    public void setUp() {
+        cx = Context.enter();
+        scope = cx.initStandardObjects();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void testCompileFunctionWithBuilder() {
+        Function func =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromSource(
+                                        "function add(a, b) { return a + b; }", scope)
+                                .sourceName("test.js")
+                                .lineno(1)
+                                .build());
+
+        assertNotNull(func);
+        Object result = func.call(cx, scope, scope, new Object[] {5, 7});
+        assertEquals(12, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testCompileFunctionFromReader() throws Exception {
+        String code = "function mul(a, b) { return a * b; }";
+
+        Function func =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromReader(new StringReader(code), scope)
+                                .sourceName("mul.js")
+                                .build());
+
+        Object result = func.call(cx, scope, scope, new Object[] {6, 7});
+        assertEquals(42, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testBuilderDefaults() {
+        FunctionCompileSpec spec = FunctionCompileSpec.fromSource("function f() {}", scope).build();
+
+        assertEquals("function f() {}", spec.source());
+        assertSame(scope, spec.scope());
+        assertNull(spec.sourceName());
+        assertEquals(0, spec.lineno());
+        assertNull(spec.securityDomain());
+        assertNull(spec.compiler());
+        assertNull(spec.compilationErrorReporter());
+        assertNull(spec.compilerEnvironsProcessor());
+    }
+
+    @Test
+    public void testNegativeLinenoNormalized() {
+        FunctionCompileSpec spec =
+                FunctionCompileSpec.fromSource("function f() {}", scope).lineno(-5).build();
+
+        assertEquals(0, spec.lineno());
+    }
+
+    @Test
+    public void testScopeIsRequiredAtFromSource() {
+        var ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> FunctionCompileSpec.fromSource("function f() {}", null));
+        assertTrue(ex.getMessage().contains("scope is required"));
+    }
+
+    @Test
+    public void testScopeIsRequiredAtFromReader() {
+        var ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                FunctionCompileSpec.fromReader(
+                                        new StringReader("function f() {}"), null));
+        assertTrue(ex.getMessage().contains("scope is required"));
+    }
+
+    @Test
+    public void testRecordCompactConstructorRejectsNullScope() {
+        var ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                new FunctionCompileSpec(
+                                        "function f() {}", null, null, 0, null, null, null, null));
+        assertTrue(ex.getMessage().contains("scope is required"));
+    }
+
+    @Test
+    public void testLegacyCompileFunctionMatchesSpec() {
+        Function oldWay =
+                cx.compileFunction(
+                        scope, "function add(a, b) { return a + b; }", "old.js", 1, null);
+        Function newWay =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromSource(
+                                        "function add(a, b) { return a + b; }", scope)
+                                .sourceName("new.js")
+                                .lineno(1)
+                                .build());
+
+        Object[] args = new Object[] {1, 2};
+        Object oldResult = oldWay.call(cx, scope, scope, args);
+        Object newResult = newWay.call(cx, scope, scope, args);
+        assertEquals(((Number) oldResult).intValue(), ((Number) newResult).intValue());
+        assertEquals(3, ((Number) newResult).intValue());
+    }
+
+    @Test
+    public void testNonFunctionSourceThrows() {
+        var ex =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                cx.compileFunction(
+                                        FunctionCompileSpec.fromSource("var x = 1;", scope)
+                                                .sourceName("not-a-function.js")
+                                                .build()));
+        assertTrue(
+                ex.getMessage()
+                        .contains("compileFunction only accepts source with single JS function"),
+                "message should explain the constraint, was: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("var x = 1;"), "message should include the source");
+    }
+
+    @Test
+    public void testFunctionFollowedByEmptyStatementsIsAccepted() {
+        // The "first child is FUNCTION" check explicitly tolerates trailing empty statements.
+        Function func =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromSource("function f() { return 1; };;;", scope)
+                                .sourceName("trailing.js")
+                                .build());
+        Object result = func.call(cx, scope, scope, new Object[0]);
+        assertEquals(1, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testCompilerEnvironsProcessorIsInvoked() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        AtomicReference<CompilerEnvirons> received = new AtomicReference<>();
+
+        Function func =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromSource("function f() { return 7; }", scope)
+                                .sourceName("processed.js")
+                                .compilerEnvironsProcessor(
+                                        env -> {
+                                            called.set(true);
+                                            received.set(env);
+                                            env.setGeneratingSource(true);
+                                        })
+                                .build());
+
+        assertTrue(called.get(), "compilerEnvironsProcessor should be invoked");
+        assertNotNull(received.get(), "processor should receive a CompilerEnvirons instance");
+        assertTrue(
+                received.get().isGeneratingSource(),
+                "mutation in processor should take effect on the env passed to it");
+
+        Object result = func.call(cx, scope, scope, new Object[0]);
+        assertEquals(7, ((Number) result).intValue());
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptCompileSpecTest.java
@@ -1,0 +1,230 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ScriptCompileSpecTest {
+    private Context cx;
+    private TopLevel scope;
+
+    @BeforeEach
+    public void setUp() {
+        cx = Context.enter();
+        scope = cx.initStandardObjects();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void testCompileScriptWithBuilder() {
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource("var x = 42; x;")
+                                .sourceName("test.js")
+                                .lineno(1)
+                                .build());
+
+        assertNotNull(script);
+        Object result = script.exec(cx, scope, scope);
+        assertEquals(42, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testCompilerEnvironsProcessorIsInvoked() {
+        AtomicBoolean called = new AtomicBoolean(false);
+        AtomicReference<CompilerEnvirons> received = new AtomicReference<>();
+
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource("var z = 20; z;")
+                                .sourceName("processed.js")
+                                .compilerEnvironsProcessor(
+                                        env -> {
+                                            called.set(true);
+                                            received.set(env);
+                                            env.setGeneratingSource(true);
+                                        })
+                                .build());
+
+        assertTrue(called.get(), "compilerEnvironsProcessor should be invoked");
+        assertNotNull(received.get(), "processor should receive a CompilerEnvirons instance");
+        assertTrue(
+                received.get().isGeneratingSource(),
+                "mutation in processor should take effect on the env passed to it");
+        assertNotNull(script);
+    }
+
+    @Test
+    public void testBuilderDefaults() {
+        ScriptCompileSpec spec = ScriptCompileSpec.fromSource("1").build();
+
+        assertEquals("1", spec.source());
+        assertNull(spec.sourceName());
+        assertEquals(0, spec.lineno());
+        assertNull(spec.securityDomain());
+        assertNull(spec.compiler());
+        assertNull(spec.compilationErrorReporter());
+        assertNull(spec.compilerEnvironsProcessor());
+    }
+
+    @Test
+    public void testNegativeLinenoNormalized() {
+        ScriptCompileSpec spec = ScriptCompileSpec.fromSource("1").lineno(-5).build();
+
+        assertEquals(0, spec.lineno());
+    }
+
+    @Test
+    public void testCompileFromReader() throws Exception {
+        String code =
+                "var data = [1, 2, 3, 4, 5];\n"
+                        + "data.reduce(function(a, b) { return a + b; }, 0);";
+
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromReader(new StringReader(code))
+                                .sourceName("array-sum.js")
+                                .lineno(1)
+                                .build());
+
+        Object result = script.exec(cx, scope, scope);
+        assertEquals(15, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testErrorReportsSourceNameAndLineno() {
+        EvaluatorException ex =
+                assertThrows(
+                        EvaluatorException.class,
+                        () ->
+                                cx.compileScript(
+                                        ScriptCompileSpec.fromSource("var x = ;")
+                                                .sourceName("buggy-script.js")
+                                                .lineno(42)
+                                                .build()));
+        assertEquals("buggy-script.js", ex.sourceName());
+        assertEquals(42, ex.lineNumber());
+    }
+
+    @Test
+    public void testCustomCompilationErrorReporterReceivesError() {
+        AtomicReference<String> reportedSource = new AtomicReference<>();
+        AtomicReference<Integer> reportedLine = new AtomicReference<>();
+        AtomicBoolean errorCalled = new AtomicBoolean(false);
+
+        ErrorReporter capturing =
+                new ErrorReporter() {
+                    @Override
+                    public void warning(
+                            String message,
+                            String sourceName,
+                            int line,
+                            String lineSource,
+                            int lineOffset) {
+                        throw new AssertionError("should not be called");
+                    }
+
+                    @Override
+                    public void error(
+                            String message,
+                            String sourceName,
+                            int line,
+                            String lineSource,
+                            int lineOffset) {
+                        errorCalled.set(true);
+                        reportedSource.set(sourceName);
+                        reportedLine.set(line);
+                        throw new EvaluatorException(message, sourceName, line);
+                    }
+
+                    @Override
+                    public EvaluatorException runtimeError(
+                            String message,
+                            String sourceName,
+                            int line,
+                            String lineSource,
+                            int lineOffset) {
+                        throw new AssertionError("should not be called");
+                    }
+                };
+
+        assertThrows(
+                EvaluatorException.class,
+                () ->
+                        cx.compileScript(
+                                ScriptCompileSpec.fromSource("var x = ;")
+                                        .sourceName("custom.js")
+                                        .lineno(7)
+                                        .compilationErrorReporter(capturing)
+                                        .build()));
+
+        assertTrue(errorCalled.get(), "custom error reporter should be invoked");
+        assertEquals("custom.js", reportedSource.get());
+        assertEquals(7, reportedLine.get());
+    }
+
+    @Test
+    public void testSecurityDomainWithoutControllerThrows() {
+        Object securityDomain = new Object();
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        cx.compileScript(
+                                ScriptCompileSpec.fromSource("1")
+                                        .securityDomain(securityDomain)
+                                        .build()));
+    }
+
+    @Test
+    public void testLegacyCompileStringMatchesSpec() {
+        Script oldWay = cx.compileString("var a = 1; a + 2;", "old.js", 1, null);
+        Script newWay =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource("var a = 1; a + 2;")
+                                .sourceName("new.js")
+                                .lineno(1)
+                                .build());
+
+        Object oldResult = oldWay.exec(cx, scope, scope);
+        Object newResult = newWay.exec(cx, scope, scope);
+        assertEquals(((Number) oldResult).intValue(), ((Number) newResult).intValue());
+        assertEquals(3, ((Number) newResult).intValue());
+    }
+
+    @Test
+    public void testEvaluateScriptUsesProvidedScope() {
+        scope.put("seed", scope, 10);
+        Object result =
+                cx.evaluateScript(
+                        ScriptCompileSpec.fromSource("seed * 4;").sourceName("eval.js").build(),
+                        scope);
+
+        assertEquals(40, ((Number) result).intValue());
+    }
+
+    @Test
+    public void testEvaluateLegacyMatchesSpec() {
+        String src = "var a = 5; a * a;";
+        Object oldWay = cx.evaluateString(scope, src, "old.js", 1, null);
+        Object newWay =
+                cx.evaluateScript(
+                        ScriptCompileSpec.fromSource(src).sourceName("new.js").lineno(1).build(),
+                        scope);
+
+        assertEquals(oldWay, newWay);
+        assertEquals(25, ((Number) newWay).intValue());
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptCompileSpecTest.java
@@ -71,20 +71,20 @@ public class ScriptCompileSpecTest {
     public void testBuilderDefaults() {
         ScriptCompileSpec spec = ScriptCompileSpec.fromSource("1").build();
 
-        assertEquals("1", spec.source());
-        assertNull(spec.sourceName());
-        assertEquals(0, spec.lineno());
-        assertNull(spec.securityDomain());
-        assertNull(spec.compiler());
-        assertNull(spec.compilationErrorReporter());
-        assertNull(spec.compilerEnvironsProcessor());
+        assertEquals("1", spec.getSource());
+        assertNull(spec.getSourceName());
+        assertEquals(0, spec.getLineno());
+        assertNull(spec.getSecurityDomain());
+        assertNull(spec.getCompiler());
+        assertNull(spec.getCompilationErrorReporter());
+        assertNull(spec.getCompilerEnvironsProcessor());
     }
 
     @Test
     public void testNegativeLinenoNormalized() {
         ScriptCompileSpec spec = ScriptCompileSpec.fromSource("1").lineno(-5).build();
 
-        assertEquals(0, spec.lineno());
+        assertEquals(0, spec.getLineno());
     }
 
     @Test


### PR DESCRIPTION
The various variants of `Context.compile` and `eval` take already a ton of arguments. To implement source maps, we need to add at least one more, so I've started by refactoring them to take two simple record classes, named `FunctionCompileSpec` and `ScriptCompileSpec`.

I've attempted various designs and I think this one, with two separate classes, is the least bad option. :) I've created builder for simpler usage.

Backward compatibility is preserved, and I have not refactored existing tests. We could do that, since the 2.0 upgrade is big enough that refactorings like that make sense. I can do that as a follow-up step if you all think it's worthwhile.

Really only necessary mainly as a prerequisite of https://github.com/mozilla/rhino/pull/2387 