### PR TITLE
Fix typed array constructor to avoid large test 262 regression.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -520,6 +520,36 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             }
             return v;
         }
+
+        if (ScriptRuntime.isObject(arg0)) {
+            var items = (Scriptable) arg0;
+            Object iteratorProp = ScriptableObject.getProperty(items, SymbolKey.ITERATOR);
+            final Object[] arrayElements;
+            if ((iteratorProp != Scriptable.NOT_FOUND) && !Undefined.isUndefined(iteratorProp)) {
+                final Object iterator = ScriptRuntime.callIterator(items, cx, scope);
+                if (!Undefined.isUndefined(iterator)) {
+                    final ArrayList<Object> elems = new ArrayList<>();
+                    try (IteratorLikeIterable it = new IteratorLikeIterable(cx, scope, iterator)) {
+                        for (Object temp : it) {
+                            elems.add(temp);
+                        }
+                    }
+                    arrayElements = elems.toArray();
+                } else {
+                    arrayElements = ScriptRuntime.getArrayElements(items);
+                }
+            } else {
+                arrayElements = ScriptRuntime.getArrayElements(items);
+            }
+
+            NativeArrayBuffer na =
+                    makeArrayBuffer(cx, scope, arrayElements.length, bytesPerElement);
+            NativeTypedArrayView<?> v = constructable.construct(na, 0, arrayElements.length);
+            for (int i = 0; i < arrayElements.length; i++) {
+                v.js_set(i, arrayElements[i]);
+            }
+            return v;
+        }
         throw ScriptRuntime.constructError("Error", "invalid argument");
     }
 

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -597,12 +597,9 @@ built-ins/Array 241/3081 (7.82%)
     proto-from-ctor-realm-two.js
     proto-from-ctor-realm-zero.js
 
-built-ins/ArrayBuffer 50/221 (22.62%)
+built-ins/ArrayBuffer 47/221 (21.27%)
     isView/arg-is-dataview-subclass-instance.js {unsupported: [class]}
-    isView/arg-is-typedarray.js
-    isView/arg-is-typedarray-buffer.js
     isView/arg-is-typedarray-subclass-instance.js {unsupported: [class]}
-    isView/invoked-as-a-fn.js
     prototype/byteLength/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/detached/this-is-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     prototype/detached/this-is-sharedarraybuffer-resizable.js {unsupported: [SharedArrayBuffer]}
@@ -634,8 +631,7 @@ built-ins/ArrayBuffer 50/221 (22.62%)
     proto-from-ctor-realm.js
     prototype-from-newtarget.js
 
-built-ins/ArrayIteratorPrototype 1/27 (3.7%)
-    next/detach-typedarray-in-progress.js
+built-ins/ArrayIteratorPrototype 0/27 (0.0%)
 
 ~built-ins/AsyncDisposableStack 104/104 (100.0%)
 
@@ -2548,661 +2544,125 @@ built-ins/ThrowTypeError 3/14 (21.43%)
     unique-per-realm-function-proto.js
     unique-per-realm-non-simple.js non-strict
 
-built-ins/TypedArray 667/1438 (46.38%)
+built-ins/TypedArray 131/1438 (9.11%)
     from/iterated-array-changed-by-tonumber.js
     prototype/at/coerced-index-resize.js
-    prototype/at/index-argument-tointeger.js
-    prototype/at/index-non-numeric-argument-tointeger.js
-    prototype/at/index-non-numeric-argument-tointeger-invalid.js
     prototype/at/resizable-buffer.js
-    prototype/at/returns-item.js
-    prototype/at/returns-item-relative-index.js
-    prototype/at/returns-undefined-for-holes-in-sparse-arrays.js
-    prototype/at/returns-undefined-for-out-of-range-index.js
-    prototype/buffer/this-inherits-typedarray.js
-    prototype/byteLength/BigInt/return-bytelength.js
     prototype/byteLength/resizable-buffer-assorted.js
     prototype/byteLength/resized-out-of-bounds-1.js
     prototype/byteLength/resized-out-of-bounds-2.js
-    prototype/byteLength/return-bytelength.js
     prototype/byteOffset/resized-out-of-bounds.js
-    prototype/copyWithin/BigInt/coerced-values-end.js
-    prototype/copyWithin/BigInt/coerced-values-start.js
-    prototype/copyWithin/BigInt/coerced-values-target.js
-    prototype/copyWithin/BigInt/negative-end.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-end.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-start.js
-    prototype/copyWithin/BigInt/negative-out-of-bounds-target.js
-    prototype/copyWithin/BigInt/negative-start.js
-    prototype/copyWithin/BigInt/negative-target.js
-    prototype/copyWithin/BigInt/non-negative-out-of-bounds-end.js
-    prototype/copyWithin/BigInt/non-negative-out-of-bounds-target-and-start.js
-    prototype/copyWithin/BigInt/non-negative-target-and-start.js
-    prototype/copyWithin/BigInt/non-negative-target-start-and-end.js
-    prototype/copyWithin/BigInt/return-this.js
-    prototype/copyWithin/BigInt/undefined-end.js
-    prototype/copyWithin/byteoffset.js
     prototype/copyWithin/coerced-target-start-end-shrink.js
     prototype/copyWithin/coerced-target-start-grow.js
-    prototype/copyWithin/coerced-values-end.js
-    prototype/copyWithin/coerced-values-start.js
-    prototype/copyWithin/coerced-values-target.js
-    prototype/copyWithin/negative-end.js
-    prototype/copyWithin/negative-out-of-bounds-end.js
-    prototype/copyWithin/negative-out-of-bounds-start.js
-    prototype/copyWithin/negative-out-of-bounds-target.js
-    prototype/copyWithin/negative-start.js
-    prototype/copyWithin/negative-target.js
-    prototype/copyWithin/non-negative-out-of-bounds-end.js
-    prototype/copyWithin/non-negative-out-of-bounds-target-and-start.js
-    prototype/copyWithin/non-negative-target-and-start.js
-    prototype/copyWithin/non-negative-target-start-and-end.js
     prototype/copyWithin/resizable-buffer.js
-    prototype/copyWithin/return-this.js
-    prototype/copyWithin/undefined-end.js
-    prototype/entries/BigInt/iter-prototype.js
-    prototype/entries/BigInt/return-itor.js
-    prototype/entries/iter-prototype.js
     prototype/entries/resizable-buffer.js
     prototype/entries/resizable-buffer-grow-mid-iteration.js
     prototype/entries/resizable-buffer-shrink-mid-iteration.js
