### PR TITLE
some more improvements for Reflect/Proxy

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -1,5 +1,7 @@
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.Scriptable.NOT_FOUND;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -8,8 +10,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
 import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
-
-import static org.mozilla.javascript.Scriptable.NOT_FOUND;
 
 /**
  * Abstract Object Operations as defined by EcmaScript
@@ -550,6 +550,7 @@ public class AbstractEcmaObjectOperations {
         }
         return false;
     }
+
     /**
      * Implements the OrdinarySetWithOwnDescriptor abstract operation.
      *
@@ -571,7 +572,18 @@ public class AbstractEcmaObjectOperations {
             // Target owns the property: delegate to OrdinarySetWithOwnDescriptor.
             return ordinarySetWithOwnDescriptor(cx, s, o, p, v, receiver, ownDesc);
         }
-        return false;
+
+        // ownDesc is null (undefined in spec terms): target has no own property.
+        // Per OrdinarySetWithOwnDescriptor step for undefined ownDesc:
+        // treat as a writable data property and CreateDataProperty(Receiver, P, V).
+        if (!(receiver instanceof ScriptableObject)) {
+            return false;
+        }
+
+        ScriptableObject receiverObj = (ScriptableObject) receiver;
+        DescriptorInfo newDesc = new DescriptorInfo(true, true, true, v);
+        receiverObj.defineOwnProperty(cx, p, newDesc, false);
+        return true;
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -9,6 +9,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
+import static org.mozilla.javascript.Scriptable.NOT_FOUND;
+
 /**
  * Abstract Object Operations as defined by EcmaScript
  *
@@ -199,7 +201,7 @@ public class AbstractEcmaObjectOperations {
         8. Throw a TypeError exception.
          */
         Object constructor = ScriptableObject.getProperty((Scriptable) s, "constructor");
