### PR TITLE
Reflect and Proxy get() improvements

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -387,7 +387,7 @@ class NativeProxy extends ScriptableObject {
 
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
-            Object trapResult = callTrap(trap, new Object[] {target, name, this});
+            Object trapResult = callTrap(trap, new Object[] {target, name, start});
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
             if (targetDesc != null && targetDesc.isConfigurable(false)) {
@@ -443,7 +443,7 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
             Object trapResult =
-                    callTrap(trap, new Object[] {target, ScriptRuntime.toString(index), this});
+                    callTrap(trap, new Object[] {target, ScriptRuntime.toString(index), start});
 
             DescriptorInfo targetDesc =
                     target.getOwnPropertyDescriptor(Context.getContext(), index);
@@ -501,7 +501,7 @@ class NativeProxy extends ScriptableObject {
 
         Function trap = getTrap(TRAP_GET);
         if (trap != null) {
-            Object trapResult = callTrap(trap, new Object[] {target, key, this});
+            Object trapResult = callTrap(trap, new Object[] {target, key, start});
 
             DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
             if (targetDesc != null

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -258,20 +258,26 @@ final class NativeReflect extends ScriptableObject {
          */
         ScriptableObject target = checkTarget(args);
 
-        if (args.length > 1) {
-            if (ScriptRuntime.isSymbol(args[1])) {
-                Object prop = ScriptableObject.getProperty(target, (Symbol) args[1]);
-                return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
-            }
-            if (args[1] instanceof Number) {
-                Object prop = ScriptableObject.getProperty(target, ScriptRuntime.toIndex(args[1]));
-                return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
-            }
-
-            Object prop = ScriptableObject.getProperty(target, ScriptRuntime.toString(args[1]));
-            return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
+        if (args.length < 2) {
+            return Undefined.SCRIPTABLE_UNDEFINED;
         }
-        return Undefined.SCRIPTABLE_UNDEFINED;
+
+        Scriptable receiver =
+                (args.length > 2 && args[2] instanceof Scriptable) ? (Scriptable) args[2] : target;
+
+        Object prop;
+        if (ScriptRuntime.isSymbol(args[1])) {
+            prop = ScriptableObject.getSuperProperty(target, receiver, (Symbol) args[1]);
+        } else if (args[1] instanceof Number) {
+            prop =
+                    ScriptableObject.getSuperProperty(
+                            target, receiver, ScriptRuntime.toIndex(args[1]));
+        } else {
+            prop =
+                    ScriptableObject.getSuperProperty(
+                            target, receiver, ScriptRuntime.toString(args[1]));
+        }
+        return prop == Scriptable.NOT_FOUND ? Undefined.SCRIPTABLE_UNDEFINED : prop;
     }
 
     /**

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -715,6 +715,91 @@ public class NativeProxyTest {
     }
 
     @Test
+    public void getTrapReceivesCorrectReceiverWhenDifferentFromProxy() {
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    return 42;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, 'p', otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void getTrapReceivesProxyAsReceiverWhenNoExplicitReceiverGiven() {
+        String js =
+                "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    return receiver === proxy;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(proxy, 'p');";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getTrapReceiverIsProxyForDirectPropertyRead() {
+        String js =
+                "var log = [];\n"
+                        + "var target = {};\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    log.push(receiver === proxy ? 'proxy' : 'other');\n"
+                        + "    return 1;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "var _ = proxy.p;\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("proxy", js);
+    }
+
+    @Test
+    public void getTrapReceivesCorrectReceiverWithIndexKey() {
+        String js =
+                "var log = [];\n"
+                        + "var target = [];\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    if (prop === '0') {\n"
+                        + "      log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    }\n"
+                        + "    return undefined;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, 0, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void getTrapReceivesCorrectReceiverWithSymbolKey() {
+        String js =
+                "var log = [];\n"
+                        + "var sym = Symbol('test');\n"
+                        + "var target = {};\n"
+                        + "var otherReceiver = { label: 'other' };\n"
+                        + "var proxy = new Proxy(target, {\n"
+                        + "  get: function(t, prop, receiver) {\n"
+                        + "    if (prop === sym) {\n"
+                        + "      log.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "    }\n"
+                        + "    return undefined;\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "Reflect.get(proxy, sym, otherReceiver);\n"
+                        + "'' + log;";
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
     public void setTrap() {
         String js =
                 "var res = '';\n"

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -416,6 +416,71 @@ public class NativeReflectTest {
     }
 
     @Test
+    public void getReceiverDefaultsToTarget() {
+        // When no receiver is supplied, getter sees target as 'this'.
+        String js =
+                "var o = {};\n"
+                        + "Object.defineProperty(o, 'p', {\n"
+                        + "  get() { return this === o; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(o, 'p');";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverPassedToGetter() {
+        // When a receiver is supplied, getter sees receiver as 'this', not target.
+        String js =
+                "var target = {};\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(target, 'p', {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverPassedToGetterOnPrototype() {
+        // Getter is on the prototype, receiver is the leaf object — 'this' must
+        // still be the receiver, not the prototype where the getter lives.
+        String js =
+                "var receiver = {};\n"
+                        + "var proto = {};\n"
+                        + "Object.defineProperty(proto, 'p', {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "var target = Object.create(proto);\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void getReceiverDoesNotAffectDataProperty() {
+        // Receiver has no effect on plain data property reads — value comes from
+        // the prototype chain of target, not receiver.
+        String js =
+                "var target = { p: 42 };\n"
+                        + "var receiver = { p: 99 };\n"
+                        + "'' + Reflect.get(target, 'p', receiver);";
+        Utils.assertWithAllModes_ES6("42", js);
+    }
+
+    @Test
+    public void getReceiverWithSymbolKey() {
+        // Receiver must also be forwarded for Symbol-keyed getters.
+        String js =
+                "var sym = Symbol('test');\n"
+                        + "var target = {};\n"
+                        + "var receiver = {};\n"
+                        + "Object.defineProperty(target, sym, {\n"
+                        + "  get() { return this === receiver; }\n"
+                        + "});\n"
+                        + "'' + Reflect.get(target, sym, receiver);";
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
     public void setPrototypeOf() {
         String js =
                 "var o1 = {};\n"

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1989,11 +1989,10 @@ built-ins/Proxy 65/311 (20.9%)
     get-fn-realm.js
     get-fn-realm-recursive.js
 
-built-ins/Reflect 11/153 (7.19%)
+built-ins/Reflect 10/153 (6.54%)
     defineProperty/return-abrupt-from-property-key.js
     deleteProperty/return-abrupt-from-result.js
     deleteProperty/return-boolean.js strict
-    get/return-value-from-receiver.js
     ownKeys/return-on-corresponding-order-large-index.js
     set/call-prototype-property-set.js
     set/different-property-descriptors.js


### PR DESCRIPTION
Reflect#get:
* if receiver is not present, then set receiver to target
* use the receiver when searching for the property
* walk the prototype chain when searching for the property

Proxy#get:
* NativeProxy has to use the correct Receiver when calling the get trap