-    prototype/every/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/every/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/every/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/every/BigInt/callbackfn-not-callable-throws.js
-    prototype/every/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/every/BigInt/callbackfn-returns-abrupt.js
-    prototype/every/BigInt/callbackfn-set-value-during-interaction.js
-    prototype/every/BigInt/callbackfn-this.js
-    prototype/every/BigInt/returns-false-if-any-cb-returns-false.js
-    prototype/every/BigInt/values-are-not-cached.js
-    prototype/every/callbackfn-arguments-with-thisarg.js
-    prototype/every/callbackfn-arguments-without-thisarg.js
-    prototype/every/callbackfn-no-interaction-over-non-integer.js
-    prototype/every/callbackfn-not-callable-throws.js
-    prototype/every/callbackfn-return-does-not-change-instance.js
-    prototype/every/callbackfn-returns-abrupt.js
-    prototype/every/callbackfn-set-value-during-interaction.js
-    prototype/every/callbackfn-this.js
     prototype/every/resizable-buffer.js
     prototype/every/resizable-buffer-grow-mid-iteration.js
     prototype/every/resizable-buffer-shrink-mid-iteration.js
-    prototype/every/returns-false-if-any-cb-returns-false.js
-    prototype/every/values-are-not-cached.js
-    prototype/fill/BigInt/coerced-indexes.js
-    prototype/fill/BigInt/fill-values.js
-    prototype/fill/BigInt/fill-values-conversion-once.js
-    prototype/fill/BigInt/fill-values-custom-start-and-end.js
-    prototype/fill/BigInt/fill-values-non-numeric.js
-    prototype/fill/BigInt/fill-values-non-numeric-throw.js
-    prototype/fill/BigInt/fill-values-relative-end.js
-    prototype/fill/BigInt/fill-values-relative-start.js
-    prototype/fill/BigInt/fill-values-symbol-throws.js
-    prototype/fill/BigInt/return-abrupt-from-set-value.js
-    prototype/fill/BigInt/return-this.js
-    prototype/fill/coerced-indexes.js
     prototype/fill/coerced-value-start-end-resize.js
-    prototype/fill/fill-values.js
-    prototype/fill/fill-values-conversion-once.js
-    prototype/fill/fill-values-conversion-operations-consistent-nan.js
-    prototype/fill/fill-values-custom-start-and-end.js
-    prototype/fill/fill-values-non-numeric.js
-    prototype/fill/fill-values-relative-end.js
-    prototype/fill/fill-values-relative-start.js
-    prototype/fill/fill-values-symbol-throws.js
     prototype/fill/resizable-buffer.js
-    prototype/fill/return-abrupt-from-set-value.js
-    prototype/fill/return-this.js
-    prototype/filter/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/filter/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/filter/BigInt/callbackfn-no-iteration-over-non-integer.js
-    prototype/filter/BigInt/callbackfn-not-callable-throws.js
-    prototype/filter/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/filter/BigInt/callbackfn-returns-abrupt.js
-    prototype/filter/BigInt/callbackfn-set-value-during-iteration.js
-    prototype/filter/BigInt/callbackfn-this.js
-    prototype/filter/BigInt/result-does-not-share-buffer.js
-    prototype/filter/BigInt/result-empty-callbackfn-returns-false.js
-    prototype/filter/BigInt/result-full-callbackfn-returns-true.js
-    prototype/filter/BigInt/speciesctor-get-ctor.js
-    prototype/filter/BigInt/speciesctor-get-ctor-abrupt.js
-    prototype/filter/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/filter/BigInt/speciesctor-get-species.js
-    prototype/filter/BigInt/speciesctor-get-species-abrupt.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/filter/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/filter/BigInt/values-are-not-cached.js
-    prototype/filter/BigInt/values-are-set.js
-    prototype/filter/callbackfn-arguments-with-thisarg.js
-    prototype/filter/callbackfn-arguments-without-thisarg.js
-    prototype/filter/callbackfn-no-iteration-over-non-integer.js
-    prototype/filter/callbackfn-not-callable-throws.js
-    prototype/filter/callbackfn-return-does-not-change-instance.js
-    prototype/filter/callbackfn-returns-abrupt.js
-    prototype/filter/callbackfn-set-value-during-iteration.js
-    prototype/filter/callbackfn-this.js
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
     prototype/filter/resizable-buffer-shrink-mid-iteration.js
-    prototype/filter/result-does-not-share-buffer.js
-    prototype/filter/result-empty-callbackfn-returns-false.js
-    prototype/filter/result-full-callbackfn-returns-true.js
-    prototype/filter/speciesctor-get-ctor.js
-    prototype/filter/speciesctor-get-ctor-abrupt.js
-    prototype/filter/speciesctor-get-ctor-returns-throws.js
-    prototype/filter/speciesctor-get-species.js
-    prototype/filter/speciesctor-get-species-abrupt.js
-    prototype/filter/speciesctor-get-species-custom-ctor.js
-    prototype/filter/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length.js
-    prototype/filter/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/filter/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/filter/speciesctor-get-species-custom-ctor-throws.js
-    prototype/filter/speciesctor-get-species-returns-throws.js
-    prototype/filter/speciesctor-get-species-use-default-ctor.js
-    prototype/filter/values-are-not-cached.js
-    prototype/filter/values-are-set.js
-    prototype/find/BigInt/predicate-call-changes-value.js
-    prototype/find/BigInt/predicate-call-parameters.js
-    prototype/find/BigInt/predicate-call-this-non-strict.js non-strict
-    prototype/find/BigInt/predicate-call-this-strict.js strict
-    prototype/find/BigInt/return-abrupt-from-predicate-call.js
-    prototype/find/BigInt/return-found-value-predicate-result-is-true.js
-    prototype/find/BigInt/return-undefined-if-predicate-returns-false-value.js
-    prototype/find/predicate-call-changes-value.js
-    prototype/find/predicate-call-parameters.js
-    prototype/find/predicate-call-this-non-strict.js non-strict
-    prototype/find/predicate-call-this-strict.js strict
     prototype/find/resizable-buffer.js
     prototype/find/resizable-buffer-grow-mid-iteration.js
     prototype/find/resizable-buffer-shrink-mid-iteration.js
-    prototype/find/return-abrupt-from-predicate-call.js
-    prototype/find/return-found-value-predicate-result-is-true.js
-    prototype/find/return-undefined-if-predicate-returns-false-value.js
-    prototype/findIndex/BigInt/predicate-call-changes-value.js
-    prototype/findIndex/BigInt/predicate-call-parameters.js
-    prototype/findIndex/BigInt/predicate-call-this-non-strict.js non-strict
-    prototype/findIndex/BigInt/predicate-call-this-strict.js strict
-    prototype/findIndex/BigInt/return-abrupt-from-predicate-call.js
-    prototype/findIndex/BigInt/return-index-predicate-result-is-true.js
-    prototype/findIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
-    prototype/findIndex/predicate-call-changes-value.js
-    prototype/findIndex/predicate-call-parameters.js
-    prototype/findIndex/predicate-call-this-non-strict.js non-strict
-    prototype/findIndex/predicate-call-this-strict.js strict
     prototype/findIndex/resizable-buffer.js
     prototype/findIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findIndex/return-abrupt-from-predicate-call.js
