### PR TITLE
Fix uint8 overflow in array literal skipIndexesId and sourcePositions

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1494,6 +1494,9 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 if (((Node) propertyId).type == Token.DOTDOTDOT) {
                     // It's actually a spread! We need to do a "continue" to avoid setting it as key
                     addIcode(Icode_SPREAD);
+                    // Always emit a 2-byte operand so Icode_SPREAD is fixed-width (3 bytes).
+                    // Object-literal spread never uses sourcePositions, so emit 0.
+                    addUint16(0);
                     stackChange(-1);
                     child = child.getNext();
                     i++;
@@ -1605,6 +1608,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 addIcode(Icode_SPREAD);
                 if (skipIndexes != null) {
                     addUint16(sourcePositions[childIdx]);
+                } else {
+                    addUint16(0);
                 }
                 stackChange(-1);
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -1595,7 +1595,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         }
 
         addIndexOp(Icode_LITERAL_NEW_ARRAY, count - numberOfSpread);
-        addUint8(skipIndexesId + 1);
+        addUint16(skipIndexesId + 1);
         stackChange(1);
 
         int childIdx = 0;
@@ -1604,7 +1604,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child.getFirstChild(), 0);
                 addIcode(Icode_SPREAD);
                 if (skipIndexes != null) {
-                    addUint8(sourcePositions[childIdx]);
+                    addUint16(sourcePositions[childIdx]);
                 }
                 stackChange(-1);
             } else {

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -969,8 +969,8 @@ public final class Interpreter extends Icode implements Evaluator {
                 return 1 + 1;
 
             case Icode_LITERAL_NEW_ARRAY:
-                // skip indexes ID byte
-                return 1 + 1;
+                // skip indexes ID (uint16)
+                return 1 + 2;
 
             case Icode_REG_BIGINT1:
                 // ubyte bigint index
@@ -4418,8 +4418,8 @@ public final class Interpreter extends Icode implements Evaluator {
             // indexReg: number of values in the literal
             NewLiteralStorage storage = NewLiteralStorage.create(cx, state.indexReg, false);
 
-            int skipIdx = 0xFF & frame.idata.itsICode[frame.pc];
-            ++frame.pc;
+            int skipIdx = getIndex(frame.idata.itsICode, frame.pc);
+            frame.pc += 2;
 
             // fill in skip indexes in array literal storage
             if (skipIdx > 0) { // 0 - no skip index, otherwise subtract 1 from idx
@@ -4493,8 +4493,8 @@ public final class Interpreter extends Icode implements Evaluator {
             NewLiteralStorage store = (NewLiteralStorage) frame.stack[state.stackTop];
 
             if (store.hasSkipIndexes()) {
-                int sourcePos = 0xFF & frame.idata.itsICode[frame.pc];
-                ++frame.pc;
+                int sourcePos = getIndex(frame.idata.itsICode, frame.pc);
+                frame.pc += 2;
                 store.spread(cx, frame.scope, source, sourcePos);
             } else {
                 store.spread(cx, frame.scope, source, 0);

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -972,6 +972,10 @@ public final class Interpreter extends Icode implements Evaluator {
                 // skip indexes ID (uint16)
                 return 1 + 2;
 
+            case Icode_SPREAD:
+                // 2-byte source position operand (always emitted, even when unused)
+                return 1 + 2;
+
             case Icode_REG_BIGINT1:
                 // ubyte bigint index
                 return 1 + 1;
@@ -4492,14 +4496,23 @@ public final class Interpreter extends Icode implements Evaluator {
             --state.stackTop;
             NewLiteralStorage store = (NewLiteralStorage) frame.stack[state.stackTop];
 
+            // Always consume the 2-byte operand to keep pc in sync.
+            int sourcePos = getIndex(frame.idata.itsICode, frame.pc);
+            frame.pc += 2;
+
             if (store.hasSkipIndexes()) {
-                int sourcePos = getIndex(frame.idata.itsICode, frame.pc);
-                frame.pc += 2;
                 store.spread(cx, frame.scope, source, sourcePos);
             } else {
                 store.spread(cx, frame.scope, source, 0);
             }
             return null;
+        }
+
+        @Override
+        void dumpICode(int op, String tname, ICodeDumpContext ctx) {
+            int sourcePos = ctx.getIndex(ctx.pc);
+            ctx.out.println(tname + " sourcePos=" + sourcePos);
+            ctx.pc += 2;
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -4432,9 +4432,9 @@ public final class Interpreter extends Icode implements Evaluator {
 
         @Override
         void dumpICode(int op, String tname, ICodeDumpContext ctx) {
-            int skipIdx = 0xFF & ctx.idata.itsICode[ctx.pc];
+            int skipIdx = getIndex(ctx.idata.itsICode, ctx.pc);
             ctx.out.println(tname + " " + ctx.indexReg + " skipIdx=" + skipIdx);
-            ++ctx.pc;
+            ctx.pc += 2;
         }
     }
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
@@ -16,7 +16,7 @@ public class ArrayLiteralOverflowTest {
      * encoding.
      */
     @Test
-    public void testLiteralIdsOverflowWithSparseArrayInterpreted() {
+    public void testLiteralIdsOverflowWithSparseArray() {
         StringBuilder sb = new StringBuilder();
 
         // Create 260 object literals to push literalIds past 255
@@ -33,7 +33,7 @@ public class ArrayLiteralOverflowTest {
 
     /** Tests spread with sparse arrays when literalIds has grown past 255. */
     @Test
-    public void testManySpreadArrayLiteralsInterpreted() {
+    public void testManySpreadArrayLiterals() {
         StringBuilder sb = new StringBuilder();
         sb.append("var base = [0];\n");
 

--- a/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
@@ -4,47 +4,234 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
- * Regression test for addUint8 overflow in CodeGenerator.visitArrayLiteral. When a script contains
- * more than 255 object/array literals, the literalIds table grows beyond 255, and skipIndexesId
- * (encoded as uint8) overflows.
+ * Regression tests for addUint8 overflow in CodeGenerator.visitArrayLiteral.
+ *
+ * <p>Two fields were encoded as uint8 and overflow when literalIds grows past 255:
+ *
+ * <ul>
+ *   <li>skipIndexesId – index into literalIds for the skip-indexes array of a sparse array literal
+ *       (elisions). Fixed by switching to addUint16.
+ *   <li>sourcePositions[i] – per-spread source position used to place spread elements at the right
+ *       index inside a sparse array. Fixed likewise.
+ * </ul>
+ *
+ * <p>Note: cases with multiple spread elements inside a single sparse array (e.g. [...[1], ,
+ * ...[2,3], , ...[4]]) expose a separate pre-existing bug in NewLiteralStorage.spreadAdjustments
+ * sizing and are not tested here.
  */
 public class ArrayLiteralOverflowTest {
 
-    /**
-     * Each object literal {k:v} adds one entry to literalIds. After 256 object literals, the next
-     * sparse array literal (with elisions) gets a skipIndexesId > 255, which overflows the uint8
-     * encoding.
-     */
-    @Test
-    public void testLiteralIdsOverflowWithSparseArray() {
-        StringBuilder sb = new StringBuilder();
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
 
-        // Create 260 object literals to push literalIds past 255
-        for (int i = 0; i < 260; i++) {
+    /** Returns a script that defines n object literals then appends body. */
+    private static String withObjectLiterals(int n, String body) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
             sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
         }
-
-        // Now create a sparse array (with elision) that needs skipIndexes
-        // [1, , 3] has a "hole" at index 1 which triggers skipIndexes
-        sb.append("var sparse = [1, , 3];\n").append("sparse[0] + sparse[2];\n");
-
-        Utils.assertWithAllModes(4.0d, sb.toString());
+        sb.append(body);
+        return sb.toString();
     }
 
-    /** Tests spread with sparse arrays when literalIds has grown past 255. */
+    // ------------------------------------------------------------------
+    // 1. Original regression: skipIndexesId overflow
+    //    (plain sparse array, no spread)
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testLiteralIdsOverflowWithSparseArray() {
+        Utils.assertWithAllModes(
+                "1/3", withObjectLiterals(260, "var a = [1, , 3]; a[0] + '/' + a[2];\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Boundary values for skipIndexesId overflow
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testSkipIndexesIdAt254Literals() {
+        Utils.assertWithAllModes(
+                "1/3", withObjectLiterals(254, "var a = [1, , 3]; a[0] + '/' + a[2];\n"));
+    }
+
+    @Test
+    public void testSkipIndexesIdAt255Literals() {
+        Utils.assertWithAllModes(
+                "1/3", withObjectLiterals(255, "var a = [1, , 3]; a[0] + '/' + a[2];\n"));
+    }
+
+    @Test
+    public void testSkipIndexesIdAt256Literals() {
+        Utils.assertWithAllModes(
+                "1/3", withObjectLiterals(256, "var a = [1, , 3]; a[0] + '/' + a[2];\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Hole positions must be correct after overflow
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testHoleIsAbsentAfterOverflow() {
+        Utils.assertWithAllModes(
+                "1/absent/3",
+                withObjectLiterals(
+                        260,
+                        "var a = [1, , 3];\n"
+                                + "a[0] + '/'"
+                                + " + ((1 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[2];\n"));
+    }
+
+    @Test
+    public void testLengthAfterOverflow() {
+        Utils.assertWithAllModes(
+                "1/3/3",
+                withObjectLiterals(260, "var a = [1, , 3]; a[0] + '/' + a[2] + '/' + a.length;\n"));
+    }
+
+    @Test
+    public void testMultipleHolesAfterOverflow() {
+        // [1, , , 4] — two consecutive holes; both must be absent
+        Utils.assertWithAllModes(
+                "1/absent/absent/4",
+                withObjectLiterals(
+                        260,
+                        "var a = [1, , , 4];\n"
+                                + "a[0] + '/'"
+                                + " + ((1 in a) ? 'present' : 'absent') + '/'"
+                                + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[3];\n"));
+    }
+
+    @Test
+    public void testLeadingHoleAfterOverflow() {
+        Utils.assertWithAllModes(
+                "absent/1/2",
+                withObjectLiterals(
+                        260,
+                        "var a = [, 1, 2];\n"
+                                + "((0 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[1] + '/' + a[2];\n"));
+    }
+
+    @Test
+    public void testTrailingHoleAfterOverflow() {
+        Utils.assertWithAllModes(
+                "1/2/3",
+                withObjectLiterals(
+                        260, "var a = [1, 2, ,];\n" + "a[0] + '/' + a[1] + '/' + a.length;\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Multiple sparse arrays in one script
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testTwoSparseArraysAfterOverflow() {
+        Utils.assertWithAllModes(
+                "1/3/4/6",
+                withObjectLiterals(
+                        260,
+                        "var a = [1, , 3];\n"
+                                + "var b = [4, , 6];\n"
+                                + "a[0] + '/' + a[2] + '/' + b[0] + '/' + b[2];\n"));
+    }
+
+    @Test
+    public void testSparseArrayInsideFunctionAfterOverflow() {
+        Utils.assertWithAllModes(
+                "1/3",
+                withObjectLiterals(
+                        260,
+                        "function f() { return [1, , 3]; }\n"
+                                + "var a = f(); a[0] + '/' + a[2];\n"));
+    }
+
+    // ------------------------------------------------------------------
+    // 5. sourcePositions overflow: spread inside a sparse array
+    // ------------------------------------------------------------------
+
+    /** Original regression test kept for continuity. */
     @Test
     public void testManySpreadArrayLiterals() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("var base = [0];\n");
+        Utils.assertWithAllModes(
+                "0/42",
+                withObjectLiterals(
+                        260,
+                        "var base = [0];\n"
+                                + "var result = [...base, , 42];\n"
+                                + "result[0] + '/' + result[2];\n"));
+    }
 
-        // 260 object literals to fill literalIds
-        for (int i = 0; i < 260; i++) {
-            sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
-        }
+    @Test
+    public void testSpreadSourcePositionAt255Literals() {
+        Utils.assertWithAllModes(
+                "10/99", withObjectLiterals(255, "var a = [...[10], , 99]; a[0] + '/' + a[2];\n"));
+    }
 
-        // Sparse array with spread: triggers both skipIndexesId and sourcePositions overflow
-        sb.append("var result = [...base, , 42];\n").append("result[2];\n");
+    @Test
+    public void testSpreadElementIsAtCorrectIndexAfterOverflow() {
+        // [...[10, 20], , 42] → [10, 20, <hole>, 42]
+        Utils.assertWithAllModes(
+                "10/20/absent/42",
+                withObjectLiterals(
+                        260,
+                        "var a = [...[10, 20], , 42];\n"
+                                + "a[0] + '/' + a[1] + '/'"
+                                + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[3];\n"));
+    }
 
-        Utils.assertWithAllModes(42.0d, sb.toString());
+    @Test
+    public void testHoleAfterSpreadIsAbsentAfterOverflow() {
+        // [...[1, 2], , 99] → [1, 2, <hole>, 99]
+        Utils.assertWithAllModes(
+                "1/2/absent/99",
+                withObjectLiterals(
+                        260,
+                        "var a = [...[1, 2], , 99];\n"
+                                + "a[0] + '/' + a[1] + '/'"
+                                + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[3];\n"));
+    }
+
+    @Test
+    public void testSpreadAtStartOfSparseArrayAfterOverflow() {
+        // [...[1, 2], , 3] → [1, 2, <hole>, 3]
+        Utils.assertWithAllModes(
+                "1/2/absent/3",
+                withObjectLiterals(
+                        260,
+                        "var a = [...[1, 2], , 3];\n"
+                                + "a[0] + '/' + a[1] + '/'"
+                                + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[3];\n"));
+    }
+
+    @Test
+    public void testSpreadAtEndOfSparseArrayAfterOverflow() {
+        // [, 1, ...[2, 3]] → [<hole>, 1, 2, 3]
+        Utils.assertWithAllModes(
+                "absent/1/2/3",
+                withObjectLiterals(
+                        260,
+                        "var a = [, 1, ...[2, 3]];\n"
+                                + "((0 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[1] + '/' + a[2] + '/' + a[3];\n"));
+    }
+
+    @Test
+    public void testSpreadLengthAfterOverflow() {
+        // [...[1, 2], , 3] → length 4
+        Utils.assertWithAllModes(
+                "1/2/absent/3/4",
+                withObjectLiterals(
+                        260,
+                        "var a = [...[1, 2], , 3];\n"
+                                + "a[0] + '/' + a[1] + '/'"
+                                + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                                + " + a[3] + '/' + a.length;\n"));
     }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/ArrayLiteralOverflowTest.java
@@ -1,0 +1,50 @@
+package org.mozilla.javascript.tests;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Regression test for addUint8 overflow in CodeGenerator.visitArrayLiteral. When a script contains
+ * more than 255 object/array literals, the literalIds table grows beyond 255, and skipIndexesId
+ * (encoded as uint8) overflows.
+ */
+public class ArrayLiteralOverflowTest {
+
+    /**
+     * Each object literal {k:v} adds one entry to literalIds. After 256 object literals, the next
+     * sparse array literal (with elisions) gets a skipIndexesId > 255, which overflows the uint8
+     * encoding.
+     */
+    @Test
+    public void testLiteralIdsOverflowWithSparseArrayInterpreted() {
+        StringBuilder sb = new StringBuilder();
+
+        // Create 260 object literals to push literalIds past 255
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
+        }
+
+        // Now create a sparse array (with elision) that needs skipIndexes
+        // [1, , 3] has a "hole" at index 1 which triggers skipIndexes
+        sb.append("var sparse = [1, , 3];\n").append("sparse[0] + sparse[2];\n");
+
+        Utils.assertWithAllModes(4.0d, sb.toString());
+    }
+
+    /** Tests spread with sparse arrays when literalIds has grown past 255. */
+    @Test
+    public void testManySpreadArrayLiteralsInterpreted() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("var base = [0];\n");
+
+        // 260 object literals to fill literalIds
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k: ").append(i).append("};\n");
+        }
+
+        // Sparse array with spread: triggers both skipIndexesId and sourcePositions overflow
+        sb.append("var result = [...base, , 42];\n").append("result[2];\n");
+
+        Utils.assertWithAllModes(42.0d, sb.toString());
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectLiteralSpreadBytecodeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectLiteralSpreadBytecodeTest.java
@@ -1,0 +1,227 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Regression tests for fixed-width Icode_SPREAD encoding in object literals.
+ *
+ * <p>visitObjectLiteralWithSpread() emitted Icode_SPREAD with no operand bytes. Once
+ * bytecodeSpan(Icode_SPREAD) was fixed to return 1+2, the linear bytecode scanners would skip 2
+ * extra bytes after every object spread, misreading real opcodes as operand data.
+ *
+ * <p>The desync is tested indirectly: if bytecodeSpan is wrong, instructions after the spread are
+ * misread, causing wrong values or incorrect line numbers on exceptions — all observable without
+ * internal APIs.
+ */
+public class ObjectLiteralSpreadBytecodeTest {
+
+    // ------------------------------------------------------------------
+    // 1. Runtime correctness: the unconditional addUint16(0) in
+    //    visitObjectLiteralWithSpread must not change observable behaviour.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testBasicObjectSpreadStillWorks() {
+        Utils.assertWithAllModes_ES6("1/2", "var a={x:1}; var b={...a,y:2}; b.x + '/' + b.y;");
+    }
+
+    @Test
+    public void testMultipleObjectSpreadsStillWork() {
+        Utils.assertWithAllModes_ES6(
+                "1/2/3",
+                "var a={x:1}; var b={y:2}; var c={z:3};"
+                        + "var r={...a,...b,...c}; r.x + '/' + r.y + '/' + r.z;");
+    }
+
+    @Test
+    public void testObjectSpreadOverridesStillWork() {
+        // Later spread wins; first x:1 is overwritten by x:2.
+        Utils.assertWithAllModes_ES6(2.0, "var r={x:1,...{x:2}}; r.x;");
+    }
+
+    @Test
+    public void testObjectSpreadWithNullStillIgnored() {
+        Utils.assertWithAllModes_ES6(1, "var r={...null,a:1}; r.a;");
+    }
+
+    @Test
+    public void testObjectSpreadInsideFunction() {
+        Utils.assertWithAllModes_ES6(
+                "1/2",
+                "function merge(a,b){return {...a,...b};}"
+                        + "var r=merge({x:1},{y:2}); r.x + '/' + r.y;");
+    }
+
+    @Test
+    public void testObjectSpreadAfterManyLiterals() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k:").append(i).append("};\n");
+        }
+        sb.append("var r = {...o5, extra:42}; o5.k + '/' + r.extra;");
+        Utils.assertWithAllModes_ES6("5/42", sb.toString());
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Code *after* the spread must execute correctly.
+    //    If bytecodeSpan(Icode_SPREAD) returns 1 instead of 3, the 2
+    //    operand bytes of the now-unconditional uint16 are misread as
+    //    the next opcode(s), breaking any computation that follows.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testCodeAfterObjectSpreadExecutesCorrectly() {
+        Utils.assertWithAllModes_ES6(
+                "1/9", "var a = {x:1};\n" + "var b = {...a};\n" + "b.x + '/' + 9;\n");
+    }
+
+    @Test
+    public void testConditionalAfterObjectSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "true/yes",
+                "var a = {flag:true};\n"
+                        + "var b = {...a};\n"
+                        + "b.flag + '/' + (b.flag ? 'yes' : 'no');\n");
+    }
+
+    @Test
+    public void testLoopAfterObjectSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "1/10",
+                "var a = {x:1};\n"
+                        + "var b = {...a};\n"
+                        + "var s = 0;\n"
+                        + "for (var i=0;i<10;i++) s+=b.x;\n"
+                        + "b.x + '/' + s;\n");
+    }
+
+    @Test
+    public void testFunctionCallAfterObjectSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "2/3",
+                "function add(p,q){return p+q;}\n"
+                        + "var a = {x:2};\n"
+                        + "var b = {...a};\n"
+                        + "b.x + '/' + add(b.x, 1);\n");
+    }
+
+    @Test
+    public void testMultipleObjectSpreadsCodeAfterIsCorrect() {
+        // Two spreads → 4 extra bytes skipped if span == 1.
+        Utils.assertWithAllModes_ES6(
+                "10/20",
+                "var p = {a:10};\n"
+                        + "var q = {b:20};\n"
+                        + "var r = {...p,...q};\n"
+                        + "r.a + '/' + r.b;\n");
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Error line numbers: pcSourceLineStart is driven by Icode_LINE
+    //    instructions found via bytecodeSpan(). If the span for
+    //    Icode_SPREAD is wrong, the line counter drifts.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testErrorLineAfterObjectSpreadIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var a = {x:1};\n" // line 1
+                            + "var b = {...a};\n" // line 2 (Icode_SPREAD here)
+                            + "undefinedVar;\n", // line 3 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    3,
+                    e.lineNumber(),
+                    "ReferenceError must be on line 3; "
+                            + "wrong line means bytecodeSpan(Icode_SPREAD) is incorrect");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testErrorLineAfterMultipleObjectSpreadsIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var a = {x:1};\n" // line 1
+                            + "var b = {y:2};\n" // line 2
+                            + "var c = {...a,...b};\n" // line 3 (two Icode_SPREADs)
+                            + "undefinedVar;\n", // line 4 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    4, e.lineNumber(), "ReferenceError must be on line 4 after two object spreads");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testErrorLineWithMixedSpreadsIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var obj = {x:1};\n" // line 1
+                            + "var arr = [1,2];\n" // line 2
+                            + "var o2 = {...obj, y:2};\n" // line 3 (object Icode_SPREAD)
+                            + "var a2 = [...arr, 3];\n" // line 4 (array Icode_SPREAD)
+                            + "undefinedVar;\n", // line 5 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    5, e.lineNumber(), "ReferenceError must be on line 5 after mixed spread types");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Mixed spread types: object and array spreads must coexist.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testObjectSpreadMixedWithArraySpread() {
+        Utils.assertWithAllModes_ES6(
+                "1/2/3",
+                "var obj = {x:1};\n"
+                        + "var arr = [1,2];\n"
+                        + "var o2  = {...obj, y:2};\n"
+                        + "var a2  = [...arr, 3];\n"
+                        + "o2.x + '/' + o2.y + '/' + a2[2];\n");
+    }
+
+    @Test
+    public void testObjectSpreadMixedWithSparseArraySpread() {
+        Utils.assertWithAllModes_ES6(
+                "1/2/absent/99",
+                "var base = {v:1};\n"
+                        + "var obj  = {...base, w:2};\n" // object spread
+                        + "var arr  = [...[10,20], , 99];\n" // array spread in sparse array
+                        + "obj.v + '/' + obj.w + '/'"
+                        + " + ((2 in arr) ? 'present' : 'absent') + '/'"
+                        + " + arr[3];\n");
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/SpreadSparseArrayBytecodeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/SpreadSparseArrayBytecodeTest.java
@@ -1,0 +1,243 @@
+package org.mozilla.javascript.tests.es6;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.*;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Regression tests for fixed-width Icode_SPREAD encoding in sparse array literals.
+ *
+ * <p>Before the fix, Icode_SPREAD inside a sparse array literal emitted a conditional 2-byte
+ * operand — present only when skipIndexes != null. bytecodeSpan(Icode_SPREAD) returned 1, so
+ * getLineNumbers() and dumpICode() were out of sync for any script containing a spread inside a
+ * sparse array.
+ *
+ * <p>The desync is tested indirectly: if bytecodeSpan is wrong, instructions after the spread are
+ * misread, causing wrong values or incorrect line numbers on exceptions.
+ *
+ * <p>Note: cases with multiple spread elements inside a single sparse array expose a separate
+ * pre-existing bug in NewLiteralStorage.spreadAdjustments sizing and are not tested here.
+ */
+public class SpreadSparseArrayBytecodeTest {
+
+    // ------------------------------------------------------------------
+    // 1. Basic correctness: spread inside a sparse array works at all.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testSpreadInSparseArray() {
+        // [...[1,2], , 99] → [1, 2, <hole>, 99], length 4
+        Utils.assertWithAllModes_ES6(
+                "1/2/absent/99/4",
+                "var a = [...[1,2], , 99];\n"
+                        + "a[0] + '/' + a[1] + '/'"
+                        + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                        + " + a[3] + '/' + a.length;\n");
+    }
+
+    @Test
+    public void testSpreadAtEndOfSparseArray() {
+        // [, , ...[3,4,5]] → [<hole>, <hole>, 3, 4, 5]
+        Utils.assertWithAllModes_ES6(
+                "absent/absent/3/4/5",
+                "var a = [, , ...[3,4,5]];\n"
+                        + "((0 in a) ? 'present' : 'absent') + '/'"
+                        + " + ((1 in a) ? 'present' : 'absent') + '/'"
+                        + " + a[2] + '/' + a[3] + '/' + a[4];\n");
+    }
+
+    // ------------------------------------------------------------------
+    // 2. Code *after* the spread must execute correctly.
+    //    If bytecodeSpan(Icode_SPREAD) returns 1 instead of 3, the 2
+    //    operand bytes are misread as the next opcode(s), breaking any
+    //    computation that follows.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testCodeAfterSparseSpreadExecutesCorrectly() {
+        Utils.assertWithAllModes_ES6("1/9", "var a = [...[1], , 2];\n" + "a[0] + '/' + 9;\n");
+    }
+
+    @Test
+    public void testConditionalAfterSparseSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "true/yes",
+                "var a = [...[true], , false];\n" + "a[0] + '/' + (a[0] ? 'yes' : 'no');\n");
+    }
+
+    @Test
+    public void testLoopAfterSparseSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "1/10",
+                "var a = [...[1], , 2];\n"
+                        + "var s = 0;\n"
+                        + "for (var i = 0; i < 10; i++) s += a[0];\n"
+                        + "a[0] + '/' + s;\n");
+    }
+
+    @Test
+    public void testFunctionCallAfterSparseSpreadIsCorrect() {
+        Utils.assertWithAllModes_ES6(
+                "2/3",
+                "function add(p,q){return p+q;}\n"
+                        + "var a = [...[2], , 9];\n"
+                        + "a[0] + '/' + add(a[0], 1);\n");
+    }
+
+    @Test
+    public void testTwoSparseSpreadsBytecodeConsistent() {
+        // Two Icode_SPREAD instructions: 4 extra bytes if span == 1.
+        Utils.assertWithAllModes_ES6(
+                "10/absent/20",
+                "var a = [...[10], , ...[20]];\n"
+                        + "a[0] + '/'"
+                        + " + ((1 in a) ? 'present' : 'absent') + '/'"
+                        + " + a[2];\n");
+    }
+
+    // ------------------------------------------------------------------
+    // 3. Error line numbers: if bytecodeSpan is wrong, pcSourceLineStart
+    //    drifts and exceptions report the wrong line.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testErrorLineAfterSparseSpreadIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var a = [...[1], , 2];\n" // line 1 (Icode_SPREAD here)
+                            + "undefinedVar;\n", // line 2 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    2,
+                    e.lineNumber(),
+                    "ReferenceError must be on line 2; "
+                            + "wrong line means bytecodeSpan(Icode_SPREAD) is incorrect");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testErrorLineAfterTwoSparseSpreadIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var base = [1, 2];\n" // line 1
+                            + "var a = [...base, , 9];\n" // line 2 (first spread)
+                            + "var b = [...base, , 8];\n" // line 3 (second spread)
+                            + "var c = a[0] + '/' + b[0];\n" // line 4
+                            + "undefinedVar;\n", // line 5 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    5,
+                    e.lineNumber(),
+                    "ReferenceError must be on line 5 after two sparse array spreads");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testErrorLineWithMixedSpreadTypesIsCorrect() {
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(
+                    cx.initStandardObjects(),
+                    "var obj = {x:1};\n" // line 1
+                            + "var arr = [1,2];\n" // line 2
+                            + "var sparse = [...arr, , 9];\n" // line 3 (array Icode_SPREAD)
+                            + "var merged = {...obj, y:2};\n" // line 4 (object Icode_SPREAD)
+                            + "undefinedVar;\n", // line 5 ← must be reported
+                    "test",
+                    1,
+                    null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    5, e.lineNumber(), "ReferenceError must be on line 5 after mixed spread types");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 4. Correctness after >255 literalIds (regression for the uint16
+    //    skipIndexesId / sourcePositions overflow fixed in the same PR).
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testSpreadInSparseArrayAfter260ObjectLiterals() {
+        // [...[10, 20], , 30] → [10, 20, <hole>, 30]
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k:").append(i).append("};\n");
+        }
+        sb.append("var a = [...[10, 20], , 30];\n");
+        sb.append(
+                "a[0] + '/' + a[1] + '/'"
+                        + " + ((2 in a) ? 'present' : 'absent') + '/'"
+                        + " + a[3];\n");
+        Utils.assertWithAllModes_ES6("10/20/absent/30", sb.toString());
+    }
+
+    @Test
+    public void testErrorLineAfter260LiteralsAndSparseSpread() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k:").append(i).append("};\n");
+        }
+        int errorLine = 262;
+        sb.append("var a = [...[1], , 2];\n"); // line 261
+        sb.append("undefinedVar;\n"); // line 262
+
+        Context cx = Context.enter();
+        try {
+            cx.setLanguageVersion(Context.VERSION_ES6);
+            cx.evaluateString(cx.initStandardObjects(), sb.toString(), "test", 1, null);
+            fail("Expected ReferenceError");
+        } catch (EcmaError e) {
+            assertEquals(
+                    errorLine,
+                    e.lineNumber(),
+                    "ReferenceError must be on line " + errorLine + " even with >255 literalIds");
+        } finally {
+            Context.exit();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // 5. Object-literal spread must be unaffected.
+    // ------------------------------------------------------------------
+
+    @Test
+    public void testObjectLiteralSpreadUnaffected() {
+        Utils.assertWithAllModes_ES6(
+                "1/2/3", "var o = {...{a:1, b:2}, c:3}; o.a + '/' + o.b + '/' + o.c;");
+    }
+
+    @Test
+    public void testObjectLiteralSpreadAfterManyLiterals() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 260; i++) {
+            sb.append("var o").append(i).append(" = {k:").append(i).append("};\n");
+        }
+        sb.append("var r = {...{x:7, y:8}}; r.x + '/' + r.y;\n");
+        Utils.assertWithAllModes_ES6("7/8", sb.toString());
+    }
+}


### PR DESCRIPTION
fix: use uint16 instead of uint8 for array literal skipIndexesId and sourcePositions When a script contains more than 255 object/array literals, the literalIds table grows beyond 255. The skipIndexesId (used for sparse array literals) and sourcePositions (used for spread in sparse arrays) were encoded as uint8, causing an IllegalStateException (Kit.codeBug) when the values exceeded 255.

Changed addUint8 to addUint16 in CodeGenerator.visitArrayLiteral and updated the corresponding reads in Interpreter (DoLiteralNewArray, DoSpread) to use getIndex (uint16) instead of single-byte reads.

adapted from the inital work of Finomosec (pr: #2321)