### PR TITLE
Refactor compilation API for full type-safety

### DIFF
--- a/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
+++ b/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
@@ -34,7 +34,7 @@ public class ClassFileWriter {
 
         private static final long serialVersionUID = 1263998431033790599L;
 
-        ClassFileFormatException(String message) {
+        public ClassFileFormatException(String message) {
             super(message);
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/CompilationResult.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompilationResult.java
@@ -1,0 +1,19 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import org.mozilla.javascript.debug.DebuggableScript;
+
+/**
+ * Opaque result of compiling a {@link org.mozilla.javascript.ast.ScriptNode} via an {@link
+ * Evaluator}. Each {@link Evaluator} implementation provides its own concrete subtype; callers must
+ * pass the result back to the same evaluator that produced it. The type parameter ties the result
+ * to either {@link JSScript} or {@link JSFunction}.
+ */
+public interface CompilationResult<T extends ScriptOrFn<T>> {
+    DebuggableScript getDebuggableScript();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2606,8 +2606,15 @@ public class Context implements Closeable {
                 Evaluator evaluator, CompilerEnvirons env, ScriptNode tree, String rawSource);
     }
 
-    private record Compiled<T extends ScriptOrFn<T>>(
-            Evaluator evaluator, CompilationResult<T> result) {}
+    private static final class Compiled<T extends ScriptOrFn<T>> {
+        private final Evaluator evaluator;
+        private final CompilationResult<T> result;
+
+        private Compiled(Evaluator evaluator, CompilationResult<T> result) {
+            this.evaluator = evaluator;
+            this.result = result;
+        }
+    }
 
     private <T extends ScriptOrFn<T>> Compiled<T> compileImpl(
             String sourceString,

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2570,7 +2570,7 @@ public class Context implements Closeable {
     }
 
     protected Script compileScriptImpl(ScriptCompileSpec spec) {
-        return (Script)
+        Compiled<JSScript> compiled =
                 compileImpl(
                         spec.getSource(),
                         spec.getSourceName(),
@@ -2579,12 +2579,13 @@ public class Context implements Closeable {
                         spec.getCompiler(),
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
-                        null,
-                        false);
+                        false,
+                        Evaluator::compileScript);
+        return compiled.evaluator.createScriptObject(compiled.result, spec.getSecurityDomain());
     }
 
     protected Function compileFunctionImpl(FunctionCompileSpec spec) {
-        return (Function)
+        Compiled<JSFunction> compiled =
                 compileImpl(
                         spec.getSource(),
                         spec.getSourceName(),
@@ -2593,11 +2594,22 @@ public class Context implements Closeable {
                         spec.getCompiler(),
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
-                        spec.getScope(),
-                        true);
+                        true,
+                        Evaluator::compileFunction);
+        return compiled.evaluator.createFunctionObject(
+                this, spec.getScope(), compiled.result, spec.getSecurityDomain());
     }
 
-    private Object compileImpl(
+    @FunctionalInterface
+    private interface CompileFn<T extends ScriptOrFn<T>> {
+        CompilationResult<T> compile(
+                Evaluator evaluator, CompilerEnvirons env, ScriptNode tree, String rawSource);
+    }
+
+    private record Compiled<T extends ScriptOrFn<T>>(
+            Evaluator evaluator, CompilationResult<T> result) {}
+
+    private <T extends ScriptOrFn<T>> Compiled<T> compileImpl(
             String sourceString,
             String sourceName,
             int lineno,
@@ -2605,8 +2617,8 @@ public class Context implements Closeable {
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
             Consumer<CompilerEnvirons> compilerEnvironProcessor,
-            VarScope scope,
-            boolean returnFunction) {
+            boolean returnFunction,
+            CompileFn<T> compileFn) {
         if (sourceName == null) {
             sourceName = "unnamed script";
         }
@@ -2615,9 +2627,6 @@ public class Context implements Closeable {
             throw new IllegalArgumentException(
                     "securityDomain should be null if setSecurityController() was never called");
         }
-
-        // scope should be given if and only if compiling function
-        if (!(scope == null ^ returnFunction)) Kit.codeBug();
 
         CompilerEnvirons compilerEnv = new CompilerEnvirons();
         compilerEnv.initFromContext(this);
@@ -2640,13 +2649,13 @@ public class Context implements Closeable {
                         compilationErrorReporter,
                         returnFunction);
 
-        Object bytecode;
+        CompilationResult<T> result;
         try {
             if (compiler == null) {
                 compiler = createCompiler();
             }
 
-            bytecode = compiler.compile(compilerEnv, tree, sourceString, returnFunction);
+            result = compileFn.compile(compiler, compilerEnv, tree, sourceString);
         } catch (ClassFileFormatException e) {
             // we hit some class file limit, fall back to interpreter or report
 
@@ -2662,12 +2671,12 @@ public class Context implements Closeable {
                             returnFunction);
 
             compiler = createInterpreter();
-            bytecode = compiler.compile(compilerEnv, tree, sourceString, returnFunction);
+            result = compileFn.compile(compiler, compilerEnv, tree, sourceString);
         }
 
         if (debugger != null) {
             if (sourceString == null) Kit.codeBug();
-            DebuggableScript dscript = compiler.getDebuggableScript(bytecode);
+            DebuggableScript dscript = result.getDebuggableScript();
             if (dscript != null) {
                 notifyDebugger_r(this, dscript, sourceString);
             } else {
@@ -2675,14 +2684,7 @@ public class Context implements Closeable {
             }
         }
 
-        Object result;
-        if (returnFunction) {
-            result = compiler.createFunctionObject(this, scope, bytecode, securityDomain);
-        } else {
-            result = compiler.createScriptObject(bytecode, securityDomain);
-        }
-
-        return result;
+        return new Compiled<>(compiler, result);
     }
 
     private ScriptNode parse(

--- a/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Evaluator.java
@@ -8,47 +8,55 @@ package org.mozilla.javascript;
 
 import java.util.List;
 import org.mozilla.javascript.ast.ScriptNode;
-import org.mozilla.javascript.debug.DebuggableScript;
 
 /** Abstraction of evaluation, which can be implemented either by an interpreter or compiler. */
 public interface Evaluator {
 
     /**
-     * Compile the script or function from intermediate representation tree into an executable form.
+     * Compile a script from intermediate representation tree into an executable form.
      *
      * @param compilerEnv Compiler environment
      * @param tree parse tree
      * @param rawSource the source code
-     * @param returnFunction if true, compiling a function
-     * @return an opaque object that can be passed to either createFunctionObject or
-     *     createScriptObject, depending on the value of returnFunction
+     * @return a result that can be passed to {@link #createScriptObject}
      */
-    public Object compile(
-            CompilerEnvirons compilerEnv,
-            ScriptNode tree,
-            String rawSource,
-            boolean returnFunction);
+    CompilationResult<JSScript> compileScript(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource);
+
+    /**
+     * Compile a function from intermediate representation tree into an executable form.
+     *
+     * @param compilerEnv Compiler environment
+     * @param tree parse tree
+     * @param rawSource the source code
+     * @return a result that can be passed to {@link #createFunctionObject}
+     */
+    CompilationResult<JSFunction> compileFunction(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource);
 
     /**
      * Create a function object.
      *
      * @param cx Current context
      * @param scope scope of the function
-     * @param bytecode opaque object returned by compile
+     * @param compiled the result returned by {@link #compileFunction}
      * @param staticSecurityDomain security domain
      * @return Function object that can be called
      */
-    public Function createFunctionObject(
-            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain);
+    Function createFunctionObject(
+            Context cx,
+            VarScope scope,
+            CompilationResult<JSFunction> compiled,
+            Object staticSecurityDomain);
 
     /**
      * Create a script object.
      *
-     * @param bytecode opaque object returned by compile
+     * @param compiled the result returned by {@link #compileScript}
      * @param staticSecurityDomain security domain
      * @return Script object that can be evaluated
      */
-    public Script createScriptObject(Object bytecode, Object staticSecurityDomain);
+    Script createScriptObject(CompilationResult<JSScript> compiled, Object staticSecurityDomain);
 
     /**
      * Capture stack information from the given exception.
@@ -83,8 +91,4 @@ public interface Evaluator {
      * @return list of strings for the stack trace
      */
     public List<String> getScriptStack(RhinoException ex);
-
-    public default DebuggableScript getDebuggableScript(Object bytecode) {
-        return null;
-    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -716,53 +716,54 @@ public final class Interpreter extends Icode implements Evaluator {
         }
     }
 
-    private static class CompilationResult<T extends ScriptOrFn<T>> {
+    private static class InterpreterCompilationResult<T extends ScriptOrFn<T>>
+            implements CompilationResult<T> {
         private final JSDescriptor<T> descriptor;
         private final Scriptable homeObject;
 
-        CompilationResult(JSDescriptor<T> descriptor, Scriptable homeObject) {
+        InterpreterCompilationResult(JSDescriptor<T> descriptor, Scriptable homeObject) {
             this.descriptor = descriptor;
             this.homeObject = homeObject;
+        }
+
+        @Override
+        public DebuggableScript getDebuggableScript() {
+            return descriptor;
         }
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Object compile(
-            CompilerEnvirons compilerEnv,
-            ScriptNode tree,
-            String rawSource,
-            boolean returnFunction) {
-        CodeGenerator<?> cgen = new CodeGenerator<>();
-        var itsData = cgen.compile(compilerEnv, tree, rawSource, returnFunction);
-        return new CompilationResult(itsData, compilerEnv.homeObject());
+    public CompilationResult<JSScript> compileScript(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+        CodeGenerator<JSScript> cgen = new CodeGenerator<>();
+        JSDescriptor<JSScript> itsData = cgen.compile(compilerEnv, tree, rawSource, false);
+        return new InterpreterCompilationResult<>(itsData, compilerEnv.homeObject());
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public DebuggableScript getDebuggableScript(Object bytecode) {
-        return ((CompilationResult<?>) bytecode).descriptor;
+    public CompilationResult<JSFunction> compileFunction(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+        CodeGenerator<JSFunction> cgen = new CodeGenerator<>();
+        JSDescriptor<JSFunction> itsData = cgen.compile(compilerEnv, tree, rawSource, true);
+        return new InterpreterCompilationResult<>(itsData, compilerEnv.homeObject());
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Script createScriptObject(Object bytecode, Object staticSecurityDomain) {
-        var compilerResult = (CompilationResult<JSScript>) bytecode;
-        return JSFunction.createScript(
-                compilerResult.descriptor, compilerResult.homeObject, staticSecurityDomain);
+    public Script createScriptObject(
+            CompilationResult<JSScript> compiled, Object staticSecurityDomain) {
+        var result = (InterpreterCompilationResult<JSScript>) compiled;
+        return JSFunction.createScript(result.descriptor, result.homeObject, staticSecurityDomain);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Function createFunctionObject(
-            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain) {
-        var compilerResult = (CompilationResult<JSFunction>) bytecode;
+            Context cx,
+            VarScope scope,
+            CompilationResult<JSFunction> compiled,
+            Object staticSecurityDomain) {
+        var result = (InterpreterCompilationResult<JSFunction>) compiled;
         return JSFunction.createFunction(
-                cx,
-                scope,
-                compilerResult.descriptor,
-                compilerResult.homeObject,
-                staticSecurityDomain);
+                cx, scope, result.descriptor, result.homeObject, staticSecurityDomain);
     }
 
     private static int getShort(byte[] iCode, int pc) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CodeGenUtils;
+import org.mozilla.javascript.CompilationResult;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Evaluator;
@@ -39,6 +40,7 @@ import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Name;
 import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.ast.TemplateCharacters;
+import org.mozilla.javascript.debug.DebuggableScript;
 
 /**
  * This class generates code for a given IR tree.
@@ -67,13 +69,14 @@ public class Codegen implements Evaluator {
         throw new UnsupportedOperationException();
     }
 
-    private static class CompilationResult<T extends ScriptOrFn<T>> {
+    private static class CodegenCompilationResult<T extends ScriptOrFn<T>>
+            implements CompilationResult<T> {
         final JSDescriptor.Builder<T> builder;
         final String className;
         final byte[] bytecode;
         final OptJSCode.BuilderEnv builderEnv;
 
-        CompilationResult(
+        CodegenCompilationResult(
                 JSDescriptor.Builder<T> builder,
                 String className,
                 byte[] bytecode,
@@ -83,11 +86,27 @@ public class Codegen implements Evaluator {
             this.bytecode = bytecode;
             this.builderEnv = builderEnv;
         }
+
+        @Override
+        public DebuggableScript getDebuggableScript() {
+            // Can't debug compiled classes
+            return null;
+        }
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Object compile(
+    public CompilationResult<JSScript> compileScript(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+        return doCompile(compilerEnv, tree, rawSource, false);
+    }
+
+    @Override
+    public CompilationResult<JSFunction> compileFunction(
+            CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+        return doCompile(compilerEnv, tree, rawSource, true);
+    }
+
+    private <T extends ScriptOrFn<T>> CodegenCompilationResult<T> doCompile(
             CompilerEnvirons compilerEnv,
             ScriptNode tree,
             String rawSource,
@@ -107,7 +126,7 @@ public class Codegen implements Evaluator {
 
         String mainClassName = "org.mozilla.javascript.gen." + baseName + "_" + serial;
 
-        JSDescriptor.Builder<?> builder = new JSDescriptor.Builder();
+        JSDescriptor.Builder<T> builder = new JSDescriptor.Builder<>();
         OptJSCode.BuilderEnv builderEnv = new OptJSCode.BuilderEnv(mainClassName);
         byte[] mainClassBytes =
                 compileToClassFile(
@@ -119,28 +138,30 @@ public class Codegen implements Evaluator {
                         rawSource,
                         returnFunction);
 
-        return new CompilationResult(builder, mainClassName, mainClassBytes, builderEnv);
+        return new CodegenCompilationResult<>(builder, mainClassName, mainClassBytes, builderEnv);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
-    public Script createScriptObject(Object bytecode, Object staticSecurityDomain) {
+    public Script createScriptObject(
+            CompilationResult<JSScript> compiled, Object staticSecurityDomain) {
         JSDescriptor<JSScript> desc =
-                defineClass((CompilationResult<JSScript>) bytecode, staticSecurityDomain);
+                defineClass((CodegenCompilationResult<JSScript>) compiled, staticSecurityDomain);
         return JSFunction.createScript(desc, null, staticSecurityDomain);
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Function createFunctionObject(
-            Context cx, VarScope scope, Object bytecode, Object staticSecurityDomain) {
+            Context cx,
+            VarScope scope,
+            CompilationResult<JSFunction> compiled,
+            Object staticSecurityDomain) {
         JSDescriptor<JSFunction> desc =
-                defineClass((CompilationResult<JSFunction>) bytecode, staticSecurityDomain);
+                defineClass((CodegenCompilationResult<JSFunction>) compiled, staticSecurityDomain);
         return JSFunction.createFunction(cx, scope, desc, null, staticSecurityDomain);
     }
 
     private <T extends ScriptOrFn<T>> JSDescriptor<T> defineClass(
-            CompilationResult<T> compiled, Object staticSecurityDomain) {
+            CodegenCompilationResult<T> compiled, Object staticSecurityDomain) {
         // The generated classes in this case refer only to Rhino classes
         // which must be accessible through this class loader
         ClassLoader rhinoLoader = getClass().getClassLoader();

--- a/tests/src/test/java/org/mozilla/javascript/tests/CompilerFallbackTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CompilerFallbackTest.java
@@ -1,0 +1,134 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mozilla.classfile.ClassFileWriter.ClassFileFormatException;
+import org.mozilla.javascript.CompilationResult;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.Evaluator;
+import org.mozilla.javascript.Function;
+import org.mozilla.javascript.FunctionCompileSpec;
+import org.mozilla.javascript.JSFunction;
+import org.mozilla.javascript.JSScript;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.Script;
+import org.mozilla.javascript.ScriptCompileSpec;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.ast.ScriptNode;
+
+/**
+ * When the compiler throws {@link ClassFileFormatException} (e.g. method bytecode exceeds 64K),
+ * {@code Context.compileImpl} must transparently fall back to the interpreter and produce a working
+ * Script/Function.
+ */
+public class CompilerFallbackTest {
+    private Context cx;
+    private TopLevel scope;
+
+    @BeforeEach
+    public void setUp() {
+        cx = Context.enter();
+        scope = cx.initStandardObjects();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Context.exit();
+    }
+
+    @Test
+    public void scriptCompileFallsBackToInterpreterOnClassFileFormatException() {
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource("1 + 2 + 3")
+                                .sourceName("fallback.js")
+                                .compiler(new AlwaysFailingEvaluator())
+                                .build());
+
+        assertNotNull(script);
+        Object result = script.exec(cx, scope, scope.getGlobalThis());
+        assertEquals(6, ((Number) result).intValue());
+    }
+
+    @Test
+    public void functionCompileFallsBackToInterpreterOnClassFileFormatException() {
+        Function func =
+                cx.compileFunction(
+                        FunctionCompileSpec.fromSource(
+                                        "function add(a, b) { return a + b; }", scope)
+                                .sourceName("fallback-fn.js")
+                                .compiler(new AlwaysFailingEvaluator())
+                                .build());
+
+        assertNotNull(func);
+        Object result = func.call(cx, scope, scope.getGlobalThis(), new Object[] {3, 4});
+        assertEquals(7, ((Number) result).intValue());
+    }
+
+    /**
+     * Stand-in for a {@link org.mozilla.javascript.optimizer.Codegen} that always hits a class-file
+     * size limit during compilation. After the throw, {@code Context.compileImpl} should swap to a
+     * fresh interpreter and complete compilation.
+     */
+    private static final class AlwaysFailingEvaluator implements Evaluator {
+        @Override
+        public CompilationResult<JSScript> compileScript(
+                CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+            throw new ClassFileFormatException("simulated: method too big");
+        }
+
+        @Override
+        public CompilationResult<JSFunction> compileFunction(
+                CompilerEnvirons compilerEnv, ScriptNode tree, String rawSource) {
+            throw new ClassFileFormatException("simulated: method too big");
+        }
+
+        @Override
+        public Function createFunctionObject(
+                Context cx,
+                VarScope scope,
+                CompilationResult<JSFunction> compiled,
+                Object staticSecurityDomain) {
+            throw new AssertionError(
+                    "createFunctionObject must not be called on the failing compiler after fallback");
+        }
+
+        @Override
+        public Script createScriptObject(
+                CompilationResult<JSScript> compiled, Object staticSecurityDomain) {
+            throw new AssertionError(
+                    "createScriptObject must not be called on the failing compiler after fallback");
+        }
+
+        @Override
+        public void captureStackInfo(RhinoException ex) {
+            throw new AssertionError("should not have been called");
+        }
+
+        @Override
+        public String getSourcePositionFromStack(Context cx, int[] linep) {
+            throw new AssertionError("should not have been called");
+        }
+
+        @Override
+        public String getPatchedStack(RhinoException ex, String nativeStackTrace) {
+            throw new AssertionError("should not have been called");
+        }
+
+        @Override
+        public List<String> getScriptStack(RhinoException ex) {
+            throw new AssertionError("should not have been called");
+        }
+    }
+}


### PR DESCRIPTION
Implements [Duncan's suggestion](https://github.com/mozilla/rhino/pull/2386#pullrequestreview-4191925795). Stacked on top of https://github.com/mozilla/rhino/pull/2386

---

Gets rid of the unchecked casts in `Context` for function or script compilation by completely splitting the API in two in the `Evaluator` interface. The `<T>` gets propagated and makes the code wholly type-safe, at the cost of a couple interfaces more.

Also added a test about the "can't compile jvm class => fallback to interpreter" pre-existing feature.