-    prototype/findIndex/return-index-predicate-result-is-true.js
-    prototype/findIndex/return-negative-one-if-predicate-returns-false-value.js
-    prototype/findLast/BigInt/predicate-call-changes-value.js
-    prototype/findLast/BigInt/predicate-call-parameters.js
-    prototype/findLast/BigInt/predicate-call-this-non-strict.js non-strict
-    prototype/findLast/BigInt/predicate-call-this-strict.js strict
-    prototype/findLast/BigInt/return-abrupt-from-predicate-call.js
-    prototype/findLast/BigInt/return-found-value-predicate-result-is-true.js
-    prototype/findLast/BigInt/return-undefined-if-predicate-returns-false-value.js
-    prototype/findLast/predicate-call-changes-value.js
-    prototype/findLast/predicate-call-parameters.js
-    prototype/findLast/predicate-call-this-non-strict.js non-strict
-    prototype/findLast/predicate-call-this-strict.js strict
     prototype/findLast/resizable-buffer.js
     prototype/findLast/resizable-buffer-grow-mid-iteration.js
     prototype/findLast/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLast/return-abrupt-from-predicate-call.js
-    prototype/findLast/return-found-value-predicate-result-is-true.js
-    prototype/findLast/return-undefined-if-predicate-returns-false-value.js
-    prototype/findLastIndex/BigInt/predicate-call-changes-value.js
-    prototype/findLastIndex/BigInt/predicate-call-parameters.js
-    prototype/findLastIndex/BigInt/predicate-call-this-non-strict.js non-strict
-    prototype/findLastIndex/BigInt/predicate-call-this-strict.js strict
-    prototype/findLastIndex/BigInt/return-abrupt-from-predicate-call.js
-    prototype/findLastIndex/BigInt/return-index-predicate-result-is-true.js
-    prototype/findLastIndex/BigInt/return-negative-one-if-predicate-returns-false-value.js
-    prototype/findLastIndex/predicate-call-changes-value.js
-    prototype/findLastIndex/predicate-call-parameters.js
-    prototype/findLastIndex/predicate-call-this-non-strict.js non-strict
-    prototype/findLastIndex/predicate-call-this-strict.js strict
     prototype/findLastIndex/resizable-buffer.js
     prototype/findLastIndex/resizable-buffer-grow-mid-iteration.js
     prototype/findLastIndex/resizable-buffer-shrink-mid-iteration.js
-    prototype/findLastIndex/return-abrupt-from-predicate-call.js
-    prototype/findLastIndex/return-index-predicate-result-is-true.js
-    prototype/findLastIndex/return-negative-one-if-predicate-returns-false-value.js
-    prototype/forEach/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/forEach/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/forEach/BigInt/callbackfn-is-not-callable.js
-    prototype/forEach/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/forEach/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/forEach/BigInt/callbackfn-returns-abrupt.js
-    prototype/forEach/BigInt/callbackfn-set-value-during-interaction.js
-    prototype/forEach/BigInt/callbackfn-this.js
-    prototype/forEach/BigInt/returns-undefined.js
-    prototype/forEach/BigInt/values-are-not-cached.js
-    prototype/forEach/callbackfn-arguments-with-thisarg.js
-    prototype/forEach/callbackfn-arguments-without-thisarg.js
-    prototype/forEach/callbackfn-is-not-callable.js
-    prototype/forEach/callbackfn-no-interaction-over-non-integer.js
-    prototype/forEach/callbackfn-return-does-not-change-instance.js
-    prototype/forEach/callbackfn-returns-abrupt.js
-    prototype/forEach/callbackfn-set-value-during-interaction.js
-    prototype/forEach/callbackfn-this.js
     prototype/forEach/resizable-buffer.js
     prototype/forEach/resizable-buffer-grow-mid-iteration.js
     prototype/forEach/resizable-buffer-shrink-mid-iteration.js
-    prototype/forEach/returns-undefined.js
-    prototype/forEach/values-are-not-cached.js
-    prototype/includes/BigInt/fromIndex-equal-or-greater-length-returns-false.js
-    prototype/includes/BigInt/fromIndex-infinity.js
-    prototype/includes/BigInt/fromIndex-minus-zero.js
-    prototype/includes/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/includes/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/includes/BigInt/search-found-returns-true.js
-    prototype/includes/BigInt/search-not-found-returns-false.js
-    prototype/includes/BigInt/tointeger-fromindex.js
     prototype/includes/coerced-searchelement-fromindex-resize.js
-    prototype/includes/fromIndex-equal-or-greater-length-returns-false.js
-    prototype/includes/fromIndex-infinity.js
-    prototype/includes/fromIndex-minus-zero.js
     prototype/includes/resizable-buffer.js
     prototype/includes/resizable-buffer-special-float-values.js
-    prototype/includes/return-abrupt-tointeger-fromindex.js
-    prototype/includes/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/includes/samevaluezero.js
-    prototype/includes/search-found-returns-true.js
-    prototype/includes/search-not-found-returns-false.js
-    prototype/includes/searchelement-not-integer.js
-    prototype/includes/tointeger-fromindex.js
-    prototype/indexOf/BigInt/fromIndex-equal-or-greater-length-returns-minus-one.js
-    prototype/indexOf/BigInt/fromIndex-infinity.js
-    prototype/indexOf/BigInt/fromIndex-minus-zero.js
-    prototype/indexOf/BigInt/no-arg.js
-    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/indexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/indexOf/BigInt/search-found-returns-index.js
-    prototype/indexOf/BigInt/search-not-found-returns-minus-one.js
-    prototype/indexOf/BigInt/tointeger-fromindex.js
     prototype/indexOf/coerced-searchelement-fromindex-grow.js
     prototype/indexOf/coerced-searchelement-fromindex-shrink.js
-    prototype/indexOf/fromIndex-equal-or-greater-length-returns-minus-one.js
-    prototype/indexOf/fromIndex-infinity.js
-    prototype/indexOf/fromIndex-minus-zero.js
-    prototype/indexOf/no-arg.js
     prototype/indexOf/resizable-buffer.js
     prototype/indexOf/resizable-buffer-special-float-values.js
-    prototype/indexOf/return-abrupt-tointeger-fromindex.js
-    prototype/indexOf/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/indexOf/search-found-returns-index.js
-    prototype/indexOf/search-not-found-returns-minus-one.js
-    prototype/indexOf/strict-comparison.js
-    prototype/indexOf/tointeger-fromindex.js
-    prototype/join/BigInt/custom-separator-result-from-tostring-on-each-simple-value.js
-    prototype/join/BigInt/result-from-tostring-on-each-simple-value.js
     prototype/join/coerced-separator-grow.js
     prototype/join/coerced-separator-shrink.js
