### PR TITLE
Fix register count in ClassCompiler

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -368,7 +368,7 @@ public class ClassCompiler {
                 "Ljava/util/List;");
 
         cfw.add(ByteCode.ARETURN);
-        cfw.stopMethod(2);
+        cfw.stopMethod(3);
         for (var child : builder.nestedFunctions) {
             buildDescriptor(cfw, (JSDescriptor.Builder) child, classes, builders);
         }


### PR DESCRIPTION
ClassCompiler does not pass the right number to "stopMethod". The test only
passes because we are running with Jacoco which adds extra stuff to the
bytecode.

Verified this by turning off Jacoco in "publishing-conventions.gradle"
and verifying that CLassCompilerTest fails.
