### PR TITLE
Implement source map support

### DIFF
--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -31,6 +31,7 @@ jar {
                 'org.mozilla.javascript.lc.type',
                 'org.mozilla.javascript.optimizer',
                 'org.mozilla.javascript.serialize',
+                'org.mozilla.javascript.sourcemap',
                 'org.mozilla.javascript.typedarrays',
                 'org.mozilla.javascript.xml',
             ].join(','),

--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module org.mozilla.rhino {
     exports org.mozilla.javascript.debug;
     exports org.mozilla.javascript.optimizer;
     exports org.mozilla.javascript.serialize;
+    exports org.mozilla.javascript.sourcemap;
     exports org.mozilla.javascript.typedarrays;
     exports org.mozilla.javascript.xml;
     exports org.mozilla.javascript.config;

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -262,7 +262,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         if (mapper != null) {
             Position mapped = mapper.mapPosition(lineno, node.getColumn());
             if (mapped == null) return;
-            lineno = mapped.line();
+            lineno = mapped.getLine();
         }
         if (lineno == lineNumber) return;
         if (itsData.firstLinePC < 0) {

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -16,6 +16,8 @@ import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
 import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.ast.TemplateCharacters;
+import org.mozilla.javascript.sourcemap.Position;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /** Generates bytecode for the Interpreter. */
 class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
@@ -255,14 +257,20 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
     private void updateLineNumber(Node node) {
         int lineno = node.getLineno();
-        if (lineno != lineNumber && lineno >= 0) {
-            if (itsData.firstLinePC < 0) {
-                itsData.firstLinePC = lineno;
-            }
-            lineNumber = lineno;
-            addIcode(Icode_LINE);
-            addUint16(lineno & 0xFFFF);
+        if (lineno < 0) return;
+        SourceMapper mapper = compilerEnv.getSourceMapper();
+        if (mapper != null) {
+            Position mapped = mapper.mapPosition(lineno, node.getColumn());
+            if (mapped == null) return;
+            lineno = mapped.line();
         }
+        if (lineno == lineNumber) return;
+        if (itsData.firstLinePC < 0) {
+            itsData.firstLinePC = lineno;
+        }
+        lineNumber = lineno;
+        addIcode(Icode_LINE);
+        addUint16(lineno & 0xFFFF);
     }
 
     private static RuntimeException badTree(Node node) {

--- a/rhino/src/main/java/org/mozilla/javascript/CompilerEnvirons.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompilerEnvirons.java
@@ -8,6 +8,7 @@ package org.mozilla.javascript;
 
 import java.util.Set;
 import org.mozilla.javascript.ast.ErrorCollector;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 public class CompilerEnvirons {
     public CompilerEnvirons() {
@@ -276,6 +277,14 @@ public class CompilerEnvirons {
         return securityDomain;
     }
 
+    public void setSourceMapper(SourceMapper sourceMapper) {
+        this.sourceMapper = sourceMapper;
+    }
+
+    public SourceMapper getSourceMapper() {
+        return sourceMapper;
+    }
+
     /**
      * Returns a {@code CompilerEnvirons} suitable for using Rhino in an IDE environment. Most
      * features are enabled by default. The {@link ErrorReporter} is set to an {@link
@@ -318,4 +327,5 @@ public class CompilerEnvirons {
     private Scriptable homeObjecgt;
     private SecurityController securityController;
     private Object securityDomain;
+    private SourceMapper sourceMapper;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -35,6 +35,7 @@ import org.mozilla.javascript.debug.DebuggableScript;
 import org.mozilla.javascript.debug.Debugger;
 import org.mozilla.javascript.lc.type.TypeInfo;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 import org.mozilla.javascript.xml.XMLLib;
 
 /**
@@ -2580,6 +2581,7 @@ public class Context implements Closeable {
                         spec.getCompiler(),
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
+                        spec.getSourceMapper(),
                         false,
                         Evaluator::compileScript);
         return compiled.evaluator.createScriptObject(compiled.result, spec.getSecurityDomain());
@@ -2595,6 +2597,7 @@ public class Context implements Closeable {
                         spec.getCompiler(),
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
+                        spec.getSourceMapper(),
                         true,
                         Evaluator::compileFunction);
         return compiled.evaluator.createFunctionObject(
@@ -2625,6 +2628,7 @@ public class Context implements Closeable {
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
             Consumer<CompilerEnvirons> compilerEnvironProcessor,
+            SourceMapper sourceMapper,
             boolean returnFunction,
             CompileFn<T> compileFn) {
         if (sourceName == null) {
@@ -2639,6 +2643,9 @@ public class Context implements Closeable {
         CompilerEnvirons compilerEnv = new CompilerEnvirons();
         compilerEnv.initFromContext(this);
         compilerEnv.setSecurityDomain(securityDomain);
+        if (sourceMapper != null) {
+            compilerEnv.setSourceMapper(sourceMapper);
+        }
 
         if (compilationErrorReporter == null) {
             compilationErrorReporter = compilerEnv.getErrorReporter();
@@ -2686,7 +2693,15 @@ public class Context implements Closeable {
             if (sourceString == null) Kit.codeBug();
             DebuggableScript dscript = result.getDebuggableScript();
             if (dscript != null) {
-                notifyDebugger_r(this, dscript, sourceString);
+                String debugSource = sourceString;
+                SourceMapper mapper = compilerEnv.getSourceMapper();
+                if (mapper != null) {
+                    String original = mapper.getOriginalSource();
+                    if (original != null) {
+                        debugSource = original;
+                    }
+                }
+                notifyDebugger_r(this, dscript, debugSource);
             } else {
                 throw new RuntimeException("NOT SUPPORTED");
             }

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.function.Consumer;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
  * Parameters for compiling a JavaScript function (a single function definition). The parent scope
@@ -21,6 +22,7 @@ public final class FunctionCompileSpec {
     private final Evaluator compiler;
     private final ErrorReporter compilationErrorReporter;
     private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    private final SourceMapper sourceMapper;
 
     public FunctionCompileSpec(
             String source,
@@ -30,7 +32,8 @@ public final class FunctionCompileSpec {
             Object securityDomain,
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            Consumer<CompilerEnvirons> compilerEnvironsProcessor,
+            SourceMapper sourceMapper) {
         if (scope == null) {
             throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
         }
@@ -42,6 +45,7 @@ public final class FunctionCompileSpec {
         this.compiler = compiler;
         this.compilationErrorReporter = compilationErrorReporter;
         this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+        this.sourceMapper = sourceMapper;
     }
 
     public static Builder fromSource(String source, VarScope scope) {
@@ -84,6 +88,10 @@ public final class FunctionCompileSpec {
         return compilerEnvironsProcessor;
     }
 
+    public SourceMapper getSourceMapper() {
+        return sourceMapper;
+    }
+
     public static final class Builder {
         private final String source;
         private final VarScope scope;
@@ -93,6 +101,7 @@ public final class FunctionCompileSpec {
         private Evaluator compiler;
         private ErrorReporter compilationErrorReporter;
         private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+        private SourceMapper sourceMapper;
 
         private Builder(String source, VarScope scope) {
             if (scope == null) {
@@ -133,6 +142,11 @@ public final class FunctionCompileSpec {
             return this;
         }
 
+        public Builder sourceMapper(SourceMapper sourceMapper) {
+            this.sourceMapper = sourceMapper;
+            return this;
+        }
+
         public FunctionCompileSpec build() {
             int normalizedLineno = Math.max(lineno, 0);
             return new FunctionCompileSpec(
@@ -143,7 +157,8 @@ public final class FunctionCompileSpec {
                     securityDomain,
                     compiler,
                     compilationErrorReporter,
-                    compilerEnvironsProcessor);
+                    compilerEnvironsProcessor,
+                    sourceMapper);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -89,6 +89,8 @@ import org.mozilla.javascript.ast.XmlPropRef;
 import org.mozilla.javascript.ast.XmlRef;
 import org.mozilla.javascript.ast.XmlString;
 import org.mozilla.javascript.ast.Yield;
+import org.mozilla.javascript.sourcemap.Position;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
  * This class implements the JavaScript parser.
@@ -212,12 +214,8 @@ public class Parser {
         } else if (errorCollector != null) {
             errorCollector.warning(message, sourceURI, position, length);
         } else {
-            errorReporter.warning(
-                    message,
-                    sourceURI,
-                    currentPos.getLineno(),
-                    currentPos.getLine(),
-                    currentPos.getOffset());
+            MappedLocation loc = mapCurrentPos();
+            errorReporter.warning(message, sourceURI, loc.line, loc.lineSource, loc.offset);
         }
     }
 
@@ -244,13 +242,15 @@ public class Parser {
         if (errorCollector != null) {
             errorCollector.error(message, sourceURI, position, length);
         } else {
-            errorReporter.error(
-                    message,
-                    sourceURI,
-                    currentPos.getLineno(),
-                    currentPos.getLine(),
-                    currentPos.getOffset());
+            MappedLocation loc = mapCurrentPos();
+            errorReporter.error(message, sourceURI, loc.line, loc.lineSource, loc.offset);
         }
+    }
+
+    private record MappedLocation(int line, String lineSource, int offset) {}
+
+    private MappedLocation mapCurrentPos() {
+        return mapLocation(currentPos.getLineno(), currentPos.getLine(), currentPos.getOffset());
     }
 
     private void addStrictWarning(
@@ -280,7 +280,8 @@ public class Parser {
         } else if (errorCollector != null) {
             errorCollector.warning(message, sourceURI, position, length);
         } else {
-            errorReporter.warning(message, sourceURI, line, lineSource, lineOffset);
+            MappedLocation loc = mapLocation(line, lineSource, lineOffset);
+            errorReporter.warning(message, sourceURI, loc.line, loc.lineSource, loc.offset);
         }
     }
 
@@ -297,8 +298,25 @@ public class Parser {
         if (errorCollector != null) {
             errorCollector.error(message, sourceURI, position, length);
         } else {
-            errorReporter.error(message, sourceURI, line, lineSource, lineOffset);
+            MappedLocation loc = mapLocation(line, lineSource, lineOffset);
+            errorReporter.error(message, sourceURI, loc.line, loc.lineSource, loc.offset);
         }
+    }
+
+    private MappedLocation mapLocation(int line, String lineSource, int offset) {
+        SourceMapper mapper = compilerEnv.getSourceMapper();
+        if (mapper != null) {
+            Position mapped = mapper.mapPosition(line, offset);
+            if (mapped != null) {
+                line = mapped.line();
+                offset = mapped.column();
+                String mappedLine = mapper.getSourceLineText(line);
+                if (mappedLine != null) {
+                    lineSource = mappedLine;
+                }
+            }
+        }
+        return new MappedLocation(line, lineSource, offset);
     }
 
     String lookupMessage(String messageId) {

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.mozilla.javascript.ast.AbstractObjectProperty;
 import org.mozilla.javascript.ast.ArrayComprehension;
@@ -247,7 +248,58 @@ public class Parser {
         }
     }
 
-    private record MappedLocation(int line, String lineSource, int offset) {}
+    private static final class MappedLocation {
+        private final int line;
+        private final String lineSource;
+        private final int offset;
+
+        private MappedLocation(int line, String lineSource, int offset) {
+            this.line = line;
+            this.lineSource = lineSource;
+            this.offset = offset;
+        }
+
+        public int getLine() {
+            return line;
+        }
+
+        public String getLineSource() {
+            return lineSource;
+        }
+
+        public int getOffset() {
+            return offset;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            var that = (MappedLocation) obj;
+            return this.line == that.line
+                    && Objects.equals(this.lineSource, that.lineSource)
+                    && this.offset == that.offset;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(line, lineSource, offset);
+        }
+
+        @Override
+        public String toString() {
+            return "MappedLocation["
+                    + "line="
+                    + line
+                    + ", "
+                    + "lineSource="
+                    + lineSource
+                    + ", "
+                    + "offset="
+                    + offset
+                    + ']';
+        }
+    }
 
     private MappedLocation mapCurrentPos() {
         return mapLocation(currentPos.getLineno(), currentPos.getLine(), currentPos.getOffset());
@@ -308,8 +360,8 @@ public class Parser {
         if (mapper != null) {
             Position mapped = mapper.mapPosition(line, offset);
             if (mapped != null) {
-                line = mapped.line();
-                offset = mapped.column();
+                line = mapped.getLine();
+                offset = mapped.getColumn();
                 String mappedLine = mapper.getSourceLineText(line);
                 if (mappedLine != null) {
                     lineSource = mappedLine;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -3,6 +3,7 @@ package org.mozilla.javascript;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.function.Consumer;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
  * Parameters for compiling a JavaScript script (i.e. top-level program source). Build instances via
@@ -20,6 +21,7 @@ public final class ScriptCompileSpec {
     private final Evaluator compiler;
     private final ErrorReporter compilationErrorReporter;
     private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    private final SourceMapper sourceMapper;
 
     public ScriptCompileSpec(
             String source,
@@ -28,7 +30,8 @@ public final class ScriptCompileSpec {
             Object securityDomain,
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            Consumer<CompilerEnvirons> compilerEnvironsProcessor,
+            SourceMapper sourceMapper) {
         this.source = source;
         this.sourceName = sourceName;
         this.lineno = lineno;
@@ -36,6 +39,7 @@ public final class ScriptCompileSpec {
         this.compiler = compiler;
         this.compilationErrorReporter = compilationErrorReporter;
         this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+        this.sourceMapper = sourceMapper;
     }
 
     public static Builder fromSource(String source) {
@@ -74,6 +78,10 @@ public final class ScriptCompileSpec {
         return compilerEnvironsProcessor;
     }
 
+    public SourceMapper getSourceMapper() {
+        return sourceMapper;
+    }
+
     public static final class Builder {
         private final String source;
         private String sourceName;
@@ -82,6 +90,7 @@ public final class ScriptCompileSpec {
         private Evaluator compiler;
         private ErrorReporter compilationErrorReporter;
         private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+        private SourceMapper sourceMapper;
 
         private Builder(String source) {
             this.source = source;
@@ -118,6 +127,11 @@ public final class ScriptCompileSpec {
             return this;
         }
 
+        public Builder sourceMapper(SourceMapper sourceMapper) {
+            this.sourceMapper = sourceMapper;
+            return this;
+        }
+
         public ScriptCompileSpec build() {
             int normalizedLineno = Math.max(lineno, 0);
             return new ScriptCompileSpec(
@@ -127,7 +141,8 @@ public final class ScriptCompileSpec {
                     securityDomain,
                     compiler,
                     compilationErrorReporter,
-                    compilerEnvironsProcessor);
+                    compilerEnvironsProcessor,
+                    sourceMapper);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -3156,7 +3156,7 @@ class BodyCodegen {
         SourceMapper mapper = compilerEnv.getSourceMapper();
         if (mapper == null) return line;
         Position mapped = mapper.mapPosition(line, column);
-        return mapped == null ? -1 : mapped.line();
+        return mapped == null ? -1 : mapped.getLine();
     }
 
     private void visitTryCatchFinally(Jump node, Node child) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -23,6 +23,8 @@ import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
 import org.mozilla.javascript.ast.ScriptNode;
+import org.mozilla.javascript.sourcemap.Position;
+import org.mozilla.javascript.sourcemap.SourceMapper;
 
 class BodyCodegen {
     void generateBodyCode() {
@@ -485,7 +487,7 @@ class BodyCodegen {
             cfw.addAStore(popvLocal);
 
             int linenum = scriptOrFn.getEndLineno();
-            if (linenum != -1) cfw.addLineNumberEntry((short) linenum);
+            if (linenum != -1) addRemappedLineEntry(linenum, 0);
 
         } else {
             if (fnCurrent.itsContainsCalls0) {
@@ -3136,9 +3138,25 @@ class BodyCodegen {
     }
 
     private void updateLineNumber(Node node) {
-        itsLineNumber = node.getLineno();
-        if (itsLineNumber == -1) return;
-        cfw.addLineNumberEntry((short) itsLineNumber);
+        int lineno = node.getLineno();
+        if (lineno == -1) return;
+        int emitLine = remapLine(lineno, node.getColumn());
+        if (emitLine == -1) return;
+        itsLineNumber = emitLine;
+        cfw.addLineNumberEntry((short) emitLine);
+    }
+
+    private void addRemappedLineEntry(int line, int column) {
+        int emitLine = remapLine(line, column);
+        if (emitLine == -1) return;
+        cfw.addLineNumberEntry((short) emitLine);
+    }
+
+    private int remapLine(int line, int column) {
+        SourceMapper mapper = compilerEnv.getSourceMapper();
+        if (mapper == null) return line;
+        Position mapped = mapper.mapPosition(line, column);
+        return mapped == null ? -1 : mapped.line();
     }
 
     private void visitTryCatchFinally(Jump node, Node child) {

--- a/rhino/src/main/java/org/mozilla/javascript/sourcemap/Position.java
+++ b/rhino/src/main/java/org/mozilla/javascript/sourcemap/Position.java
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.sourcemap;
+
+/** A 1-indexed line and column position in a source file. */
+public record Position(int line, int column) {}

--- a/rhino/src/main/java/org/mozilla/javascript/sourcemap/Position.java
+++ b/rhino/src/main/java/org/mozilla/javascript/sourcemap/Position.java
@@ -4,5 +4,41 @@
 
 package org.mozilla.javascript.sourcemap;
 
+import java.util.Objects;
+
 /** A 1-indexed line and column position in a source file. */
-public record Position(int line, int column) {}
+public final class Position {
+    private final int line;
+    private final int column;
+
+    public Position(int line, int column) {
+        this.line = line;
+        this.column = column;
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public int getColumn() {
+        return column;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (Position) obj;
+        return this.line == that.line && this.column == that.column;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(line, column);
+    }
+
+    @Override
+    public String toString() {
+        return "Position[" + "line=" + line + ", " + "column=" + column + ']';
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/sourcemap/SourceMapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/sourcemap/SourceMapper.java
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.sourcemap;
+
+/**
+ * Maps positions in a transpiled (target) script back to positions in the original source. Attach
+ * an instance via {@link
+ * org.mozilla.javascript.ScriptCompileSpec.Builder#sourceMapper(SourceMapper)} (or the equivalent
+ * on {@link org.mozilla.javascript.FunctionCompileSpec}) so that line numbers in stack traces, the
+ * debugger source handoff, and parser error messages refer to the original source rather than the
+ * transpiled output.
+ */
+public interface SourceMapper {
+
+    /**
+     * Maps a target {@code (line, column)} position to the corresponding original-source position.
+     *
+     * @param targetLine 1-indexed line in the transpiled source
+     * @param targetColumn 1-indexed column in the transpiled source
+     * @return the original-source position, or {@code null} if no mapping exists for this position
+     */
+    Position mapPosition(int targetLine, int targetColumn);
+
+    /**
+     * Returns the full text of the original source so the debugger can display it during
+     * compilation handoff.
+     *
+     * @return the original source, or {@code null} if it is not available
+     */
+    String getOriginalSource();
+
+    /**
+     * Returns the text of the given line of the original source. Used to populate parser error
+     * messages with the offending line from the original source.
+     *
+     * @param sourceLine 1-indexed line number in the original source
+     * @return the line text, or {@code null} if the line is out of range or unavailable
+     */
+    String getSourceLineText(int sourceLine);
+}

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
@@ -117,7 +117,15 @@ public class FunctionCompileSpecTest {
                         IllegalArgumentException.class,
                         () ->
                                 new FunctionCompileSpec(
-                                        "function f() {}", null, null, 0, null, null, null, null));
+                                        "function f() {}",
+                                        null,
+                                        null,
+                                        0,
+                                        null,
+                                        null,
+                                        null,
+                                        null,
+                                        null));
         assertTrue(ex.getMessage().contains("scope is required"));
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/InterpreterBytecodeDumpTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/InterpreterBytecodeDumpTest.java
@@ -4,13 +4,10 @@
 
 package org.mozilla.javascript;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.PrintStream;
 import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.testutils.Utils;
 
@@ -488,24 +485,12 @@ class InterpreterBytecodeDumpTest {
     }
 
     private static String getByteCodeFrom(String source) throws IOException {
-        var oldBytecodePrintStream = Interpreter.interpreterBytecodePrintStream;
-        var oldTokenPrintICode = Token.printICode;
-        var oldTokenPrintNames = Token.printNames;
-        try (var buffer = new ByteArrayOutputStream()) {
-            Interpreter.interpreterBytecodePrintStream = new PrintStream(buffer);
-            Token.printICode = true;
-            Token.printNames = true;
-
-            try (Context cx = Context.enter()) {
-                cx.setInterpretedMode(true);
-                cx.compileString(source, "test", 1, null);
-            }
-
-            return buffer.toString(UTF_8);
-        } finally {
-            Token.printNames = oldTokenPrintNames;
-            Token.printICode = oldTokenPrintICode;
-            Interpreter.interpreterBytecodePrintStream = oldBytecodePrintStream;
-        }
+        return InterpreterIcodeCapture.capture(
+                () -> {
+                    try (Context cx = Context.enter()) {
+                        cx.setInterpretedMode(true);
+                        cx.compileString(source, "test", 1, null);
+                    }
+                });
     }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/InterpreterIcodeCapture.java
+++ b/rhino/src/test/java/org/mozilla/javascript/InterpreterIcodeCapture.java
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+
+/**
+ * Test-only helper that captures the interpreter icode dump produced while {@code action} runs.
+ * Lives in {@link org.mozilla.javascript} so it can flip the package-private switches on {@link
+ * Interpreter} and {@link Token}.
+ */
+final class InterpreterIcodeCapture {
+
+    private InterpreterIcodeCapture() {}
+
+    static String capture(Runnable action) {
+        PrintStream oldStream = Interpreter.interpreterBytecodePrintStream;
+        boolean oldPrintICode = Token.printICode;
+        boolean oldPrintNames = Token.printNames;
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            Interpreter.interpreterBytecodePrintStream = new PrintStream(buffer);
+            Token.printICode = true;
+            Token.printNames = true;
+            action.run();
+            return buffer.toString(UTF_8);
+        } catch (java.io.IOException e) {
+            throw new UncheckedIOException(e);
+        } finally {
+            Token.printNames = oldPrintNames;
+            Token.printICode = oldPrintICode;
+            Interpreter.interpreterBytecodePrintStream = oldStream;
+        }
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
@@ -1,0 +1,357 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.debug.DebugFrame;
+import org.mozilla.javascript.debug.DebuggableScript;
+import org.mozilla.javascript.debug.Debugger;
+import org.mozilla.javascript.sourcemap.Position;
+import org.mozilla.javascript.sourcemap.SourceMapper;
+import org.mozilla.javascript.testutils.Utils;
+
+class SourceMapperTest {
+
+    /**
+     * Maps target line N to source line {@code 100 + N} and column M to {@code 200 + M}. Returns
+     * null for any target line in {@code skipLines} so we can exercise the skip-on-null path.
+     */
+    private static final class TestMapper implements SourceMapper {
+        private final Set<Integer> skipLines;
+        private final String originalSource;
+        private final List<String> originalLines;
+
+        TestMapper(String originalSource, Integer... skipLines) {
+            this.originalSource = originalSource;
+            this.originalLines =
+                    originalSource == null
+                            ? List.of()
+                            : Arrays.asList(originalSource.split("\n", -1));
+            this.skipLines = new HashSet<>(Arrays.asList(skipLines));
+        }
+
+        @Override
+        public Position mapPosition(int targetLine, int targetColumn) {
+            if (skipLines.contains(targetLine)) return null;
+            return new Position(100 + targetLine, 200 + targetColumn);
+        }
+
+        @Override
+        public String getOriginalSource() {
+            return originalSource;
+        }
+
+        @Override
+        public String getSourceLineText(int sourceLine) {
+            // mapPosition emits source lines starting at 101 (target line 1 → 101). Honor the
+            // same offset here so the source space is internally consistent.
+            int idx = sourceLine - 101;
+            if (idx < 0 || idx >= originalLines.size()) return null;
+            return originalLines.get(idx);
+        }
+    }
+
+    // ---- interpreter-only icode tests ----
+
+    @Test
+    void interpreterIcodeLineRemapped() {
+        Utils.runWithMode(
+                cx -> {
+                    SourceMapper mapper = new TestMapper("// original");
+                    String dump = captureIcodeDump(cx, "var x = 42; x;\n", mapper);
+
+                    assertTrue(
+                            dump.contains("LINE : 101"),
+                            "expected mapped line 101 in icode dump but got:\n" + dump);
+                    assertFalse(
+                            dump.contains(" LINE : 1\n"),
+                            "expected unmapped LINE : 1 to be absent from:\n" + dump);
+                    return null;
+                },
+                true);
+    }
+
+    @Test
+    void interpreterSkipsLineWhenMapperReturnsNull() {
+        Utils.runWithMode(
+                cx -> {
+                    SourceMapper mapper = new TestMapper("// original\n// line 2\n", 2);
+                    String dump = captureIcodeDump(cx, "var x = 1;\nvar y = 2;\n", mapper);
+
+                    assertTrue(
+                            dump.contains("LINE : 101"),
+                            "expected line 101 in dump but got:\n" + dump);
+                    assertFalse(
+                            dump.contains("LINE : 102"),
+                            "expected no entry for skipped line 2 in dump:\n" + dump);
+                    assertFalse(
+                            dump.contains(" LINE : 2\n"),
+                            "expected no raw target line 2 in dump:\n" + dump);
+                    return null;
+                },
+                true);
+    }
+
+    @Test
+    void interpreterNoMapperLeavesIcodeUnchanged() {
+        Utils.runWithMode(
+                cx -> {
+                    String dumpWithoutMapper = captureIcodeDump(cx, "var x = 42;\n", null);
+                    assertTrue(
+                            dumpWithoutMapper.contains("LINE : 1"),
+                            "no-mapper dump should report the raw line 1");
+                    return null;
+                },
+                true);
+    }
+
+    // ---- mode-agnostic tests ----
+
+    @Test
+    void stackTraceUsesMappedLine() {
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    SourceMapper mapper = new TestMapper("throw 'err';\n");
+                    Script script =
+                            cx.compileScript(
+                                    ScriptCompileSpec.fromSource("throw 'err';\n")
+                                            .sourceName("transpiled.js")
+                                            .lineno(1)
+                                            .sourceMapper(mapper)
+                                            .build());
+
+                    RhinoException ex =
+                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                    assertEquals(101, ex.lineNumber(), "stack-trace line should be remapped");
+                    return null;
+                });
+    }
+
+    @Test
+    void skippedLineFallsBackToPreviousMappedLine() {
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    // Line 1 maps to 101, line 2 has no mapping. Throw on line 2 — expect line 101.
+                    SourceMapper mapper = new TestMapper("var x = 1;\nthrow 'err';\n", 2);
+                    Script script =
+                            cx.compileScript(
+                                    ScriptCompileSpec.fromSource("var x = 1;\nthrow 'err';\n")
+                                            .sourceName("transpiled.js")
+                                            .lineno(1)
+                                            .sourceMapper(mapper)
+                                            .build());
+
+                    RhinoException ex =
+                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                    assertEquals(
+                            101,
+                            ex.lineNumber(),
+                            "unmapped line should fall back to last mapped line");
+                    return null;
+                });
+    }
+
+    @Test
+    void parserErrorsUseMappedPosition() {
+        Utils.runWithAllModes(
+                cx -> {
+                    SourceMapper mapper = new TestMapper("let x = 'unterminated;\n");
+                    RecordingErrorReporter reporter = new RecordingErrorReporter();
+                    cx.setErrorReporter(reporter);
+
+                    assertThrows(
+                            EvaluatorException.class,
+                            () ->
+                                    cx.compileScript(
+                                            ScriptCompileSpec.fromSource("var x = 'unterminated;\n")
+                                                    .sourceName("transpiled.js")
+                                                    .lineno(1)
+                                                    .sourceMapper(mapper)
+                                                    .build()));
+
+                    assertFalse(reporter.errors.isEmpty(), "expected at least one error");
+                    ReportedError err = reporter.errors.get(0);
+                    assertEquals(101, err.line(), "error line should be remapped");
+                    assertEquals(
+                            "let x = 'unterminated;",
+                            err.lineSource(),
+                            "lineSource should come from the mapper");
+                    return null;
+                });
+    }
+
+    @Test
+    void compileFunctionStackTraceUsesMappedLine() {
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    SourceMapper mapper = new TestMapper("throw 'err';");
+
+                    Function fn =
+                            cx.compileFunction(
+                                    FunctionCompileSpec.fromSource(
+                                                    "function f() { throw 'err'; }", scope)
+                                            .sourceName("transpiled.js")
+                                            .lineno(1)
+                                            .sourceMapper(mapper)
+                                            .build());
+
+                    RhinoException ex =
+                            assertThrows(
+                                    RhinoException.class,
+                                    () -> fn.call(cx, scope, scope, new Object[0]));
+                    assertEquals(101, ex.lineNumber(), "function-path line should be remapped");
+                    return null;
+                });
+    }
+
+    // ---- debugger tests, interpreter-only  ----
+
+    @Test
+    void debuggerReceivesOriginalSource() {
+        Utils.runWithMode(
+                cx -> {
+                    String original = "// the original source\nfoo();\n";
+                    SourceMapper mapper = new TestMapper(original);
+
+                    RecordingDebugger debugger = new RecordingDebugger();
+                    cx.setDebugger(debugger, null);
+                    try {
+                        cx.compileScript(
+                                ScriptCompileSpec.fromSource("bar();\n")
+                                        .sourceName("transpiled.js")
+                                        .lineno(1)
+                                        .sourceMapper(mapper)
+                                        .build());
+                    } finally {
+                        cx.setDebugger(null, null);
+                    }
+
+                    assertFalse(debugger.sources.isEmpty(), "debugger should have been notified");
+                    assertEquals(original, debugger.sources.iterator().next());
+                    return null;
+                },
+                true);
+    }
+
+    @Test
+    void debuggerFallsBackToTranspiledSourceWhenOriginalUnavailable() {
+        Utils.runWithMode(
+                cx -> {
+                    SourceMapper mapper = new TestMapper(null);
+
+                    RecordingDebugger debugger = new RecordingDebugger();
+                    cx.setDebugger(debugger, null);
+                    try {
+                        cx.compileScript(
+                                ScriptCompileSpec.fromSource("bar();\n")
+                                        .sourceName("transpiled.js")
+                                        .lineno(1)
+                                        .sourceMapper(mapper)
+                                        .build());
+                    } finally {
+                        cx.setDebugger(null, null);
+                    }
+
+                    assertEquals(
+                            "bar();\n",
+                            debugger.sources.iterator().next(),
+                            "should fall back to the transpiled source");
+                    return null;
+                },
+                true);
+    }
+
+    // ---- spec/builder unit tests ----
+
+    @Test
+    void scriptCompileSpecExposesSourceMapper() {
+        SourceMapper mapper = new TestMapper("");
+        ScriptCompileSpec spec = ScriptCompileSpec.fromSource("1").sourceMapper(mapper).build();
+        assertEquals(mapper, spec.getSourceMapper());
+
+        ScriptCompileSpec defaultSpec = ScriptCompileSpec.fromSource("1").build();
+        assertNull(defaultSpec.getSourceMapper(), "sourceMapper should default to null");
+    }
+
+    @Test
+    void functionCompileSpecExposesSourceMapper() {
+        Utils.runWithMode(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    SourceMapper mapper = new TestMapper("");
+                    FunctionCompileSpec spec =
+                            FunctionCompileSpec.fromSource("function f() {}", scope)
+                                    .sourceMapper(mapper)
+                                    .build();
+                    assertEquals(mapper, spec.getSourceMapper());
+                    return null;
+                },
+                true);
+    }
+
+    private String captureIcodeDump(Context cx, String source, SourceMapper mapper) {
+        ScriptCompileSpec.Builder builder =
+                ScriptCompileSpec.fromSource(source).sourceName("test").lineno(1);
+        if (mapper != null) {
+            builder.sourceMapper(mapper);
+        }
+
+        ScriptCompileSpec spec = builder.build();
+        return InterpreterIcodeCapture.capture(() -> cx.compileScript(spec));
+    }
+
+    private record ReportedError(String message, int line, String lineSource, int offset) {}
+
+    private static final class RecordingErrorReporter implements ErrorReporter {
+        final List<ReportedError> errors = new ArrayList<>();
+
+        @Override
+        public void warning(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            throw new AssertionError("should not have happened");
+        }
+
+        @Override
+        public void error(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            errors.add(new ReportedError(message, line, lineSource, lineOffset));
+        }
+
+        @Override
+        public EvaluatorException runtimeError(
+                String message, String sourceName, int line, String lineSource, int lineOffset) {
+            return new EvaluatorException(message, sourceName, line, lineSource, lineOffset);
+        }
+    }
+
+    private static final class RecordingDebugger implements Debugger {
+        final Set<String> sources = new LinkedHashSet<>();
+
+        @Override
+        public void handleCompilationDone(Context cx, DebuggableScript fnOrScript, String source) {
+            sources.add(source);
+        }
+
+        @Override
+        public DebugFrame getFrame(Context cx, DebuggableScript fnOrScript) {
+            return null;
+        }
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
@@ -306,6 +306,59 @@ class SourceMapperTest {
                 true);
     }
 
+    // ---- realistic source-map integration test ----
+
+    @Test
+    void realisticSourceMapMapsThrowToOriginalLine() {
+        // Simulates a two-line original file bundled onto one minified line:
+        //   original line 1: "var x = 1;"   -> minified cols 1-8
+        //   original line 2: "throw ..."    -> minified col 9 onward
+        String originalSource = "var x = 1;\nthrow new Error(\"oops\");\n";
+        String minifiedSource = "var x=1;throw new Error(\"oops\");\n";
+        SourceMapper mapper =
+                new SourceMapper() {
+                    @Override
+                    public Position mapPosition(int targetLine, int targetColumn) {
+                        if (targetLine != 1) return null;
+                        return targetColumn < 9
+                                ? new Position(1, targetColumn)
+                                : new Position(2, targetColumn - 8);
+                    }
+
+                    @Override
+                    public String getOriginalSource() {
+                        return originalSource;
+                    }
+
+                    @Override
+                    public String getSourceLineText(int sourceLine) {
+                        if (sourceLine == 1) return "var x = 1;";
+                        if (sourceLine == 2) return "throw new Error(\"oops\");";
+                        return null;
+                    }
+                };
+
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    Script script =
+                            cx.compileScript(
+                                    ScriptCompileSpec.fromSource(minifiedSource)
+                                            .sourceName("app.min.js")
+                                            .lineno(1)
+                                            .sourceMapper(mapper)
+                                            .build());
+
+                    RhinoException ex =
+                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                    assertEquals(
+                            2,
+                            ex.lineNumber(),
+                            "throw at minified col 9 should map to original line 2");
+                    return null;
+                });
+    }
+
     private String captureIcodeDump(Context cx, String source, SourceMapper mapper) {
         ScriptCompileSpec.Builder builder =
                 ScriptCompileSpec.fromSource(source).sourceName("test").lineno(1);

--- a/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
@@ -309,7 +309,7 @@ class SourceMapperTest {
     // ---- realistic source-map integration test ----
 
     @Test
-    void realisticSourceMapMapsThrowToOriginalLine() {
+    void minifiedSourceMap() {
         // Simulates a two-line original file bundled onto one minified line:
         //   original line 1: "var x = 1;"   -> minified cols 1-8
         //   original line 2: "throw ..."    -> minified col 9 onward
@@ -355,6 +355,52 @@ class SourceMapperTest {
                             2,
                             ex.lineNumber(),
                             "throw at minified col 9 should map to original line 2");
+                    return null;
+                });
+    }
+
+    @Test
+    void transpiledSourceMap() {
+        // A computed-property literal ({["x"]: 1}) can't run on IE11, so a transpiler splits the
+        // one original line into two: object creation + property assignment.  The throw lands on
+        // transpiled line 2 but must be reported as original line 1.
+        String originalSource = "var obj = {[\"x\"]: 1}; throw \"done\";\n";
+        String transpiledSource = "var obj = {};\nobj[\"x\"] = 1; throw \"done\";\n";
+        SourceMapper mapper =
+                new SourceMapper() {
+                    @Override
+                    public Position mapPosition(int targetLine, int targetColumn) {
+                        return new Position(1, targetColumn); // both lines originate from line 1
+                    }
+
+                    @Override
+                    public String getOriginalSource() {
+                        return originalSource;
+                    }
+
+                    @Override
+                    public String getSourceLineText(int sourceLine) {
+                        return sourceLine == 1 ? "var obj = {[\"x\"]: 1}; throw \"done\";" : null;
+                    }
+                };
+
+        Utils.runWithAllModes(
+                cx -> {
+                    TopLevel scope = cx.initStandardObjects();
+                    Script script =
+                            cx.compileScript(
+                                    ScriptCompileSpec.fromSource(transpiledSource)
+                                            .sourceName("app.transpiled.js")
+                                            .lineno(1)
+                                            .sourceMapper(mapper)
+                                            .build());
+
+                    RhinoException ex =
+                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                    assertEquals(
+                            1,
+                            ex.lineNumber(),
+                            "throw on transpiled line 2 should map back to original line 1");
                     return null;
                 });
     }

--- a/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
@@ -136,7 +136,9 @@ class SourceMapperTest {
                                             .build());
 
                     RhinoException ex =
-                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                            assertThrows(
+                                    RhinoException.class,
+                                    () -> script.exec(cx, scope, scope.getGlobalThis()));
                     assertEquals(101, ex.lineNumber(), "stack-trace line should be remapped");
                     return null;
                 });