-    prototype/join/custom-separator-result-from-tostring-on-each-simple-value.js
     prototype/join/resizable-buffer.js
-    prototype/join/result-from-tostring-on-each-simple-value.js
-    prototype/keys/BigInt/iter-prototype.js
-    prototype/keys/iter-prototype.js
     prototype/keys/resizable-buffer.js
     prototype/keys/resizable-buffer-grow-mid-iteration.js
     prototype/keys/resizable-buffer-shrink-mid-iteration.js
-    prototype/lastIndexOf/BigInt/fromIndex-infinity.js
-    prototype/lastIndexOf/BigInt/fromIndex-minus-zero.js
-    prototype/lastIndexOf/BigInt/no-arg.js
-    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex.js
-    prototype/lastIndexOf/BigInt/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/lastIndexOf/BigInt/search-found-returns-index.js
-    prototype/lastIndexOf/BigInt/search-not-found-returns-minus-one.js
-    prototype/lastIndexOf/BigInt/tointeger-fromindex.js
     prototype/lastIndexOf/coerced-position-grow.js
     prototype/lastIndexOf/coerced-position-shrink.js
-    prototype/lastIndexOf/fromIndex-infinity.js
-    prototype/lastIndexOf/fromIndex-minus-zero.js
-    prototype/lastIndexOf/no-arg.js
     prototype/lastIndexOf/resizable-buffer.js
     prototype/lastIndexOf/resizable-buffer-special-float-values.js
-    prototype/lastIndexOf/return-abrupt-tointeger-fromindex.js
-    prototype/lastIndexOf/return-abrupt-tointeger-fromindex-symbol.js
-    prototype/lastIndexOf/search-found-returns-index.js
-    prototype/lastIndexOf/search-not-found-returns-minus-one.js
-    prototype/lastIndexOf/strict-comparison.js
-    prototype/lastIndexOf/tointeger-fromindex.js
-    prototype/length/BigInt/return-length.js
     prototype/length/resizable-buffer-assorted.js
     prototype/length/resized-out-of-bounds-1.js
     prototype/length/resized-out-of-bounds-2.js
-    prototype/length/return-length.js
-    prototype/map/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/map/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/map/BigInt/callbackfn-is-not-callable.js
-    prototype/map/BigInt/callbackfn-no-interaction-over-non-integer-properties.js
-    prototype/map/BigInt/callbackfn-return-affects-returned-object.js
-    prototype/map/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/map/BigInt/callbackfn-return-does-not-copy-non-integer-properties.js
-    prototype/map/BigInt/callbackfn-returns-abrupt.js
-    prototype/map/BigInt/callbackfn-set-value-during-interaction.js
-    prototype/map/BigInt/callbackfn-this.js
-    prototype/map/BigInt/return-new-typedarray-from-empty-length.js
-    prototype/map/BigInt/return-new-typedarray-from-positive-length.js
-    prototype/map/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/map/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/map/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/map/BigInt/values-are-not-cached.js
-    prototype/map/callbackfn-arguments-with-thisarg.js
-    prototype/map/callbackfn-arguments-without-thisarg.js
-    prototype/map/callbackfn-is-not-callable.js
-    prototype/map/callbackfn-no-interaction-over-non-integer-properties.js
-    prototype/map/callbackfn-return-affects-returned-object.js
-    prototype/map/callbackfn-return-does-not-change-instance.js
-    prototype/map/callbackfn-return-does-not-copy-non-integer-properties.js
-    prototype/map/callbackfn-returns-abrupt.js
-    prototype/map/callbackfn-set-value-during-interaction.js
-    prototype/map/callbackfn-this.js
     prototype/map/resizable-buffer.js
     prototype/map/resizable-buffer-grow-mid-iteration.js
     prototype/map/resizable-buffer-shrink-mid-iteration.js
-    prototype/map/return-new-typedarray-from-empty-length.js
-    prototype/map/return-new-typedarray-from-positive-length.js
-    prototype/map/speciesctor-get-ctor-returns-throws.js
-    prototype/map/speciesctor-get-species-custom-ctor.js
-    prototype/map/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/map/speciesctor-get-species-custom-ctor-length.js
-    prototype/map/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/map/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/map/speciesctor-get-species-custom-ctor-throws.js
-    prototype/map/speciesctor-get-species-returns-throws.js
-    prototype/map/speciesctor-get-species-use-default-ctor.js
     prototype/map/speciesctor-resizable-buffer-grow.js
     prototype/map/speciesctor-resizable-buffer-shrink.js
-    prototype/map/values-are-not-cached.js
-    prototype/reduce/BigInt/callbackfn-arguments-custom-accumulator.js
-    prototype/reduce/BigInt/callbackfn-arguments-default-accumulator.js
-    prototype/reduce/BigInt/callbackfn-is-not-callable-throws.js
-    prototype/reduce/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduce/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/reduce/BigInt/callbackfn-returns-abrupt.js
-    prototype/reduce/BigInt/callbackfn-set-value-during-iteration.js
-    prototype/reduce/BigInt/callbackfn-this.js
-    prototype/reduce/BigInt/result-is-last-callbackfn-return.js
-    prototype/reduce/BigInt/result-of-any-type.js
-    prototype/reduce/BigInt/return-first-value-without-callbackfn.js
-    prototype/reduce/BigInt/values-are-not-cached.js
-    prototype/reduce/callbackfn-arguments-custom-accumulator.js
-    prototype/reduce/callbackfn-arguments-default-accumulator.js
-    prototype/reduce/callbackfn-is-not-callable-throws.js
-    prototype/reduce/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduce/callbackfn-return-does-not-change-instance.js
-    prototype/reduce/callbackfn-returns-abrupt.js
-    prototype/reduce/callbackfn-set-value-during-iteration.js
-    prototype/reduce/callbackfn-this.js
     prototype/reduce/resizable-buffer.js
     prototype/reduce/resizable-buffer-grow-mid-iteration.js
     prototype/reduce/resizable-buffer-shrink-mid-iteration.js
