### PR TITLE
Fix cross realm array creation behaviour.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -176,6 +176,14 @@ public class ArrayLikeAbstractOperations {
     static Scriptable arraySpeciesCreate(Context cx, VarScope scope, Object o, int length) {
         if (o instanceof NativeArray) {
             Object c = ScriptableObject.getProperty((Scriptable) o, "constructor");
+            if (c instanceof Function f && f.isConstructor()) {
+                VarScope ctorScope = ScriptableObject.getTopLevelScope(f.getDeclarationScope());
+                if (ctorScope != ScriptableObject.getTopLevelScope(scope)
+                        && c == ScriptableObject.getProperty(ctorScope, "Array")) {
+                    c = Undefined.instance;
+                }
+            }
+
             if (c instanceof Scriptable) {
                 c = ScriptableObject.getProperty((Scriptable) c, SymbolKey.SPECIES);
                 if (c == null || c == NOT_FOUND) {

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -449,13 +449,12 @@ built-ins/AggregateError 3/25 (12.0%)
     newtarget-proto-fallback.js
     proto-from-ctor-realm.js
 
-built-ins/Array 241/3081 (7.82%)
+built-ins/Array 236/3081 (7.66%)
     fromAsync 95/95 (100.0%)
     length/define-own-prop-length-coercion-order-set.js
     prototype/at/coerced-index-resize.js
     prototype/at/typed-array-resizable-buffer.js
     prototype/concat/Array.prototype.concat_non-array.js
-    prototype/concat/create-proto-from-ctor-realm-array.js
     prototype/concat/create-proxy.js
     prototype/copyWithin/coerced-values-start-change-start.js
     prototype/copyWithin/coerced-values-start-change-target.js
@@ -471,7 +470,6 @@ built-ins/Array 241/3081 (7.82%)
     prototype/fill/resizable-buffer.js
     prototype/fill/typed-array-resize.js
     prototype/filter/callbackfn-resize-arraybuffer.js
-    prototype/filter/create-proto-from-ctor-realm-array.js
     prototype/filter/create-proxy.js
     prototype/filter/resizable-buffer.js
     prototype/filter/resizable-buffer-grow-mid-iteration.js
@@ -518,7 +516,6 @@ built-ins/Array 241/3081 (7.82%)
     prototype/lastIndexOf/length-zero-returns-minus-one.js
     prototype/lastIndexOf/resizable-buffer.js
     prototype/map/callbackfn-resize-arraybuffer.js
-    prototype/map/create-proto-from-ctor-realm-array.js
     prototype/map/create-proxy.js
     prototype/map/resizable-buffer.js
     prototype/map/resizable-buffer-grow-mid-iteration.js
@@ -553,7 +550,6 @@ built-ins/Array 241/3081 (7.82%)
     prototype/shift/throws-when-this-value-length-is-writable-false.js non-strict
     prototype/slice/coerced-start-end-grow.js
     prototype/slice/coerced-start-end-shrink.js
-    prototype/slice/create-proto-from-ctor-realm-array.js
     prototype/slice/create-proxy.js
     prototype/slice/create-species.js
     prototype/slice/resizable-buffer.js
@@ -566,7 +562,6 @@ built-ins/Array 241/3081 (7.82%)
     prototype/sort/comparefn-shrink.js
     prototype/sort/resizable-buffer-default-comparator.js
     prototype/splice/clamps-length-to-integer-limit.js
-    prototype/splice/create-proto-from-ctor-realm-array.js
     prototype/splice/create-proto-from-ctor-realm-non-array.js
     prototype/splice/create-proxy.js
     prototype/splice/create-revoked-proxy.js


### PR DESCRIPTION
Apparently this worked (possibly by accident) before we converted arrays away from `IdScriptableObject`. Now works for us internally _and_ passes 262 tests.