-        if (constructor == Scriptable.NOT_FOUND || Undefined.isUndefined(constructor)) {
+        if (constructor == NOT_FOUND || Undefined.isUndefined(constructor)) {
             return defaultConstructor;
         }
         if (!ScriptRuntime.isObject(constructor)) {
@@ -207,7 +209,7 @@ public class AbstractEcmaObjectOperations {
                     "msg.arg.not.object", ScriptRuntime.typeof(constructor));
         }
         Object species = ScriptableObject.getProperty((Scriptable) constructor, SymbolKey.SPECIES);
-        if (species == Scriptable.NOT_FOUND || species == null || Undefined.isUndefined(species)) {
+        if (species == NOT_FOUND || species == null || Undefined.isUndefined(species)) {
             return defaultConstructor;
         }
         if (!(species instanceof Constructable)) {
@@ -547,5 +549,102 @@ public class AbstractEcmaObjectOperations {
             return true;
         }
         return false;
+    }
+    /**
+     * Implements the OrdinarySetWithOwnDescriptor abstract operation.
+     *
+     * <p>see <a href="https://262.ecma-international.org/14.0/#sec-ordinaryset">OrdinarySet ( O, P,
+     * V, Receiver )</a>
+     */
+    public static boolean ordinarySet(
+            Context cx, VarScope s, ScriptableObject o, Object p, Object v, Scriptable receiver) {
+        /*
+         * 1. Let ownDesc be ? O.[[GetOwnProperty]](P).
+         * 2. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
+         */
+        DescriptorInfo ownDesc =
+                (ScriptRuntime.isSymbol(p))
+                        ? o.getOwnPropertyDescriptor(cx, p)
+                        : o.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
+
+        if (ownDesc != null) {
+            // Target owns the property: delegate to OrdinarySetWithOwnDescriptor.
+            return ordinarySetWithOwnDescriptor(cx, s, o, p, v, receiver, ownDesc);
+        }
+        return false;
+    }
+
+    /**
+     * Implements the OrdinarySetWithOwnDescriptor abstract operation.
+     *
+     * <p>see <a href="https://262.ecma-international.org/14.0/#sec-ordinarysetwithowndescriptor">
+     * OrdinarySetWithOwnDescriptor ( O, P, V, Receiver, ownDesc )</a>
+     */
+    private static boolean ordinarySetWithOwnDescriptor(
+            Context cx,
+            VarScope s,
+            Scriptable o,
+            Object p,
+            Object v,
+            Scriptable receiver,
+            DescriptorInfo ownDesc) {
+        /*
+         * 1. If IsDataDescriptor(ownDesc) is true, then
+         *    a. If ownDesc.[[Writable]] is false, return false.
+         *    b. If Type(Receiver) is not Object, return false.
+         *    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
+         *    d. If existingDescriptor is not undefined, then
+         *       i.  If IsAccessorDescriptor(existingDescriptor) is true, return false.
+         *       ii. If existingDescriptor.[[Writable]] is false, return false.
+         *       iii.Let valueDesc be the PropertyDescriptor { [[Value]]: V }.
+         *           Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
+         *    e. Else,
+         *       Return ? CreateDataProperty(Receiver, P, V).
+         * 2. Assert: IsAccessorDescriptor(ownDesc) is true.
+         * 3. Let setter be ownDesc.[[Set]].
+         * 4. If setter is undefined, return false.
+         * 5. Perform ? Call(setter, Receiver, « V »).
+         * 6. Return true.
+         */
+
+        if (ownDesc.isDataDescriptor()) {
+            if (ownDesc.isWritable(false)) {
+                return false;
+            }
+            if (!(receiver instanceof ScriptableObject)) {
+                return false;
+            }
+            ScriptableObject receiverObj = (ScriptableObject) receiver;
+
+            DescriptorInfo existingDesc =
+                    (ScriptRuntime.isSymbol(p))
+                            ? receiverObj.getOwnPropertyDescriptor(cx, p)
+                            : receiverObj.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
+
+            if (existingDesc != null) {
+                if (existingDesc.isAccessorDescriptor()) {
+                    return false;
+                }
+                if (existingDesc.isWritable(false)) {
+                    return false;
+                }
+                DescriptorInfo valueDesc =
+                        new DescriptorInfo(
+                                NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, v);
+                receiverObj.defineOwnProperty(cx, p, valueDesc);
+                return true;
+            }
+
+            DescriptorInfo newDesc = new DescriptorInfo(true, true, true, v);
+            receiverObj.defineOwnProperty(cx, p, newDesc);
+            return true;
+        }
+
+        Object setter = ownDesc.setter;
+        if (setter == null || setter == NOT_FOUND || Undefined.isUndefined(setter)) {
+            return false;
+        }
+        ((Function) setter).call(cx, s, receiver, new Object[] {v});
+        return true;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -568,22 +568,7 @@ public class AbstractEcmaObjectOperations {
                         ? o.getOwnPropertyDescriptor(cx, p)
                         : o.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
 
-        if (ownDesc != null) {
-            // Target owns the property: delegate to OrdinarySetWithOwnDescriptor.
-            return ordinarySetWithOwnDescriptor(cx, s, o, p, v, receiver, ownDesc);
-        }
-
-        // ownDesc is null (undefined in spec terms): target has no own property.
-        // Per OrdinarySetWithOwnDescriptor step for undefined ownDesc:
-        // treat as a writable data property and CreateDataProperty(Receiver, P, V).
-        if (!(receiver instanceof ScriptableObject)) {
-            return false;
-        }
-
-        ScriptableObject receiverObj = (ScriptableObject) receiver;
-        DescriptorInfo newDesc = new DescriptorInfo(true, true, true, v);
-        receiverObj.defineOwnProperty(cx, p, newDesc, false);
-        return true;
+        return ordinarySetWithOwnDescriptor(cx, s, o, p, v, receiver, ownDesc);
     }
 
     /**
@@ -601,7 +586,13 @@ public class AbstractEcmaObjectOperations {
             Scriptable receiver,
             DescriptorInfo ownDesc) {
         /*
-         * 1. If IsDataDescriptor(ownDesc) is true, then
+         * 1. If ownDesc is undefined, then
+         *    a. Let parent be ? O.[[GetPrototypeOf]]().
+         *    b. If parent is not null, then
+         *       i. Return ? parent.[[Set]](P, V, Receiver).
+         *    c. Else,
+         *       i. Set ownDesc to the PropertyDescriptor { [[Value]]: undefined, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }.
+         * 2. If IsDataDescriptor(ownDesc) is true, then
          *    a. If ownDesc.[[Writable]] is false, return false.
          *    b. If Type(Receiver) is not Object, return false.
          *    c. Let existingDescriptor be ? Receiver.[[GetOwnProperty]](P).
@@ -612,12 +603,31 @@ public class AbstractEcmaObjectOperations {
          *           Return ? Receiver.[[DefineOwnProperty]](P, valueDesc).
          *    e. Else,
          *       Return ? CreateDataProperty(Receiver, P, V).
-         * 2. Assert: IsAccessorDescriptor(ownDesc) is true.
-         * 3. Let setter be ownDesc.[[Set]].
-         * 4. If setter is undefined, return false.
-         * 5. Perform ? Call(setter, Receiver, « V »).
-         * 6. Return true.
+         * 3. Assert: IsAccessorDescriptor(ownDesc) is true.
+         * 4. Let setter be ownDesc.[[Set]].
+         * 5. If setter is undefined, return false.
+         * 6. Perform ? Call(setter, Receiver, « V »).
+         * 7. Return true.
          */
+
+        if (ownDesc == null || Undefined.isUndefined(ownDesc)) {
+            Scriptable parent = o.getPrototype();
+            if (parent != null) {
+                if (ScriptRuntime.isSymbol(p)) {
+                    parent.put((Symbol) p, receiver, v);
+                } else {
+                    ScriptRuntime.StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(p);
+                    if (soi.stringId == null) {
+                        parent.put(soi.index, receiver, v);
+                    } else {
+                        parent.put(soi.stringId, receiver, v);
+                    }
+                }
+                return true;
+            }
+
+            ownDesc = new DescriptorInfo(true, true, true, Undefined.instance);
+        }
 
         if (ownDesc.isDataDescriptor()) {
             if (ownDesc.isWritable(false) || !(receiver instanceof ScriptableObject)) {

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -620,10 +620,7 @@ public class AbstractEcmaObjectOperations {
          */
 
         if (ownDesc.isDataDescriptor()) {
-            if (ownDesc.isWritable(false)) {
-                return false;
-            }
-            if (!(receiver instanceof ScriptableObject)) {
+            if (ownDesc.isWritable(false) || !(receiver instanceof ScriptableObject)) {
                 return false;
             }
             ScriptableObject receiverObj = (ScriptableObject) receiver;
@@ -634,17 +631,13 @@ public class AbstractEcmaObjectOperations {
                             : receiverObj.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
 
             if (existingDesc != null) {
-                if (existingDesc.isAccessorDescriptor()) {
-                    return false;
-                }
-                if (existingDesc.isWritable(false)) {
+                if (existingDesc.isAccessorDescriptor() || existingDesc.isWritable(false)) {
                     return false;
                 }
                 DescriptorInfo valueDesc =
                         new DescriptorInfo(
                                 NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, v);
-                receiverObj.defineOwnProperty(cx, p, valueDesc);
-                return true;
+                return receiverObj.defineOwnProperty(cx, p, valueDesc);
             }
 
             DescriptorInfo newDesc = new DescriptorInfo(true, true, true, v);

--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -564,7 +564,7 @@ public class AbstractEcmaObjectOperations {
          * 2. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
          */
         DescriptorInfo ownDesc =
-                (ScriptRuntime.isSymbol(p))
+                ScriptRuntime.isSymbol(p)
                         ? o.getOwnPropertyDescriptor(cx, p)
                         : o.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
 
@@ -629,7 +629,7 @@ public class AbstractEcmaObjectOperations {
             ScriptableObject receiverObj = (ScriptableObject) receiver;
 
             DescriptorInfo existingDesc =
-                    (ScriptRuntime.isSymbol(p))
+                    ScriptRuntime.isSymbol(p)
                             ? receiverObj.getOwnPropertyDescriptor(cx, p)
                             : receiverObj.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -561,7 +561,8 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_SET);
         if (trap != null) {
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, name, value}));
+                    ScriptRuntime.toBoolean(
+                            callTrap(trap, new Object[] {target, name, value, start}));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -623,7 +624,9 @@ class NativeProxy extends ScriptableObject {
                     ScriptRuntime.toBoolean(
                             callTrap(
                                     trap,
-                                    new Object[] {target, ScriptRuntime.toString(index), value}));
+                                    new Object[] {
+                                        target, ScriptRuntime.toString(index), value, start
+                                    }));
             if (!booleanTrapResult) {
                 return; // false
             }
@@ -683,7 +686,8 @@ class NativeProxy extends ScriptableObject {
         Function trap = getTrap(TRAP_SET);
         if (trap != null) {
             boolean booleanTrapResult =
-                    ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, key, value}));
+                    ScriptRuntime.toBoolean(
+                            callTrap(trap, new Object[] {target, key, value, start}));
             if (!booleanTrapResult) {
                 return; // false
             }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -448,13 +448,13 @@ final class NativeReflect extends ScriptableObject {
         }
 
         if (ScriptRuntime.isSymbol(args[1])) {
-            receiver.put((Symbol) args[1], receiver, value);
+            target.put((Symbol) args[1], receiver, value);
         } else {
             StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(args[1]);
             if (soi.stringId == null) {
-                receiver.put(soi.index, receiver, value);
+                target.put(soi.index, receiver, value);
             } else {
-                receiver.put(soi.stringId, receiver, value);
+                target.put(soi.stringId, receiver, value);
             }
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -440,9 +440,22 @@ final class NativeReflect extends ScriptableObject {
         // incorrectly (e.g. a configurable+non-writable property where the trap
         // returns true would wrongly return false).
         if (receiver != target) {
-            if (AbstractEcmaObjectOperations.ordinarySet(cx, s, target, args[1], args[2], receiver)) {
+            if (target instanceof NativeProxy) {
+                if (ScriptRuntime.isSymbol(args[1])) {
+                    target.put((Symbol) args[1], receiver, value);
+                } else {
+                    StringIdOrIndex soi = ScriptRuntime.toStringIdOrIndex(args[1]);
+                    if (soi.stringId == null) {
+                        target.put(soi.index, receiver, value);
+                    } else {
+                        target.put(soi.stringId, receiver, value);
+                    }
+                }
                 return true;
             }
+
+            AbstractEcmaObjectOperations.ordinarySet(cx, s, target, args[1], args[2], receiver);
+            return true;
         }
 
         // receiver == target (or target has no own property P):

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -95,7 +95,7 @@ final class NativeReflect extends ScriptableObject {
         if (ScriptRuntime.isSymbol(args[2])) {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(args[2]));
         }
-        ScriptableObject argumentsList = ScriptableObject.ensureScriptableObject(args[2]);
+        Scriptable argumentsList = ScriptableObject.ensureScriptable(args[2]);
 
         return ScriptRuntime.applyOrCall(
                 true, cx, s, callable, new Object[] {thisObj, argumentsList});
@@ -430,8 +430,8 @@ final class NativeReflect extends ScriptableObject {
         // A missing value must be treated as undefined
         final Object value = args.length > 2 ? args[2] : Undefined.instance;
 
-        ScriptableObject receiver =
-                args.length > 3 ? ScriptableObject.ensureScriptableObject(args[3]) : target;
+        Scriptable receiver =
+                args.length > 3 ? ScriptableObject.ensureScriptable(args[3]) : target;
         if (receiver != target) {
             DescriptorInfo descriptor = target.getOwnPropertyDescriptor(cx, args[1]);
             if (descriptor != null) {
@@ -499,7 +499,7 @@ final class NativeReflect extends ScriptableObject {
             throw ScriptRuntime.typeErrorById("msg.arg.not.object", ScriptRuntime.typeof(args[0]));
         }
 
-        ScriptableObject proto = ScriptableObject.ensureScriptableObject(args[1]);
+        Scriptable proto = ScriptableObject.ensureScriptable(args[1]);
         if (target.getPrototype() == proto) {
             return true;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -430,23 +430,24 @@ final class NativeReflect extends ScriptableObject {
         // A missing value must be treated as undefined
         final Object value = args.length > 2 ? args[2] : Undefined.instance;
 
-        Scriptable receiver =
-                args.length > 3 ? ScriptableObject.ensureScriptable(args[3]) : target;
-        if (receiver != target) {
-            DescriptorInfo descriptor = target.getOwnPropertyDescriptor(cx, args[1]);
-            if (descriptor != null) {
-                Object setter = descriptor.setter;
-                if (setter != null && setter != NOT_FOUND) {
-                    ((Function) setter).call(cx, s, receiver, new Object[] {value});
-                    return true;
-                }
+        Scriptable receiver = args.length > 3 ? ScriptableObject.ensureScriptable(args[3]) : target;
 
-                if (descriptor.isConfigurable(false)) {
-                    return false;
-                }
+        // OrdinarySet is only needed when receiver != target.
+        // When receiver == target we must call target.[[Set]] directly via put(),
+        // which correctly invokes any proxy set trap on target.
+        // Inlining OrdinarySet when receiver == target would
+        // bypass the proxy trap and apply the plain-object non-writable check
+        // incorrectly (e.g. a configurable+non-writable property where the trap
+        // returns true would wrongly return false).
+        if (receiver != target) {
+            if (AbstractEcmaObjectOperations.ordinarySet(cx, s, target, args[1], args[2], receiver)) {
+                return true;
             }
         }
 
+        // receiver == target (or target has no own property P):
+        // delegate to [[Set]] on the receiver, which correctly fires any proxy
+        // set trap when receiver/target is a Proxy.
         if (ScriptRuntime.isSymbol(args[1])) {
             target.put((Symbol) args[1], receiver, value);
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -261,8 +261,16 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             if (num.isPresent()) {
                 int idx = num.get().intValue();
                 if (checkIndex(idx)) {
-                    throw ScriptRuntime.typeErrorById(
-                            "msg.typed.array.index.out.of.bounds", idx, 0, getLength());
+                    if (checkValid) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.typed.array.index.out.of.bounds", idx, 0, getLength());
+                    }
+
+                    // Out-of-bounds: coerce value then return false.
+                    if (desc.hasValue()) {
+                        toNumeric(desc.value);
+                    }
+                    return false;
                 }
                 if (desc.isConfigurable(false)) {
                     return false;
@@ -290,8 +298,16 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
             if (s.getStringId() == null) {
                 int idx = s.getIndex();
                 if (checkIndex(idx)) {
-                    throw ScriptRuntime.typeErrorById(
-                            "msg.typed.array.index.out.of.bounds", idx, 0, getLength());
+                    if (checkValid) {
+                        throw ScriptRuntime.typeErrorById(
+                                "msg.typed.array.index.out.of.bounds", idx, 0, getLength());
+                    }
+
+                    // Out-of-bounds: coerce value then return false.
+                    if (desc.hasValue()) {
+                        toNumeric(desc.value);
+                    }
+                    return false;
                 }
                 if (desc.hasValue()) {
                     js_set(idx, desc.value);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -1128,4 +1128,45 @@ public class NativeProxyTest {
 
         Utils.assertWithAllModes_ES6(true, js);
     }
+
+    @Test
+    public void setTrapWithProxyAsReceiverViaWith() {
+        // 'with (proxy)' uses the proxy as both the
+        // scope object and the receiver. Reflect.set(env, "p", 1, proxy) must
+        // call proxy.[[DefineOwnProperty]].
+        String js =
+                "var log = [];\n"
+                        + "var env = { p: 0 };\n"
+                        + "var proxy = new Proxy(env, {\n"
+                        + "  has(t, pk) {\n"
+                        + "    log.push('has:' + String(pk));\n"
+                        + "    return Reflect.has(t, pk);\n"
+                        + "  },\n"
+                        + "  get(t, pk, r) {\n"
+                        + "    log.push('get:' + String(pk));\n"
+                        + "    return Reflect.get(t, pk, r);\n"
+                        + "  },\n"
+                        + "  set(t, pk, v, r) {\n"
+                        + "    log.push('set:' + String(pk));\n"
+                        + "    return Reflect.set(t, pk, v, r);\n"
+                        + "  },\n"
+                        + "  getOwnPropertyDescriptor(t, pk) {\n"
+                        + "    log.push('getOwnPropertyDescriptor:' + String(pk));\n"
+                        + "    return Reflect.getOwnPropertyDescriptor(t, pk);\n"
+                        + "  },\n"
+                        + "  defineProperty(t, pk, d) {\n"
+                        + "    log.push('defineProperty:' + String(pk));\n"
+                        + "    return Reflect.defineProperty(t, pk, d);\n"
+                        + "  },\n"
+                        + "});\n"
+                        + "with (proxy) {\n"
+                        + "  p = 1;\n"
+                        + "}\n"
+                        + "'' + log";
+
+        // finally should be
+        // "has:p,get:Symbol(Symbol.unscopables),has:p,set:p,getOwnPropertyDescriptor:p,defineProperty:p"
+        Utils.assertWithAllModes_ES6(
+                "has:p,has:p,set:p,getOwnPropertyDescriptor:p,defineProperty:p", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -817,6 +817,96 @@ public class NativeProxyTest {
     }
 
     @Test
+    public void setTrapReceivesCorrectReceiverWhenDifferentFromProxy() {
+        String js =
+                "  var res = [];\n"
+                        + "  var target = {};\n"
+                        + "  var otherReceiver = { label: 'other' };\n"
+                        + "  var proxy = new Proxy(target, {\n"
+                        + "    set: function(t, prop, value, receiver) {\n"
+                        + "      res.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "      return true;\n"
+                        + "    }\n"
+                        + "  });\n"
+                        + "  Reflect.set(proxy, 'p', 1, otherReceiver);\n"
+                        + "  '' + res;\n";
+
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void setTrapReceivesProxyAsReceiverWhenNoExplicitReceiverGiven() {
+        String js =
+                "  var target = {};\n"
+                        + "  var proxy = new Proxy(target, {\n"
+                        + "    set: function(t, prop, value, receiver) {\n"
+                        + "      return receiver === proxy;\n"
+                        + "    }\n"
+                        + "  });\n"
+                        + "  Reflect.set(proxy, 'p', 1);\n";
+
+        Utils.assertWithAllModes_ES6(true, js);
+    }
+
+    @Test
+    public void setTrapReceiverIsProxyForDirectPropertyWrite() {
+        String js =
+                "  var res = [];\n"
+                        + "  var target = {};\n"
+                        + "  var proxy = new Proxy(target, {\n"
+                        + "    set: function(t, prop, value, receiver) {\n"
+                        + "      res.push(receiver === proxy ? 'proxy' : 'other');\n"
+                        + "      return true;\n"
+                        + "    }\n"
+                        + "  });\n"
+                        + "  proxy.p = 1;\n"
+                        + "  '' + res;\n";
+
+        Utils.assertWithAllModes_ES6("proxy", js);
+    }
+
+    @Test
+    public void setTrapReceivesCorrectReceiverWithIndexKey() {
+        String js =
+                "  var res = [];\n"
+                        + "  var target = [];\n"
+                        + "  var otherReceiver = { label: 'other' };\n"
+                        + "  var proxy = new Proxy(target, {\n"
+                        + "    set: function(t, prop, value, receiver) {\n"
+                        + "      if (prop === '0') {\n"
+                        + "        res.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "      }\n"
+                        + "      return true;\n"
+                        + "    }\n"
+                        + "  });\n"
+                        + "  Reflect.set(proxy, 0, 42, otherReceiver);\n"
+                        + "  '' + res;\n";
+
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
+    public void setTrapReceivesCorrectReceiverWithSymbolKey() {
+        String js =
+                "  var res = [];\n"
+                        + "  var sym = Symbol('test');\n"
+                        + "  var target = {};\n"
+                        + "  var otherReceiver = { label: 'other' };\n"
+                        + "  var proxy = new Proxy(target, {\n"
+                        + "    set: function(t, prop, value, receiver) {\n"
+                        + "      if (prop === sym) {\n"
+                        + "        res.push(receiver === otherReceiver ? 'correct' : 'wrong');\n"
+                        + "      }\n"
+                        + "      return true;\n"
+                        + "    }\n"
+                        + "  });\n"
+                        + "  Reflect.set(proxy, sym, 42, otherReceiver);\n"
+                        + "  '' + res;\n";
+
+        Utils.assertWithAllModes_ES6("correct", js);
+    }
+
+    @Test
     public void getPropertyByIntWithoutHandler() {
         String js = "var a = ['zero', 'one'];" + "var proxy1 = new Proxy(a, {});\n" + "proxy1[1];";
         Utils.assertWithAllModes_ES6("one", js);

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -580,6 +580,22 @@ public class NativeReflectTest {
     }
 
     @Test
+    public void setReceiverPassedToSetterOnPrototype() {
+        String js =
+                "  var receiver = {};\n"
+                        + "  var proto = {};\n"
+                        + "  var receivedReceiver;\n"
+                        + "  Object.defineProperty(proto, 'p', {\n"
+                        + "    set(v) { receivedReceiver = this; }\n"
+                        + "  });\n"
+                        + "  var target = Object.create(proto);\n"
+                        + "  Reflect.set(target, 'p', 1, receiver);\n"
+                        + "  '' + (receivedReceiver === receiver);\n";
+
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
     public void setReceiverAffectsWhereDataPropertyIsWritten() {
         String js =
                 "  var target = { p: 1 };\n"

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -549,4 +549,60 @@ public class NativeReflectTest {
                         + "'' + log;";
         Utils.assertWithAllModes_ES6("true", js);
     }
+
+    @Test
+    public void setReceiverDefaultsToTarget() {
+        String js =
+                "  var o = {};\n"
+                        + "  var receivedReceiver;\n"
+                        + "  Object.defineProperty(o, 'p', {\n"
+                        + "    set(v) { receivedReceiver = this; }\n"
+                        + "  });\n"
+                        + "  Reflect.set(o, 'p', 1);\n"
+                        + "  '' + (receivedReceiver === o);\n";
+
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void setReceiverPassedToSetter() {
+        String js =
+                "  var target = {};\n"
+                        + "  var receiver = {};\n"
+                        + "  var receivedReceiver;\n"
+                        + "  Object.defineProperty(target, 'p', {\n"
+                        + "    set(v) { receivedReceiver = this; }\n"
+                        + "  });\n"
+                        + "  Reflect.set(target, 'p', 1, receiver);\n"
+                        + "  '' + (receivedReceiver === receiver);\n";
+
+        Utils.assertWithAllModes_ES6("true", js);
+    }
+
+    @Test
+    public void setReceiverAffectsWhereDataPropertyIsWritten() {
+        String js =
+                "  var target = { p: 1 };\n"
+                        + "  var receiver = { p: 0 };\n"
+                        + "  Reflect.set(target, 'p', 99, receiver);\n"
+                        + "  '' + receiver.p;\n";
+
+        Utils.assertWithAllModes_ES6("99", js);
+    }
+
+    @Test
+    public void setReceiverWithSymbolKey() {
+        String js =
+                "  var sym = Symbol('test');\n"
+                        + "  var target = {};\n"
+                        + "  var receiver = {};\n"
+                        + "  var receivedReceiver;\n"
+                        + "  Object.defineProperty(target, sym, {\n"
+                        + "    set(v) { receivedReceiver = this; }\n"
+                        + "  });\n"
+                        + "  Reflect.set(target, sym, 1, receiver);\n"
+                        + "  '' + (receivedReceiver === receiver);\n";
+
+        Utils.assertWithAllModes_ES6("true", js);
+    }
 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeReflectTest.java
@@ -605,4 +605,94 @@ public class NativeReflectTest {
 
         Utils.assertWithAllModes_ES6("true", js);
     }
+
+    @Test
+    public void reflectSetTypedArray() {
+        String js =
+                "let res = '';\n"
+                        + "let receiver = {};\n"
+                        + "let typedArray = new Int32Array(10);\n"
+                        + "let valueOfCalled = 0;\n"
+                        + "let value = { valueOf() { valueOfCalled++; return 1; } };\n"
+                        + "res += Reflect.set(typedArray, 0, value, receiver);\n"
+                        + "res += ' / ';\n"
+                        + "res += valueOfCalled;\n"
+                        + "res += ' / ';\n"
+                        + "res += receiver[0] === value;\n";
+
+        Utils.assertWithAllModes_ES6("true / 0 / true", js);
+    }
+
+    @Test
+    public void reflectSetTypedArrayInvalidIndex() {
+        String js =
+                "let res = '';\n"
+                        + "let receiver = new Int32Array(10);\n"
+                        + "let obj = Object.create(receiver);\n"
+                        + "let valueOfCalled = 0;\n"
+                        + "let value = { valueOf() { valueOfCalled++; return 1; } };\n"
+                        + "res += Reflect.set(obj, 100, value, receiver);\n"
+                        + "res += ' / ';\n"
+                        + "res += valueOfCalled;\n";
+
+        Utils.assertWithAllModes_ES6("true / 1", js);
+    }
+
+    @Test
+    public void reflectSetTypedArrayReceiverOobCoercesValue() {
+        String js =
+                "var receiver = new Int32Array(10);\n"
+                        + "var obj = Object.create(receiver);\n"
+                        + "var valueOfCalled = 0;\n"
+                        + "var value = { valueOf() { valueOfCalled++; return 1; } };\n"
+                        + "var result = Reflect.set(obj, 100, value, receiver);\n"
+                        + "'' + result + ' / ' + valueOfCalled;";
+        Utils.assertWithAllModes_ES6("true / 1", js);
+    }
+
+    @Test
+    public void reflectSetTypedArrayReceiverInBoundsCoercesAndWrites() {
+        String js =
+                "var receiver = new Int32Array(10);\n"
+                        + "var obj = Object.create(receiver);\n"
+                        + "var valueOfCalled = 0;\n"
+                        + "var value = { valueOf() { valueOfCalled++; return 42; } };\n"
+                        + "var result = Reflect.set(obj, 0, value, receiver);\n"
+                        + "'' + result + ' / ' + valueOfCalled + ' / ' + receiver[0];";
+        Utils.assertWithAllModes_ES6("true / 1 / 42", js);
+    }
+
+    @Test
+    public void reflectSetTypedArrayTargetPlainReceiverDoesNotCoerce() {
+        String js =
+                "var result = '';\n"
+                        + "var receiver = {};\n"
+                        + "var typedArray = new Int32Array(10);\n"
+                        + "var valueOfCalled = 0;\n"
+                        + "var value = { valueOf() { valueOfCalled++; return 1; } };\n"
+                        + "result += Reflect.set(typedArray, 0, value, receiver);\n"
+                        + "result += ' / ';\n"
+                        + "result += valueOfCalled;\n"
+                        + "result += ' / ';\n"
+                        + "result += receiver[0] === value;";
+        Utils.assertWithAllModes_ES6("true / 0 / true", js);
+    }
+
+    @Test
+    public void defineOwnPropertyOutOfBoundsDoesNotThrowViaReflect() {
+        String js =
+                "var ta = new Int32Array(4);\n"
+                        + "'' + Reflect.defineProperty(ta, '10', { value: 1 });";
+        Utils.assertWithAllModes_ES6("false", js);
+    }
+
+    @Test
+    public void defineOwnPropertyOutOfBoundsWriteIsDiscarded() {
+        String js =
+                "var ta = new Int32Array(4);\n"
+                        + "var value = { valueOf() { return 99; } };\n"
+                        + "Reflect.defineProperty(ta, '10', { value: value });\n"
+                        + "'' + ta[10];";
+        Utils.assertWithAllModes_ES6("undefined", js);
+    }
 }

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -2665,7 +2665,7 @@ built-ins/TypedArray 130/1438 (9.04%)
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 171/738 (23.17%)
+built-ins/TypedArrayConstructors 169/738 (22.9%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2827,11 +2827,9 @@ built-ins/TypedArrayConstructors 171/738 (23.17%)
     internals/Set/BigInt/tonumber-value-throws.js
     internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/key-is-canonical-invalid-index-reflect-set.js
-    internals/Set/key-is-in-bounds-receiver-is-not-typed-array.js
     internals/Set/key-is-not-canonical-index.js
     internals/Set/key-is-not-numeric-index.js
     internals/Set/key-is-out-of-bounds-receiver-is-not-object.js
-    internals/Set/key-is-out-of-bounds-receiver-is-not-typed-array.js
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1917,7 +1917,7 @@ built-ins/Promise 416/677 (61.45%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 65/311 (20.9%)
+built-ins/Proxy 64/311 (20.58%)
     construct/arguments-realm.js
     construct/call-parameters.js
     construct/call-parameters-new-target.js
@@ -1971,7 +1971,6 @@ built-ins/Proxy 65/311 (20.9%)
     set/boolean-trap-result-is-false-number-return-false.js
     set/boolean-trap-result-is-false-string-return-false.js
     set/boolean-trap-result-is-false-undefined-return-false.js
-    set/call-parameters.js
     set/call-parameters-prototype.js
     set/call-parameters-prototype-dunder-proto.js
     set/call-parameters-prototype-index.js
@@ -2666,7 +2665,7 @@ built-ins/TypedArray 130/1438 (9.04%)
     resizable-buffer-length-tracking-1.js
     resizable-buffer-length-tracking-2.js
 
-built-ins/TypedArrayConstructors 169/738 (22.9%)
+built-ins/TypedArrayConstructors 171/738 (23.17%)
     ctors-bigint/buffer-arg/bufferbyteoffset-throws-from-modulo-element-size-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-throws-sab.js {unsupported: [SharedArrayBuffer]}
     ctors-bigint/buffer-arg/byteoffset-is-negative-zero-sab.js {unsupported: [SharedArrayBuffer]}
@@ -2828,9 +2827,11 @@ built-ins/TypedArrayConstructors 169/738 (22.9%)
     internals/Set/BigInt/tonumber-value-throws.js
     internals/Set/key-is-canonical-invalid-index-prototype-chain-set.js
     internals/Set/key-is-canonical-invalid-index-reflect-set.js
+    internals/Set/key-is-in-bounds-receiver-is-not-typed-array.js
     internals/Set/key-is-not-canonical-index.js
     internals/Set/key-is-not-numeric-index.js
     internals/Set/key-is-out-of-bounds-receiver-is-not-object.js
+    internals/Set/key-is-out-of-bounds-receiver-is-not-typed-array.js
     internals/Set/key-is-symbol.js
     internals/Set/key-is-valid-index-prototype-chain-set.js
     internals/Set/key-is-valid-index-reflect-set.js


### PR DESCRIPTION
* Reflect set uses the correct target when forwarding the call
* NativeProxy support the receiver when calling the set trap
* introduce and use AbstractEcmaObjectOperations ordinarySet() and ordinarySetWithOwnDescriptor() for Reflect
* some fixes to support `with (proxy) {}` statements
* defineOwnProperty() should not throw when called vial Reflect
* improvements for Reflect set() when applying to TypedArrays

Seems like a bunch of tests are missing in test262, no real visible progress here.
But all the unit tests added for this are checked with real browsers for correctness.