-    prototype/reduce/result-is-last-callbackfn-return.js
-    prototype/reduce/result-of-any-type.js
-    prototype/reduce/return-first-value-without-callbackfn.js
-    prototype/reduce/values-are-not-cached.js
-    prototype/reduceRight/BigInt/callbackfn-arguments-custom-accumulator.js
-    prototype/reduceRight/BigInt/callbackfn-arguments-default-accumulator.js
-    prototype/reduceRight/BigInt/callbackfn-is-not-callable-throws.js
-    prototype/reduceRight/BigInt/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduceRight/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/reduceRight/BigInt/callbackfn-returns-abrupt.js
-    prototype/reduceRight/BigInt/callbackfn-set-value-during-iteration.js
-    prototype/reduceRight/BigInt/callbackfn-this.js
-    prototype/reduceRight/BigInt/result-is-last-callbackfn-return.js
-    prototype/reduceRight/BigInt/result-of-any-type.js
-    prototype/reduceRight/BigInt/return-first-value-without-callbackfn.js
-    prototype/reduceRight/BigInt/values-are-not-cached.js
-    prototype/reduceRight/callbackfn-arguments-custom-accumulator.js
-    prototype/reduceRight/callbackfn-arguments-default-accumulator.js
-    prototype/reduceRight/callbackfn-is-not-callable-throws.js
-    prototype/reduceRight/callbackfn-no-iteration-over-non-integer-properties.js
-    prototype/reduceRight/callbackfn-return-does-not-change-instance.js
-    prototype/reduceRight/callbackfn-returns-abrupt.js
-    prototype/reduceRight/callbackfn-set-value-during-iteration.js
-    prototype/reduceRight/callbackfn-this.js
     prototype/reduceRight/resizable-buffer.js
     prototype/reduceRight/resizable-buffer-grow-mid-iteration.js
     prototype/reduceRight/resizable-buffer-shrink-mid-iteration.js
-    prototype/reduceRight/result-is-last-callbackfn-return.js
-    prototype/reduceRight/result-of-any-type.js
-    prototype/reduceRight/return-first-value-without-callbackfn.js
-    prototype/reduceRight/values-are-not-cached.js
-    prototype/reverse/BigInt/preserves-non-numeric-properties.js
-    prototype/reverse/preserves-non-numeric-properties.js
     prototype/reverse/resizable-buffer.js
-    prototype/set/BigInt/array-arg-negative-integer-offset-throws.js
-    prototype/set/BigInt/array-arg-offset-tointeger.js
     prototype/set/BigInt/array-arg-primitive-toobject.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-length.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-length-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-tointeger-offset-symbol.js
-    prototype/set/BigInt/array-arg-return-abrupt-from-toobject-offset.js
-    prototype/set/BigInt/array-arg-set-values.js
-    prototype/set/BigInt/array-arg-src-tonumber-value-type-conversions.js
     prototype/set/BigInt/bigint-tobiguint64.js
-    prototype/set/BigInt/boolean-tobigint.js
-    prototype/set/BigInt/null-tobigint.js
     prototype/set/BigInt/number-tobigint.js
-    prototype/set/BigInt/src-typedarray-big.js
-    prototype/set/BigInt/src-typedarray-not-big-throws.js
-    prototype/set/BigInt/string-nan-tobigint.js
-    prototype/set/BigInt/string-tobigint.js
-    prototype/set/BigInt/symbol-tobigint.js
-    prototype/set/BigInt/typedarray-arg-offset-tointeger.js
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type.js
     prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type.js
     prototype/set/BigInt/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type.js
     prototype/set/BigInt/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/BigInt/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    prototype/set/BigInt/undefined-tobigint.js
-    prototype/set/array-arg-negative-integer-offset-throws.js
-    prototype/set/array-arg-offset-tointeger.js
     prototype/set/array-arg-primitive-toobject.js
-    prototype/set/array-arg-return-abrupt-from-src-length.js
-    prototype/set/array-arg-return-abrupt-from-src-length-symbol.js
-    prototype/set/array-arg-return-abrupt-from-src-tonumber-value.js
-    prototype/set/array-arg-return-abrupt-from-src-tonumber-value-symbol.js
-    prototype/set/array-arg-return-abrupt-from-tointeger-offset-symbol.js
-    prototype/set/array-arg-return-abrupt-from-toobject-offset.js
-    prototype/set/array-arg-set-values.js
-    prototype/set/array-arg-src-tonumber-value-type-conversions.js
-    prototype/set/src-typedarray-big-throws.js
     prototype/set/target-grow-mid-iteration.js
     prototype/set/target-grow-source-length-getter.js
     prototype/set/target-shrink-mid-iteration.js
     prototype/set/target-shrink-source-length-getter.js
     prototype/set/this-backed-by-resizable-buffer.js
-    prototype/set/typedarray-arg-offset-tointeger.js
-    prototype/set/typedarray-arg-set-values-diff-buffer-other-type.js
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-conversions-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-diff-buffer-other-type-sab.js {unsupported: [SharedArrayBuffer]}
-    prototype/set/typedarray-arg-set-values-diff-buffer-same-type.js
     prototype/set/typedarray-arg-set-values-diff-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-set-values-same-buffer-other-type.js
-    prototype/set/typedarray-arg-set-values-same-buffer-same-type.js
     prototype/set/typedarray-arg-set-values-same-buffer-same-type-sab.js {unsupported: [SharedArrayBuffer]}
     prototype/set/typedarray-arg-src-backed-by-resizable-buffer.js
-    prototype/set/typedarray-arg-src-range-greather-than-target-throws-rangeerror.js
-    prototype/slice/BigInt/infinity.js
-    prototype/slice/BigInt/minus-zero.js
-    prototype/slice/BigInt/result-does-not-copy-ordinary-properties.js
-    prototype/slice/BigInt/results-with-different-length.js
-    prototype/slice/BigInt/results-with-empty-length.js
-    prototype/slice/BigInt/results-with-same-length.js
-    prototype/slice/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/slice/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/slice/BigInt/tointeger-end.js
-    prototype/slice/BigInt/tointeger-start.js
     prototype/slice/coerced-start-end-grow.js
     prototype/slice/coerced-start-end-shrink.js
-    prototype/slice/infinity.js
-    prototype/slice/minus-zero.js
     prototype/slice/resizable-buffer.js
-    prototype/slice/result-does-not-copy-ordinary-properties.js
-    prototype/slice/results-with-different-length.js
-    prototype/slice/results-with-empty-length.js
-    prototype/slice/results-with-same-length.js
-    prototype/slice/speciesctor-get-ctor-returns-throws.js
-    prototype/slice/speciesctor-get-species-custom-ctor.js
-    prototype/slice/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length.js
-    prototype/slice/speciesctor-get-species-custom-ctor-length-throws.js
-    prototype/slice/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/slice/speciesctor-get-species-custom-ctor-throws.js
-    prototype/slice/speciesctor-get-species-returns-throws.js
-    prototype/slice/speciesctor-get-species-use-default-ctor.js
     prototype/slice/speciesctor-resize.js