@@ -158,7 +160,9 @@ class SourceMapperTest {
                                             .build());
 
                     RhinoException ex =
-                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                            assertThrows(
+                                    RhinoException.class,
+                                    () -> script.exec(cx, scope, scope.getGlobalThis()));
                     assertEquals(
                             101,
                             ex.lineNumber(),
@@ -215,7 +219,7 @@ class SourceMapperTest {
                     RhinoException ex =
                             assertThrows(
                                     RhinoException.class,
-                                    () -> fn.call(cx, scope, scope, new Object[0]));
+                                    () -> fn.call(cx, scope, scope.getGlobalThis(), new Object[0]));
                     assertEquals(101, ex.lineNumber(), "function-path line should be remapped");
                     return null;
                 });
@@ -350,7 +354,9 @@ class SourceMapperTest {
                                             .build());
 
                     RhinoException ex =
-                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                            assertThrows(
+                                    RhinoException.class,
+                                    () -> script.exec(cx, scope, scope.getGlobalThis()));
                     assertEquals(
                             2,
                             ex.lineNumber(),
@@ -396,7 +402,9 @@ class SourceMapperTest {
                                             .build());
 
                     RhinoException ex =
-                            assertThrows(RhinoException.class, () -> script.exec(cx, scope, scope));
+                            assertThrows(
+                                    RhinoException.class,
+                                    () -> script.exec(cx, scope, scope.getGlobalThis()));
                     assertEquals(
                             1,
                             ex.lineNumber(),

--- a/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/SourceMapperTest.java
@@ -187,10 +187,10 @@ class SourceMapperTest {
 
                     assertFalse(reporter.errors.isEmpty(), "expected at least one error");
                     ReportedError err = reporter.errors.get(0);
-                    assertEquals(101, err.line(), "error line should be remapped");
+                    assertEquals(101, err.line, "error line should be remapped");
                     assertEquals(
                             "let x = 'unterminated;",
-                            err.lineSource(),
+                            err.lineSource,
                             "lineSource should come from the mapper");
                     return null;
                 });
@@ -317,7 +317,15 @@ class SourceMapperTest {
         return InterpreterIcodeCapture.capture(() -> cx.compileScript(spec));
     }
 
-    private record ReportedError(String message, int line, String lineSource, int offset) {}
+    private static final class ReportedError {
+        private final int line;
+        private final String lineSource;
+
+        private ReportedError(int line, String lineSource) {
+            this.line = line;
+            this.lineSource = lineSource;
+        }
+    }
 
     private static final class RecordingErrorReporter implements ErrorReporter {
         final List<ReportedError> errors = new ArrayList<>();
@@ -331,7 +339,7 @@ class SourceMapperTest {
         @Override
         public void error(
                 String message, String sourceName, int line, String lineSource, int lineOffset) {
-            errors.add(new ReportedError(message, line, lineSource, lineOffset));
+            errors.add(new ReportedError(line, lineSource));
         }
 
         @Override


### PR DESCRIPTION
Stacked on top of https://github.com/mozilla/rhino/pull/2388. This is basically the internal implementation that we have had in ServiceNow for some years now, slightly cleaned up.

---

Adds an abstract `SourceMapper` interface. Callers attach a mapper via
`ScriptCompileSpec`/`FunctionCompileSpec` builders; the mapper is held
on `CompilerEnvirons`.

It is consulted during code generation in both backends (`BodyCodegen`
and `CodeGenerator`) so emitted line numbers refer to the original
source - i.e. this means that features such as debugger breakpoints or
stack traces come for free.

Parser error reporting and the debugger source handoff also use the
mapper. Null mappings cause the corresponding line entry to be skipped
in both LineNumberTable and Icode_LINE.

Tests cover both backends where applicable (via
`Utils.runWithAllModes`), although there are some interpreter-only
tests. `InterpreterIcodeCapture` was added to reduces duplication with
`InterpreterBytecodeDumpTest`.

---

The next step will be implementing a fully [spec-compliant](https://tc39.es/ecma426/) source mapper parser that uses the [official test suite](https://github.com/tc39/source-map-tests/).