-    prototype/slice/tointeger-end.js
-    prototype/slice/tointeger-start.js
-    prototype/some/BigInt/callbackfn-arguments-with-thisarg.js
-    prototype/some/BigInt/callbackfn-arguments-without-thisarg.js
-    prototype/some/BigInt/callbackfn-no-interaction-over-non-integer.js
-    prototype/some/BigInt/callbackfn-not-callable-throws.js
-    prototype/some/BigInt/callbackfn-return-does-not-change-instance.js
-    prototype/some/BigInt/callbackfn-returns-abrupt.js
-    prototype/some/BigInt/callbackfn-set-value-during-interaction.js
-    prototype/some/BigInt/callbackfn-this.js
-    prototype/some/BigInt/returns-false-if-every-cb-returns-false.js
-    prototype/some/BigInt/returns-true-if-any-cb-returns-true.js
-    prototype/some/BigInt/values-are-not-cached.js
-    prototype/some/callbackfn-arguments-with-thisarg.js
-    prototype/some/callbackfn-arguments-without-thisarg.js
-    prototype/some/callbackfn-no-interaction-over-non-integer.js
-    prototype/some/callbackfn-not-callable-throws.js
-    prototype/some/callbackfn-return-does-not-change-instance.js
-    prototype/some/callbackfn-returns-abrupt.js
-    prototype/some/callbackfn-set-value-during-interaction.js
-    prototype/some/callbackfn-this.js
     prototype/some/resizable-buffer.js
     prototype/some/resizable-buffer-grow-mid-iteration.js
     prototype/some/resizable-buffer-shrink-mid-iteration.js
-    prototype/some/returns-false-if-every-cb-returns-false.js
-    prototype/some/returns-true-if-any-cb-returns-true.js
-    prototype/some/values-are-not-cached.js
-    prototype/sort/BigInt/comparefn-call-throws.js
-    prototype/sort/BigInt/comparefn-calls.js
-    prototype/sort/BigInt/comparefn-is-undefined.js
-    prototype/sort/BigInt/comparefn-nonfunction-call-throws.js
-    prototype/sort/BigInt/return-same-instance.js
-    prototype/sort/BigInt/sortcompare-with-no-tostring.js
-    prototype/sort/BigInt/sorted-values.js
-    prototype/sort/comparefn-call-throws.js
-    prototype/sort/comparefn-calls.js
     prototype/sort/comparefn-grow.js
-    prototype/sort/comparefn-is-undefined.js
-    prototype/sort/comparefn-nonfunction-call-throws.js
     prototype/sort/comparefn-resizable-buffer.js
     prototype/sort/comparefn-shrink.js
     prototype/sort/resizable-buffer-default-comparator.js
-    prototype/sort/return-same-instance.js
-    prototype/sort/sortcompare-with-no-tostring.js
-    prototype/sort/sorted-values.js
-    prototype/sort/sorted-values-nan.js
     prototype/subarray/BigInt/infinity.js
-    prototype/subarray/BigInt/minus-zero.js
-    prototype/subarray/BigInt/result-does-not-copy-ordinary-properties.js
-    prototype/subarray/BigInt/result-is-new-instance-from-same-ctor.js
-    prototype/subarray/BigInt/result-is-new-instance-with-shared-buffer.js
-    prototype/subarray/BigInt/results-with-different-length.js
-    prototype/subarray/BigInt/results-with-empty-length.js
-    prototype/subarray/BigInt/results-with-same-length.js
-    prototype/subarray/BigInt/speciesctor-get-ctor-returns-throws.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/subarray/BigInt/speciesctor-get-species-custom-ctor-throws.js
-    prototype/subarray/BigInt/speciesctor-get-species-returns-throws.js
-    prototype/subarray/BigInt/speciesctor-get-species-use-default-ctor.js
-    prototype/subarray/BigInt/tointeger-begin.js
-    prototype/subarray/BigInt/tointeger-end.js
     prototype/subarray/coerced-begin-end-grow.js
     prototype/subarray/coerced-begin-end-shrink.js
     prototype/subarray/infinity.js
-    prototype/subarray/minus-zero.js
     prototype/subarray/resizable-buffer.js
-    prototype/subarray/result-does-not-copy-ordinary-properties.js
-    prototype/subarray/result-is-new-instance-from-same-ctor.js
-    prototype/subarray/result-is-new-instance-with-shared-buffer.js
-    prototype/subarray/results-with-different-length.js
-    prototype/subarray/results-with-empty-length.js
-    prototype/subarray/results-with-same-length.js
-    prototype/subarray/speciesctor-get-ctor-returns-throws.js
-    prototype/subarray/speciesctor-get-species-custom-ctor.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-invocation.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-returns-another-instance.js
-    prototype/subarray/speciesctor-get-species-custom-ctor-throws.js
-    prototype/subarray/speciesctor-get-species-returns-throws.js
-    prototype/subarray/speciesctor-get-species-use-default-ctor.js
-    prototype/subarray/tointeger-begin.js
-    prototype/subarray/tointeger-end.js
     prototype/Symbol.toStringTag/BigInt/name.js
     prototype/Symbol.toStringTag/name.js
-    prototype/toLocaleString/BigInt/calls-tolocalestring-from-each-value.js
-    prototype/toLocaleString/BigInt/calls-valueof-from-each-value.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tolocalestring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-tostring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-firstelement-valueof.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tolocalestring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-tostring.js
-    prototype/toLocaleString/BigInt/return-abrupt-from-nextelement-valueof.js
-    prototype/toLocaleString/BigInt/return-result.js
     prototype/toLocaleString/resizable-buffer.js
     prototype/toLocaleString/user-provided-tolocalestring-grow.js
     prototype/toLocaleString/user-provided-tolocalestring-shrink.js
-    prototype/toReversed/immutable.js
     prototype/toReversed/this-value-invalid.js
-    prototype/toSorted/comparefn-not-a-function.js
-    prototype/toSorted/comparefn-stop-after-error.js
-    prototype/toSorted/immutable.js
     prototype/toSorted/this-value-invalid.js
-    prototype/values/BigInt/iter-prototype.js
-    prototype/values/BigInt/return-itor.js
-    prototype/values/iter-prototype.js
     prototype/values/make-out-of-bounds-after-exhausted.js
     prototype/values/resizable-buffer.js
     prototype/values/resizable-buffer-grow-mid-iteration.js
     prototype/values/resizable-buffer-shrink-mid-iteration.js
     prototype/with/BigInt/early-type-coercion-bigint.js
-    prototype/with/early-type-coercion.js
-    prototype/with/immutable.js
-    prototype/with/index-bigger-or-eq-than-length.js
     prototype/with/index-casted-to-number.js
     prototype/with/index-negative.js
-    prototype/with/index-smaller-than-minus-length.js
-    prototype/with/index-throw-completion.js
     prototype/with/index-validated-against-current-length.js
-    prototype/with/negative-fractional-index-truncated-to-zero.js
-    prototype/with/order-of-evaluation.js
     prototype/with/valid-typedarray-index-checked-after-coercions.js
-    prototype/with/value-throw-completion.js
     prototype/resizable-and-fixed-have-same-prototype.js
     prototype/Symbol.iterator.js
     prototype/toString.js
@@ -3214,7 +2674,7 @@ built-ins/TypedArray 667/1438 (46.38%)
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 266/738 (36.04%)
+built-ins/TypedArrayConstructors 172/738 (23.31%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -3244,53 +2704,24 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     ctors-bigint/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/length-arg/custom-proto-access-throws.js
-    ctors-bigint/length-arg/init-zeros.js
     ctors-bigint/length-arg/is-infinity-throws-rangeerror.js
     ctors-bigint/length-arg/is-negative-integer-throws-rangeerror.js
     ctors-bigint/length-arg/is-symbol-throws.js
-    ctors-bigint/length-arg/new-instance-extensibility.js
     ctors-bigint/length-arg/proto-from-ctor-realm.js
-    ctors-bigint/length-arg/returns-object.js
     ctors-bigint/length-arg/toindex-length.js
     ctors-bigint/length-arg/use-custom-proto-if-object.js
     ctors-bigint/no-args/custom-proto-access-throws.js
     ctors-bigint/no-args/proto-from-ctor-realm.js
     ctors-bigint/no-args/use-custom-proto-if-object.js
-    ctors-bigint/object-arg/as-array-returns.js
-    ctors-bigint/object-arg/as-generator-iterable-returns.js
     ctors-bigint/object-arg/bigint-tobiguint64.js
-    ctors-bigint/object-arg/boolean-tobigint.js
     ctors-bigint/object-arg/custom-proto-access-throws.js
-    ctors-bigint/object-arg/iterating-throws.js
-    ctors-bigint/object-arg/iterator-not-callable-throws.js
-    ctors-bigint/object-arg/iterator-throws.js
     ctors-bigint/object-arg/length-excessive-throws.js
-    ctors-bigint/object-arg/length-is-symbol-throws.js
-    ctors-bigint/object-arg/length-throws.js
-    ctors-bigint/object-arg/new-instance-extensibility.js
-    ctors-bigint/object-arg/null-tobigint.js
     ctors-bigint/object-arg/number-tobigint.js
     ctors-bigint/object-arg/proto-from-ctor-realm.js
-    ctors-bigint/object-arg/string-nan-tobigint.js
-    ctors-bigint/object-arg/string-tobigint.js
-    ctors-bigint/object-arg/symbol-tobigint.js
-    ctors-bigint/object-arg/throws-from-property.js
-    ctors-bigint/object-arg/throws-setting-obj-to-primitive.js
-    ctors-bigint/object-arg/throws-setting-obj-to-primitive-typeerror.js
-    ctors-bigint/object-arg/throws-setting-obj-tostring.js
-    ctors-bigint/object-arg/throws-setting-obj-valueof.js
-    ctors-bigint/object-arg/throws-setting-obj-valueof-typeerror.js
-    ctors-bigint/object-arg/throws-setting-property.js
-    ctors-bigint/object-arg/throws-setting-symbol-property.js
     ctors-bigint/object-arg/undefined-tobigint.js
     ctors-bigint/object-arg/use-custom-proto-if-object.js
     ctors-bigint/typedarray-arg/custom-proto-access-throws.js
     ctors-bigint/typedarray-arg/proto-from-ctor-realm.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-null.js
-    ctors-bigint/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
-    ctors-bigint/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
-    ctors-bigint/typedarray-arg/src-typedarray-not-big-throws.js
-    ctors-bigint/typedarray-arg/undefined-newtarget-throws.js
     ctors/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -3321,57 +2752,29 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     ctors/buffer-arg/use-custom-proto-if-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/buffer-arg/use-default-proto-if-custom-proto-is-not-object-sab.js {unsupported: [SharedArrayBuffer]}
     ctors/length-arg/custom-proto-access-throws.js
-    ctors/length-arg/init-zeros.js
     ctors/length-arg/is-infinity-throws-rangeerror.js
     ctors/length-arg/is-negative-integer-throws-rangeerror.js
     ctors/length-arg/is-symbol-throws.js
-    ctors/length-arg/new-instance-extensibility.js
     ctors/length-arg/proto-from-ctor-realm.js
-    ctors/length-arg/returns-object.js
     ctors/length-arg/toindex-length.js
     ctors/length-arg/use-custom-proto-if-object.js
     ctors/no-args/custom-proto-access-throws.js
     ctors/no-args/proto-from-ctor-realm.js
     ctors/no-args/use-custom-proto-if-object.js
-    ctors/object-arg/as-generator-iterable-returns.js
     ctors/object-arg/custom-proto-access-throws.js
     ctors/object-arg/iterated-array-changed-by-tonumber.js
     ctors/object-arg/iterated-array-with-modified-array-iterator.js
-    ctors/object-arg/iterating-throws.js
     ctors/object-arg/iterator-is-null-as-array-like.js
-    ctors/object-arg/iterator-not-callable-throws.js
-    ctors/object-arg/iterator-throws.js
     ctors/object-arg/length-excessive-throws.js
-    ctors/object-arg/length-is-symbol-throws.js
-    ctors/object-arg/length-throws.js
-    ctors/object-arg/new-instance-extensibility.js
     ctors/object-arg/proto-from-ctor-realm.js
-    ctors/object-arg/returns.js
-    ctors/object-arg/throws-from-property.js
-    ctors/object-arg/throws-setting-obj-to-primitive.js
-    ctors/object-arg/throws-setting-obj-to-primitive-typeerror.js
-    ctors/object-arg/throws-setting-obj-tostring.js
-    ctors/object-arg/throws-setting-obj-valueof.js
-    ctors/object-arg/throws-setting-obj-valueof-typeerror.js
-    ctors/object-arg/throws-setting-property.js
-    ctors/object-arg/throws-setting-symbol-property.js
     ctors/object-arg/use-custom-proto-if-object.js
     ctors/typedarray-arg/custom-proto-access-throws.js
     ctors/typedarray-arg/proto-from-ctor-realm.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-null.js
-    ctors/typedarray-arg/same-ctor-buffer-ctor-species-undefined.js
-    ctors/typedarray-arg/same-ctor-returns-new-cloned-typedarray.js
-    ctors/typedarray-arg/src-typedarray-big-throws.js
     ctors/typedarray-arg/src-typedarray-resizable-buffer.js
     ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
-    ctors/typedarray-arg/undefined-newtarget-throws.js
     ctors/typedarray-arg/use-custom-proto-if-object.js
     ctors/no-species.js
-    from/BigInt/custom-ctor-returns-other-instance.js
-    from/BigInt/custom-ctor-returns-smaller-instance-throws.js
     from/custom-ctor-returns-immutable-arraybuffer.js
-    from/custom-ctor-returns-other-instance.js
-    from/custom-ctor-returns-smaller-instance-throws.js
     from/nan-conversion.js
     from/new-instance-from-sparse-array.js
     internals/DefineOwnProperty/BigInt/key-is-not-canonical-index.js
@@ -3381,7 +2784,6 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-enumerable-throws.js
     internals/DefineOwnProperty/BigInt/key-is-numericindex-desc-not-writable-throws.js
     internals/DefineOwnProperty/BigInt/non-extensible-redefine-key.js
-    internals/DefineOwnProperty/conversion-operation-consistent-nan.js
     internals/DefineOwnProperty/key-is-not-canonical-index.js
     internals/DefineOwnProperty/key-is-numericindex.js
     internals/DefineOwnProperty/key-is-numericindex-accessor-desc-throws.js
@@ -3389,22 +2791,16 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     internals/DefineOwnProperty/key-is-numericindex-desc-not-enumerable-throws.js
     internals/DefineOwnProperty/key-is-numericindex-desc-not-writable-throws.js
     internals/DefineOwnProperty/non-extensible-redefine-key.js
-    internals/Delete/BigInt/indexed-value-ab-non-strict.js non-strict
     internals/Delete/BigInt/indexed-value-ab-strict.js strict
     internals/Delete/BigInt/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/BigInt/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/BigInt/key-is-not-minus-zero-strict.js strict
-    internals/Delete/BigInt/key-is-out-of-bounds-non-strict.js non-strict
     internals/Delete/BigInt/key-is-out-of-bounds-strict.js strict
-    internals/Delete/BigInt/key-is-symbol.js
-    internals/Delete/indexed-value-ab-non-strict.js non-strict
     internals/Delete/indexed-value-ab-strict.js strict
     internals/Delete/indexed-value-sab-non-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/indexed-value-sab-strict.js {unsupported: [SharedArrayBuffer]}
     internals/Delete/key-is-not-minus-zero-strict.js strict
-    internals/Delete/key-is-out-of-bounds-non-strict.js non-strict
     internals/Delete/key-is-out-of-bounds-strict.js strict
-    internals/Delete/key-is-symbol.js
     internals/Get/BigInt/indexed-value-sab.js {unsupported: [SharedArrayBuffer]}
     internals/Get/BigInt/key-is-not-integer.js
     internals/Get/BigInt/key-is-not-minus-zero.js
@@ -3414,24 +2810,12 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     internals/Get/key-is-not-minus-zero.js
     internals/Get/key-is-out-of-bounds.js
     internals/GetOwnProperty/BigInt/index-prop-desc.js
-    internals/GetOwnProperty/BigInt/key-is-minus-zero.js
-    internals/GetOwnProperty/BigInt/key-is-not-integer.js
-    internals/GetOwnProperty/BigInt/key-is-out-of-bounds.js
     internals/GetOwnProperty/index-prop-desc.js
-    internals/GetOwnProperty/key-is-minus-zero.js
-    internals/GetOwnProperty/key-is-not-integer.js
-    internals/GetOwnProperty/key-is-out-of-bounds.js
     internals/HasProperty/BigInt/abrupt-from-ordinary-has-parent-hasproperty.js
-    internals/HasProperty/BigInt/indexed-value.js
-    internals/HasProperty/BigInt/inherited-property.js
-    internals/HasProperty/BigInt/key-is-greater-than-last-index.js
     internals/HasProperty/BigInt/key-is-lower-than-zero.js
     internals/HasProperty/BigInt/key-is-minus-zero.js
     internals/HasProperty/BigInt/key-is-not-integer.js
     internals/HasProperty/abrupt-from-ordinary-has-parent-hasproperty.js
-    internals/HasProperty/indexed-value.js
-    internals/HasProperty/inherited-property.js
-    internals/HasProperty/key-is-greater-than-last-index.js
     internals/HasProperty/key-is-lower-than-zero.js
     internals/HasProperty/key-is-minus-zero.js
     internals/HasProperty/key-is-not-integer.js
@@ -3444,45 +2828,27 @@ built-ins/TypedArrayConstructors 266/738 (36.04%)
     internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-auto.js
     internals/OwnPropertyKeys/integer-indexes-resizable-array-buffer-fixed.js
     internals/Set/BigInt/bigint-tobiguint64.js
-    internals/Set/BigInt/boolean-tobigint.js
     internals/Set/BigInt/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/BigInt/key-is-canonical-invalid-index-reflect-set.js
-    internals/Set/BigInt/key-is-minus-zero.js
     internals/Set/BigInt/key-is-not-canonical-index.js
-    internals/Set/BigInt/key-is-not-integer.js
     internals/Set/BigInt/key-is-not-numeric-index.js
-    internals/Set/BigInt/key-is-out-of-bounds.js
     internals/Set/BigInt/key-is-symbol.js
     internals/Set/BigInt/key-is-valid-index-prototype-chain-set.js
     internals/Set/BigInt/key-is-valid-index-reflect-set.js
-    internals/Set/BigInt/null-tobigint.js
     internals/Set/BigInt/number-tobigint.js
-    internals/Set/BigInt/string-nan-tobigint.js
-    internals/Set/BigInt/string-tobigint.js
-    internals/Set/BigInt/symbol-tobigint.js
     internals/Set/BigInt/tonumber-value-throws.js
-    internals/Set/BigInt/undefined-tobigint.js
-    internals/Set/bigint-tonumber.js
-    internals/Set/conversion-operation-consistent-nan.js
     internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/key-is-canonical-invalid-index-reflect-set.js
-    internals/Set/key-is-minus-zero.js
     internals/Set/key-is-not-canonical-index.js
-    internals/Set/key-is-not-integer.js
     internals/Set/key-is-not-numeric-index.js
-    internals/Set/key-is-out-of-bounds.js
     internals/Set/key-is-out-of-bounds-receiver-is-not-object.js
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js
     internals/Set/tonumber-value-throws.js
-    of/BigInt/custom-ctor-returns-other-instance.js
-    of/BigInt/custom-ctor-returns-smaller-instance-throws.js
     of/custom-ctor-returns-immutable-arraybuffer.js
-    of/custom-ctor-returns-other-instance.js
-    of/custom-ctor-returns-smaller-instance-throws.js
 
-built-ins/Uint8Array 63/70 (90.0%)
+built-ins/Uint8Array 62/70 (88.57%)
     fromBase64/alphabet.js
     fromBase64/descriptor.js
     fromBase64/ignores-receiver.js
@@ -3544,7 +2910,6 @@ built-ins/Uint8Array 63/70 (90.0%)
     prototype/toHex/length.js
     prototype/toHex/name.js
     prototype/toHex/nonconstructor.js
-    prototype/toHex/receiver-not-uint8array.js
     prototype/toHex/results.js
 
 built-ins/WeakMap 40/141 (28.37%)


### PR DESCRIPTION
The update to 262 meant we were exercising the typed array constructor more thoroughly in many tests, and failing. This isn't a perfect fix (I think something better can be done once everything is converted over to descriptors and we can easily check for known iterator methods) but this will do for now.