### PR TITLE
Refactor away from inheriting from `Icode`.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -20,7 +20,7 @@ import org.mozilla.javascript.sourcemap.Position;
 import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /** Generates bytecode for the Interpreter. */
-class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
+class CodeGenerator<T extends ScriptOrFn<T>> {
 
     private static final int MIN_LABEL_TABLE_SIZE = 32;
     private static final int MIN_FIXUP_TABLE_SIZE = 40;
@@ -105,7 +105,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
         if (theFunction.isGenerator()) {
             // For generators with default parameters, generate parameter initialization
-            // bytecode BEFORE Icode_GENERATOR so defaults are evaluated before generator
+            // bytecode BEFORE Icode.GENERATOR so defaults are evaluated before generator
             // object creation. Ref: Ecma 2026, 10.2.11 FunctionDeclarationInstantiation
             Node paramInitBlock = theFunction.getGeneratorParamInitBlock();
             if (paramInitBlock != null) {
@@ -125,12 +125,12 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 for (int i = 0; i < functionCount; i++) {
                     FunctionNode fn = theFunction.getFunctionNode(i);
                     if (fn.getFunctionType() == FunctionNode.FUNCTION_STATEMENT) {
-                        addIndexOp(Icode_CLOSURE_STMT, i);
+                        addIndexOp(Icode.CLOSURE_STMT, i);
                     }
                 }
             }
 
-            addIcode(Icode_GENERATOR);
+            addIcode(Icode.GENERATOR);
             addUint16(theFunction.getBaseLineno() & 0xFFFF);
         }
 
@@ -269,7 +269,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             itsData.firstLinePC = lineno;
         }
         lineNumber = lineno;
-        addIcode(Icode_LINE);
+        addIcode(Icode.LINE);
         addUint16(lineno & 0xFFFF);
     }
 
@@ -292,7 +292,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     // In addition, function expressions can not be present here
                     // at statement level, they must only be present as expressions.
                     if (fnType == FunctionNode.FUNCTION_EXPRESSION_STATEMENT) {
-                        addIndexOp(Icode_CLOSURE_STMT, fnIndex);
+                        addIndexOp(Icode.CLOSURE_STMT, fnIndex);
                     } else {
                         if (fnType != FunctionNode.FUNCTION_STATEMENT) {
                             throw Kit.codeBug();
@@ -307,9 +307,9 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                         // For example, eval("function () {}") should return a
                         // function, not undefined.
                         if (!itsInFunctionFlag) {
-                            addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
+                            addIndexOp(Icode.CLOSURE_EXPR, fnIndex);
                             stackChange(1);
-                            addIcode(Icode_POP_RESULT);
+                            addIcode(Icode.POP_RESULT);
                             stackChange(-1);
                         }
                     }
@@ -349,13 +349,13 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                         visitStatement(child, initialStackDepth);
                         child = child.getNext();
                     }
-                    addIndexOp(Icode_LOCAL_CLEAR, local);
+                    addIndexOp(Icode.LOCAL_CLEAR, local);
                     releaseLocal(local);
                 }
                 break;
 
             case Token.DEBUGGER:
-                addIcode(Icode_DEBUGGER);
+                addIcode(Icode.DEBUGGER);
                 break;
 
             case Token.SWITCH:
@@ -369,17 +369,17 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                             caseNode = (Jump) caseNode.getNext()) {
                         if (caseNode.getType() != Token.CASE) throw badTree(caseNode);
                         Node test = caseNode.getFirstChild();
-                        addIcode(Icode_DUP);
+                        addIcode(Icode.DUP);
                         stackChange(1);
                         visitExpression(test, 0);
                         addToken(Token.SHEQ);
                         stackChange(-1);
-                        // If true, Icode_IFEQ_POP will jump and remove case
+                        // If true, Icode.IFEQ_POP will jump and remove case
                         // value from stack
-                        addGoto(caseNode.target, Icode_IFEQ_POP);
+                        addGoto(caseNode.target, Icode.IFEQ_POP);
                         stackChange(-1);
                     }
-                    addIcode(Icode_POP);
+                    addIcode(Icode.POP);
                     stackChange(-1);
                 }
                 break;
@@ -408,7 +408,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             case Token.JSR:
                 {
                     Node target = ((Jump) node).target;
-                    addGoto(target, Icode_GOSUB);
+                    addGoto(target, Icode.GOSUB);
                 }
                 break;
 
@@ -417,13 +417,13 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     // Account for incomming GOTOSUB address
                     stackChange(1);
                     int finallyRegister = getLocalBlockRef(node);
-                    addIndexOp(Icode_STARTSUB, finallyRegister);
+                    addIndexOp(Icode.STARTSUB, finallyRegister);
                     stackChange(-1);
                     while (child != null) {
                         visitStatement(child, initialStackDepth);
                         child = child.getNext();
                     }
-                    addIndexOp(Icode_RETSUB, finallyRegister);
+                    addIndexOp(Icode.RETSUB, finallyRegister);
                 }
                 break;
 
@@ -431,7 +431,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             case Token.EXPR_RESULT:
                 updateLineNumber(node);
                 visitExpression(child, 0);
-                addIcode((type == Token.EXPR_VOID) ? Icode_POP : Icode_POP_RESULT);
+                addIcode((type == Token.EXPR_VOID) ? Icode.POP : Icode.POP_RESULT);
                 stackChange(-1);
                 break;
 
@@ -441,7 +441,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     int exceptionObjectLocal = getLocalBlockRef(tryNode);
                     int scopeLocal = allocLocal();
 
-                    addIndexOp(Icode_SCOPE_SAVE, scopeLocal);
+                    addIndexOp(Icode.SCOPE_SAVE, scopeLocal);
 
                     int tryStart = iCodeTop;
                     boolean savedFlag = itsInTryFlag;
@@ -475,7 +475,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                                 scopeLocal);
                     }
 
-                    addIndexOp(Icode_LOCAL_CLEAR, scopeLocal);
+                    addIndexOp(Icode.LOCAL_CLEAR, scopeLocal);
                     releaseLocal(scopeLocal);
                 }
                 break;
@@ -515,18 +515,18 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                             || (compilerEnv.getLanguageVersion() < Context.VERSION_ES6)) {
                         // End generator function with no result, or old language version
                         // in which generators never return a result.
-                        addIcode(Icode_GENERATOR_END);
+                        addIcode(Icode.GENERATOR_END);
                         addUint16(lineNumber & 0xFFFF);
                     } else {
                         visitExpression(child, ECF_TAIL);
-                        addIcode(Icode_GENERATOR_RETURN);
+                        addIcode(Icode.GENERATOR_RETURN);
                         addUint16(lineNumber & 0xFFFF);
                         stackChange(-1);
                     }
 
                 } else {
                     if (child == null) {
-                        addIcode(Icode_RETUNDEF);
+                        addIcode(Icode.RETUNDEF);
                     } else {
                         visitExpression(child, ECF_TAIL);
                         addToken(Token.RETURN);
@@ -549,7 +549,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 stackChange(-1);
                 break;
 
-            case Icode_GENERATOR:
+            case Icode.GENERATOR:
                 break;
 
             default:
@@ -576,9 +576,9 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                         throw Kit.codeBug();
                     }
                     if (fn.isMethodDefinition()) {
-                        addIndexOp(Icode_METHOD_EXPR, fnIndex);
+                        addIndexOp(Icode.METHOD_EXPR, fnIndex);
                     } else {
-                        addIndexOp(Icode_CLOSURE_EXPR, fnIndex);
+                        addIndexOp(Icode.CLOSURE_EXPR, fnIndex);
                     }
                     stackChange(1);
                 }
@@ -597,7 +597,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     Node lastChild = node.getLastChild();
                     while (child != lastChild) {
                         visitExpression(child, 0);
-                        addIcode(Icode_POP);
+                        addIcode(Icode.POP);
                         stackChange(-1);
                         child = child.getNext();
                     }
@@ -647,8 +647,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                         }
                     }
 
-                    // Bytecode: [Icode_OBJECT_REST] [literalId:index] [computedKeyCount:uint8]
-                    addIndexOp(Icode_OBJECT_REST, staticKeysLiteralId);
+                    // Bytecode: [Icode.OBJECT_REST] [literalId:index] [computedKeyCount:uint8]
+                    addIndexOp(Icode.OBJECT_REST, staticKeysLiteralId);
                     addUint8(computedKeyCount);
 
                     stackChange(-computedKeyCount); // Computed keys removed from stack
@@ -679,12 +679,12 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     int callType = node.getIntProp(Node.SPECIALCALL_PROP, Node.NON_SPECIALCALL);
                     if (type != Token.REF_CALL && callType != Node.NON_SPECIALCALL) {
                         // embed line number and source filename
-                        addIndexOp(Icode_CALLSPECIAL, argCount);
+                        addIndexOp(Icode.CALLSPECIAL, argCount);
                         addUint8(callType);
                         addUint8(type == Token.NEW ? 1 : 0);
                         addUint16(lineNumber & 0xFFFF);
                     } else if (node.getIntProp(Node.SUPER_PROPERTY_ACCESS, 0) == 1) {
-                        addIndexOp(Icode_CALL_ON_SUPER, argCount);
+                        addIndexOp(Icode.CALL_ON_SUPER, argCount);
                     } else {
                         // Only use the tail call optimization if we're not in a try
                         // or we're not generating debug info (since the
@@ -693,7 +693,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                                 && (contextFlags & ECF_TAIL) != 0
                                 && !compilerEnv.isGenerateDebugInfo()
                                 && !itsInTryFlag) {
-                            type = Icode_TAIL_CALL;
+                            type = Icode.TAIL_CALL;
                         }
                         addIndexOp(type, argCount);
                     }
@@ -720,13 +720,13 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             case Token.OR:
                 {
                     visitExpression(child, 0);
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     int afterSecondJumpStart = iCodeTop;
                     int jump = (type == Token.AND) ? Token.IFNE : Token.IFEQ;
                     addGotoOp(jump);
                     stackChange(-1);
-                    addIcode(Icode_POP);
+                    addIcode(Icode.POP);
                     stackChange(-1);
                     child = child.getNext();
                     // Preserve tail context flag if any
@@ -761,10 +761,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 child = child.getNext();
                 if (node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1) {
                     // Jump if null or undefined
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     int putUndefinedLabel = iCodeTop;
-                    addGotoOp(Icode.Icode_IF_NULL_UNDEF);
+                    addGotoOp(Icode.IF_NULL_UNDEF);
                     stackChange(-1);
 
                     // Access property
@@ -774,8 +774,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
                     // Put undefined
                     resolveForwardGoto(putUndefinedLabel);
-                    addIcode(Icode_POP);
-                    addIcode(Icode_UNDEF);
+                    addIcode(Icode.POP);
+                    addIcode(Icode.UNDEF);
                     resolveForwardGoto(afterLabel);
                 } else if (node.getIntProp(Node.SUPER_PROPERTY_ACCESS, 0) == 1) {
                     addStringOp(
@@ -792,10 +792,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 child = child.getNext();
                 visitExpression(child, 0);
                 if (node.getIntProp(Node.SUPER_PROPERTY_ACCESS, 0) == 1) {
-                    addIcode(Icode_DELPROP_SUPER);
+                    addIcode(Icode.DELPROP_SUPER);
                 } else if (isName) {
                     // special handling for delete name
-                    addIcode(Icode_DELNAME);
+                    addIcode(Icode.DELNAME);
                 } else {
                     addToken(Token.DELPROP);
                 }
@@ -806,10 +806,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child, 0);
                 child = child.getNext();
                 if (node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1) {
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     int putUndefinedLabel = iCodeTop;
-                    addGotoOp(Icode.Icode_IF_NULL_UNDEF);
+                    addGotoOp(Icode.IF_NULL_UNDEF);
                     stackChange(-1);
 
                     // Infix op
@@ -819,8 +819,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
                     // Put undefined
                     resolveForwardGoto(putUndefinedLabel);
-                    addIcode(Icode_POP);
-                    addIcode(Icode_UNDEF);
+                    addIcode(Icode.POP);
+                    addIcode(Icode.UNDEF);
                     resolveForwardGoto(afterLabel);
                 } else if (node.getIntProp(Node.SUPER_PROPERTY_ACCESS, 0) == 1) {
                     visitExpression(child, 0);
@@ -876,8 +876,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             case Token.VOID:
                 visitExpression(child, 0);
                 if (type == Token.VOID) {
-                    addIcode(Icode_POP);
-                    addIcode(Icode_UNDEF);
+                    addIcode(Icode.POP);
+                    addIcode(Icode.UNDEF);
                 } else {
                     addToken(type);
                 }
@@ -888,12 +888,12 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child, 0);
                 if (node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1) {
                     // On the stack we'll have either the Ref or undefined
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
 
                     // If it's null or undefined, just jump ahead
                     int afterLabel = iCodeTop;
-                    addGotoOp(Icode.Icode_IF_NULL_UNDEF);
+                    addGotoOp(Icode.IF_NULL_UNDEF);
                     stackChange(-1);
 
                     // Otherwise do the GET_REF
@@ -913,7 +913,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     String property = child.getString();
                     child = child.getNext();
                     if (type == Token.SETPROP_OP) {
-                        addIcode(Icode_DUP);
+                        addIcode(Icode.DUP);
                         stackChange(1);
                         addStringOp(Token.GETPROP, property);
                         // Compensate for the following USE_STACK
@@ -936,7 +936,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child, 0);
                 child = child.getNext();
                 if (type == Token.SETELEM_OP) {
-                    addIcode(Icode_DUP2);
+                    addIcode(Icode.DUP2);
                     stackChange(2);
                     addToken(Token.GETELEM);
                     stackChange(-1);
@@ -956,7 +956,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child, 0);
                 child = child.getNext();
                 if (type == Token.SET_REF_OP) {
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     addToken(Token.GET_REF);
                     // Compensate for the following USE_STACK
@@ -985,7 +985,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     visitExpression(child, 0);
                     child = child.getNext();
                     visitExpression(child, 0);
-                    addStringOp(Icode_SETCONST, name);
+                    addStringOp(Icode.SETCONST, name);
                     stackChange(-1);
                 }
                 break;
@@ -998,7 +998,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     if (itsInFunctionFlag && !builder.requiresActivationFrame)
                         index = scriptOrFn.getIndexForNameNode(node);
                     if (index == -1) {
-                        addStringOp(Icode_TYPEOFNAME, node.getString());
+                        addStringOp(Icode.TYPEOFNAME, node.getString());
                         stackChange(1);
                     } else {
                         addVarOp(Token.GETVAR, index);
@@ -1067,7 +1067,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 break;
 
             case Token.UNDEFINED:
-                addIcode(Icode_UNDEF);
+                addIcode(Icode.UNDEF);
                 stackChange(1);
                 break;
 
@@ -1103,10 +1103,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(child, 0);
                 if (node.getIntProp(Node.OPTIONAL_CHAINING, 0) == 1) {
                     // Jump if null or undefined
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     int putUndefinedLabel = iCodeTop;
-                    addGotoOp(Icode.Icode_IF_NULL_UNDEF);
+                    addGotoOp(Icode.IF_NULL_UNDEF);
                     stackChange(-1);
 
                     // Access property
@@ -1116,8 +1116,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
                     // Put undefined
                     resolveForwardGoto(putUndefinedLabel);
-                    addIcode(Icode_POP);
-                    addIcode(Icode_UNDEF);
+                    addIcode(Icode.POP);
+                    addIcode(Icode.UNDEF);
                     resolveForwardGoto(afterLabel);
                 } else {
                     addStringOp(type, (String) node.getProp(Node.NAME_PROP));
@@ -1147,11 +1147,11 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     int queryPC;
                     updateLineNumber(node);
                     visitExpression(child, 0);
-                    addIcode(Icode_ENTERDQ);
+                    addIcode(Icode.ENTERDQ);
                     stackChange(-1);
                     queryPC = iCodeTop;
                     visitExpression(child.getNext(), 0);
-                    addBackwardGoto(Icode_LEAVEDQ, queryPC);
+                    addBackwardGoto(Icode.LEAVEDQ, queryPC);
                 }
                 break;
 
@@ -1167,13 +1167,13 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 if (child != null) {
                     visitExpression(child, 0);
                 } else {
-                    addIcode(Icode_UNDEF);
+                    addIcode(Icode.UNDEF);
                     stackChange(1);
                 }
                 if (type == Token.YIELD) {
                     addToken(Token.YIELD);
                 } else {
-                    addIcode(Icode_YIELD_STAR);
+                    addIcode(Icode.YIELD_STAR);
                 }
                 addUint16(node.getLineno() & 0xFFFF);
                 break;
@@ -1199,13 +1199,13 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     visitExpression(child, 0);
                     child = child.getNext();
 
-                    addIcode(Icode_DUP);
+                    addIcode(Icode.DUP);
                     stackChange(1);
                     int end = iCodeTop;
-                    addGotoOp(Icode.Icode_IF_NOT_NULL_UNDEF);
+                    addGotoOp(Icode.IF_NOT_NULL_UNDEF);
                     stackChange(-1);
 
-                    addIcode(Icode_POP);
+                    addIcode(Icode.POP);
                     visitExpression(child, 0);
                     stackChange(-1);
 
@@ -1225,19 +1225,19 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         int inum = (int) num;
         if (inum == num) {
             if (inum == 0) {
-                addIcode(Icode_ZERO);
+                addIcode(Icode.ZERO);
                 // Check for negative zero
                 if (1.0 / num < 0.0) {
                     addToken(Token.NEG);
                 }
             } else if (inum == 1) {
-                addIcode(Icode_ONE);
+                addIcode(Icode.ONE);
             } else if ((short) inum == inum) {
-                addIcode(Icode_SHORTNUMBER);
+                addIcode(Icode.SHORTNUMBER);
                 // write short as uin16 bit pattern
                 addUint16(inum & 0xFFFF);
             } else {
-                addIcode(Icode_INTNUMBER);
+                addIcode(Icode.INTNUMBER);
                 addInt(inum);
             }
         } else {
@@ -1263,11 +1263,11 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     String name = left.getString();
                     // stack: ... -> ... function thisObj
                     if (isOptionalChainingCall) {
-                        addStringOp(Icode_NAME_AND_THIS_OPTIONAL, name);
+                        addStringOp(Icode.NAME_AND_THIS_OPTIONAL, name);
                         stackChange(2);
                         return completeOptionalCallJump();
                     } else {
-                        addStringOp(Icode_NAME_AND_THIS, name);
+                        addStringOp(Icode.NAME_AND_THIS, name);
                         stackChange(2);
                     }
                     break;
@@ -1282,21 +1282,21 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                         String property = id.getString();
                         // stack: ... target -> ... function thisObj
                         if (isOptionalChainingCall) {
-                            addStringOp(Icode_PROP_AND_THIS_OPTIONAL, property);
+                            addStringOp(Icode.PROP_AND_THIS_OPTIONAL, property);
                             stackChange(1);
                             return completeOptionalCallJump();
                         } else {
-                            addStringOp(Icode_PROP_AND_THIS, property);
+                            addStringOp(Icode.PROP_AND_THIS, property);
                             stackChange(1);
                         }
                     } else {
                         visitExpression(id, 0);
                         // stack: ... target id -> ... function thisObj
                         if (isOptionalChainingCall) {
-                            addIcode(Icode_ELEM_AND_THIS_OPTIONAL);
+                            addIcode(Icode.ELEM_AND_THIS_OPTIONAL);
                             return completeOptionalCallJump();
                         } else {
-                            addIcode(Icode_ELEM_AND_THIS);
+                            addIcode(Icode.ELEM_AND_THIS);
                         }
                     }
                     break;
@@ -1306,11 +1306,11 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 visitExpression(left, 0);
                 // stack: ... value -> ... function thisObj
                 if (isOptionalChainingCall) {
-                    addIcode(Icode_VALUE_AND_THIS_OPTIONAL);
+                    addIcode(Icode.VALUE_AND_THIS_OPTIONAL);
                     stackChange(1);
                     return completeOptionalCallJump();
                 } else {
-                    addIcode(Icode_VALUE_AND_THIS);
+                    addIcode(Icode.VALUE_AND_THIS);
                     stackChange(1);
                 }
                 break;
@@ -1320,15 +1320,15 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
     private CompleteOptionalCallJump completeOptionalCallJump() {
         // If it's null or undefined, pop undefined and skip the arguments and call
-        addIcode(Icode_DUP);
+        addIcode(Icode.DUP);
         stackChange(1);
         int putArgsAndDoCallLabel = iCodeTop;
-        addGotoOp(Icode.Icode_IF_NOT_NULL_UNDEF);
+        addGotoOp(Icode.IF_NOT_NULL_UNDEF);
         stackChange(-1);
 
         // Put undefined
-        addIcode(Icode_POP);
-        addIcode(Icode_UNDEF);
+        addIcode(Icode.POP);
+        addIcode(Icode.UNDEF);
         int afterLabel = iCodeTop;
         addGotoOp(Token.GOTO);
 
@@ -1349,7 +1349,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 {
                     if (builder.requiresActivationFrame) Kit.codeBug();
                     int i = scriptOrFn.getIndexForNameNode(child);
-                    addVarOp(Icode_VAR_INC_DEC, i);
+                    addVarOp(Icode.VAR_INC_DEC, i);
                     addUint8(incrDecrMask);
                     stackChange(1);
                     break;
@@ -1357,7 +1357,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             case Token.NAME:
                 {
                     String name = child.getString();
-                    addStringOp(Icode_NAME_INC_DEC, name);
+                    addStringOp(Icode.NAME_INC_DEC, name);
                     addUint8(incrDecrMask);
                     stackChange(1);
                     break;
@@ -1367,7 +1367,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     Node object = child.getFirstChild();
                     visitExpression(object, 0);
                     String property = object.getNext().getString();
-                    addStringOp(Icode_PROP_INC_DEC, property);
+                    addStringOp(Icode.PROP_INC_DEC, property);
                     addUint8(incrDecrMask);
                     break;
                 }
@@ -1377,7 +1377,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                     visitExpression(object, 0);
                     Node index = object.getNext();
                     visitExpression(index, 0);
-                    addIcode(Icode_ELEM_INC_DEC);
+                    addIcode(Icode.ELEM_INC_DEC);
                     addUint8(incrDecrMask);
                     stackChange(-1);
                     break;
@@ -1386,7 +1386,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 {
                     Node ref = child.getFirstChild();
                     visitExpression(ref, 0);
-                    addIcode(Icode_REF_INC_DEC);
+                    addIcode(Icode.REF_INC_DEC);
                     addUint8(incrDecrMask);
                     break;
                 }
@@ -1425,17 +1425,17 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         // If it's a postfix expression, we copy the old value
         // If it's postfix, we only need the _new_ value on the stack
         if ((incrDecrMask & Node.POST_FLAG) != 0) {
-            addIcode(Icode_DUP); // stack: postfix [p, p], prefix: [p]
+            addIcode(Icode.DUP); // stack: postfix [p, p], prefix: [p]
             stackChange(+1);
         }
 
         // We need, in order, super and then the new value
         addToken(Token.SUPER); // stack: postfix [p, p, super], prefix: [p, super]
         stackChange(+1);
-        addIcode(Icode_SWAP); // stack: postfix [p, super, p], prefix: [super, p]
+        addIcode(Icode.SWAP); // stack: postfix [p, super, p], prefix: [super, p]
 
         // Increment or decrement the new value
-        addIcode(Icode_ONE); // stack: prefix  [p, super, p, 1], postfix: [super, p, 1]
+        addIcode(Icode.ONE); // stack: prefix  [p, super, p, 1], postfix: [super, p, 1]
         stackChange(+1);
         if ((incrDecrMask & Node.DECR_FLAG) == 0) {
             addToken(Token.ADD); // stack: prefix [p, super, p+1], postfix: [super, p+1]
@@ -1465,7 +1465,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
         // If it was a postfix, just drop the new value
         if ((incrDecrMask & Node.POST_FLAG) != 0) {
-            addIcode(Icode_POP); // stack: [p]
+            addIcode(Icode.POP); // stack: [p]
             stackChange(-1);
         }
     }
@@ -1483,9 +1483,9 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
     private void visitObjectLiteralWithSpread(
             Node node, Node child, Object[] propertyIds, int count) {
-        addIcode(Icode_REG_IND4);
+        addIcode(Icode.REG_IND4);
         addInt(-count - 1); // -1 to enforce it's negative even for {...x}
-        addIcode(Icode_LITERAL_NEW_OBJECT);
+        addIcode(Icode.LITERAL_NEW_OBJECT);
         addUint8(0); // unused
         stackChange(+2);
 
@@ -1501,8 +1501,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
 
                 if (((Node) propertyId).type == Token.DOTDOTDOT) {
                     // It's actually a spread! We need to do a "continue" to avoid setting it as key
-                    addIcode(Icode_SPREAD);
-                    // Always emit a 2-byte operand so Icode_SPREAD is fixed-width (3 bytes).
+                    addIcode(Icode.SPREAD);
+                    // Always emit a 2-byte operand so Icode.SPREAD is fixed-width (3 bytes).
                     // Object-literal spread never uses sourcePositions, so emit 0.
                     addUint16(0);
                     stackChange(-1);
@@ -1518,7 +1518,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             } else {
                 throw badTree(node);
             }
-            addIcode(Icode_LITERAL_KEY_SET);
+            addIcode(Icode.LITERAL_KEY_SET);
             stackChange(-1);
             // Value
             visitLiteralValue(child);
@@ -1546,7 +1546,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         int nextLiteralIndex = literalIds.size();
         literalIds.add(propertyIds);
 
-        addIndexOp(Icode_LITERAL_NEW_OBJECT, nextLiteralIndex);
+        addIndexOp(Icode.LITERAL_NEW_OBJECT, nextLiteralIndex);
         addUint8(hasAnyComputedProperty ? 1 : 0);
         stackChange(2);
 
@@ -1558,7 +1558,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
                 // Will be a node of type Token.COMPUTED_PROPERTY wrapping the actual expression
                 Node computedPropertyNode = (Node) propertyId;
                 visitExpression(computedPropertyNode.first, 0);
-                addIcode(Icode_LITERAL_KEY_SET);
+                addIcode(Icode.LITERAL_KEY_SET);
                 stackChange(-1);
             }
 
@@ -1605,7 +1605,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             literalIds.add(skipIndexes);
         }
 
-        addIndexOp(Icode_LITERAL_NEW_ARRAY, count - numberOfSpread);
+        addIndexOp(Icode.LITERAL_NEW_ARRAY, count - numberOfSpread);
         addUint16(skipIndexesId + 1);
         stackChange(1);
 
@@ -1613,7 +1613,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         while (child != null) {
             if (child.getType() == Token.DOTDOTDOT) {
                 visitExpression(child.getFirstChild(), 0);
-                addIcode(Icode_SPREAD);
+                addIcode(Icode.SPREAD);
                 if (skipIndexes != null) {
                     addUint16(sourcePositions[childIdx]);
                 } else {
@@ -1630,7 +1630,7 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         if (skipIndexes == null) {
             addToken(Token.ARRAYLIT);
         } else {
-            addIndexOp(Icode_SPARE_ARRAYLIT, skipIndexesId);
+            addIndexOp(Icode.SPARE_ARRAYLIT, skipIndexesId);
         }
     }
 
@@ -1638,23 +1638,23 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         int childType = child.getType();
         if (childType == Token.GET) {
             visitExpression(child.getFirstChild(), 0);
-            addIcode(Icode_LITERAL_GETTER);
+            addIcode(Icode.LITERAL_GETTER);
         } else if (childType == Token.SET) {
             visitExpression(child.getFirstChild(), 0);
-            addIcode(Icode_LITERAL_SETTER);
+            addIcode(Icode.LITERAL_SETTER);
         } else if (childType == Token.METHOD) {
             visitExpression(child.getFirstChild(), 0);
-            addIcode(Icode_LITERAL_SET);
+            addIcode(Icode.LITERAL_SET);
         } else {
             visitExpression(child, 0);
-            addIcode(Icode_LITERAL_SET);
+            addIcode(Icode.LITERAL_SET);
         }
         stackChange(-1);
     }
 
     private void visitTemplateLiteral(Node node) {
         int index = node.getExistingIntProp(Node.TEMPLATE_LITERAL_PROP);
-        addIndexOp(Icode_TEMPLATE_LITERAL_CALLSITE, index);
+        addIndexOp(Icode.TEMPLATE_LITERAL_CALLSITE, index);
         stackChange(1);
     }
 
@@ -1851,21 +1851,21 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
         switch (op) {
             case Token.SETCONSTVAR:
                 if (varIndex < 128) {
-                    addIcode(Icode_SETCONSTVAR1);
+                    addIcode(Icode.SETCONSTVAR1);
                     addUint8(varIndex);
                     return;
                 }
-                addIndexOp(Icode_SETCONSTVAR, varIndex);
+                addIndexOp(Icode.SETCONSTVAR, varIndex);
                 return;
             case Token.GETVAR:
             case Token.SETVAR:
                 if (varIndex < 128) {
-                    addIcode(op == Token.GETVAR ? Icode_GETVAR1 : Icode_SETVAR1);
+                    addIcode(op == Token.GETVAR ? Icode.GETVAR1 : Icode.SETVAR1);
                     addUint8(varIndex);
                     return;
                 }
             // fallthrough
-            case Icode_VAR_INC_DEC:
+            case Icode.VAR_INC_DEC:
                 addIndexOp(op, varIndex);
                 return;
         }
@@ -1897,15 +1897,15 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             strings.put(str, index);
         }
         if (index < 4) {
-            addIcode(Icode_REG_STR_C0 - index);
+            addIcode(Icode.REG_STR_C0 - index);
         } else if (index <= 0xFF) {
-            addIcode(Icode_REG_STR1);
+            addIcode(Icode.REG_STR1);
             addUint8(index);
         } else if (index <= 0xFFFF) {
-            addIcode(Icode_REG_STR2);
+            addIcode(Icode.REG_STR2);
             addUint16(index);
         } else {
-            addIcode(Icode_REG_STR4);
+            addIcode(Icode.REG_STR4);
             addInt(index);
         }
     }
@@ -1917,15 +1917,15 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
             bigInts.put(n, index);
         }
         if (index < 4) {
-            addIcode(Icode_REG_BIGINT_C0 - index);
+            addIcode(Icode.REG_BIGINT_C0 - index);
         } else if (index <= 0xFF) {
-            addIcode(Icode_REG_BIGINT1);
+            addIcode(Icode.REG_BIGINT1);
             addUint8(index);
         } else if (index <= 0xFFFF) {
-            addIcode(Icode_REG_BIGINT2);
+            addIcode(Icode.REG_BIGINT2);
             addUint16(index);
         } else {
-            addIcode(Icode_REG_BIGINT4);
+            addIcode(Icode.REG_BIGINT4);
             addInt(index);
         }
         addToken(Token.BIGINT);
@@ -1934,15 +1934,15 @@ class CodeGenerator<T extends ScriptOrFn<T>> extends Icode {
     private void addIndexPrefix(int index) {
         if (index < 0) Kit.codeBug();
         if (index < 6) {
-            addIcode(Icode_REG_IND_C0 - index);
+            addIcode(Icode.REG_IND_C0 - index);
         } else if (index <= 0xFF) {
-            addIcode(Icode_REG_IND1);
+            addIcode(Icode.REG_IND1);
             addUint8(index);
         } else if (index <= 0xFFFF) {
-            addIcode(Icode_REG_IND2);
+            addIcode(Icode.REG_IND2);
             addUint16(index);
         } else {
-            addIcode(Icode_REG_IND4);
+            addIcode(Icode.REG_IND4);
             addInt(index);
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Icode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Icode.java
@@ -12,164 +12,164 @@ abstract class Icode {
     static final int
 
             // delete operator used on a name
-            Icode_DELNAME = 0,
+            DELNAME = 0,
 
             // Stack: ... value1 -> ... value1 value1
-            Icode_DUP = Icode_DELNAME - 1,
+            DUP = DELNAME - 1,
 
             // Stack: ... value2 value1 -> ... value2 value1 value2 value1
-            Icode_DUP2 = Icode_DUP - 1,
+            DUP2 = DUP - 1,
 
             // Stack: ... value2 value1 -> ... value1 value2
-            Icode_SWAP = Icode_DUP2 - 1,
+            SWAP = DUP2 - 1,
 
             // Stack: ... value1 -> ...
-            Icode_POP = Icode_SWAP - 1,
+            POP = SWAP - 1,
 
             // Store stack top into return register and then pop it
-            Icode_POP_RESULT = Icode_POP - 1,
+            POP_RESULT = POP - 1,
 
             // To jump conditionally and pop additional stack value
-            Icode_IFEQ_POP = Icode_POP_RESULT - 1,
+            IFEQ_POP = POP_RESULT - 1,
 
             // various types of ++/--
-            Icode_VAR_INC_DEC = Icode_IFEQ_POP - 1,
-            Icode_NAME_INC_DEC = Icode_VAR_INC_DEC - 1,
-            Icode_PROP_INC_DEC = Icode_NAME_INC_DEC - 1,
-            Icode_ELEM_INC_DEC = Icode_PROP_INC_DEC - 1,
-            Icode_REF_INC_DEC = Icode_ELEM_INC_DEC - 1,
+            VAR_INC_DEC = IFEQ_POP - 1,
+            NAME_INC_DEC = VAR_INC_DEC - 1,
+            PROP_INC_DEC = NAME_INC_DEC - 1,
+            ELEM_INC_DEC = PROP_INC_DEC - 1,
+            REF_INC_DEC = ELEM_INC_DEC - 1,
 
             // load/save scope from/to local
-            Icode_SCOPE_LOAD = Icode_REF_INC_DEC - 1,
-            Icode_SCOPE_SAVE = Icode_SCOPE_LOAD - 1,
-            Icode_TYPEOFNAME = Icode_SCOPE_SAVE - 1,
+            SCOPE_LOAD = REF_INC_DEC - 1,
+            SCOPE_SAVE = SCOPE_LOAD - 1,
+            TYPEOFNAME = SCOPE_SAVE - 1,
 
             // helper for function calls
-            Icode_NAME_AND_THIS = Icode_TYPEOFNAME - 1,
-            Icode_PROP_AND_THIS = Icode_NAME_AND_THIS - 1,
-            Icode_ELEM_AND_THIS = Icode_PROP_AND_THIS - 1,
-            Icode_VALUE_AND_THIS = Icode_ELEM_AND_THIS - 1,
-            Icode_NAME_AND_THIS_OPTIONAL = Icode_VALUE_AND_THIS - 1,
-            Icode_PROP_AND_THIS_OPTIONAL = Icode_NAME_AND_THIS_OPTIONAL - 1,
-            Icode_ELEM_AND_THIS_OPTIONAL = Icode_PROP_AND_THIS_OPTIONAL - 1,
-            Icode_VALUE_AND_THIS_OPTIONAL = Icode_ELEM_AND_THIS_OPTIONAL - 1,
+            NAME_AND_THIS = TYPEOFNAME - 1,
+            PROP_AND_THIS = NAME_AND_THIS - 1,
+            ELEM_AND_THIS = PROP_AND_THIS - 1,
+            VALUE_AND_THIS = ELEM_AND_THIS - 1,
+            NAME_AND_THIS_OPTIONAL = VALUE_AND_THIS - 1,
+            PROP_AND_THIS_OPTIONAL = NAME_AND_THIS_OPTIONAL - 1,
+            ELEM_AND_THIS_OPTIONAL = PROP_AND_THIS_OPTIONAL - 1,
+            VALUE_AND_THIS_OPTIONAL = ELEM_AND_THIS_OPTIONAL - 1,
 
             // Create closure object for nested functions
-            Icode_CLOSURE_EXPR = Icode_VALUE_AND_THIS_OPTIONAL - 1,
-            Icode_CLOSURE_STMT = Icode_CLOSURE_EXPR - 1,
+            CLOSURE_EXPR = VALUE_AND_THIS_OPTIONAL - 1,
+            CLOSURE_STMT = CLOSURE_EXPR - 1,
 
             // Special calls
-            Icode_CALLSPECIAL = Icode_CLOSURE_STMT - 1,
-            Icode_CALLSPECIAL_OPTIONAL = Icode_CALLSPECIAL - 1,
+            CALLSPECIAL = CLOSURE_STMT - 1,
+            CALLSPECIAL_OPTIONAL = CALLSPECIAL - 1,
 
             // To return undefined value
-            Icode_RETUNDEF = Icode_CALLSPECIAL_OPTIONAL - 1,
+            RETUNDEF = CALLSPECIAL_OPTIONAL - 1,
 
             // Exception handling implementation
-            Icode_GOSUB = Icode_RETUNDEF - 1,
-            Icode_STARTSUB = Icode_GOSUB - 1,
-            Icode_RETSUB = Icode_STARTSUB - 1,
+            GOSUB = RETUNDEF - 1,
+            STARTSUB = GOSUB - 1,
+            RETSUB = STARTSUB - 1,
 
             // To indicating a line number change in icodes.
-            Icode_LINE = Icode_RETSUB - 1,
+            LINE = RETSUB - 1,
 
             // To store shorts and ints inline
-            Icode_SHORTNUMBER = Icode_LINE - 1,
-            Icode_INTNUMBER = Icode_SHORTNUMBER - 1,
+            SHORTNUMBER = LINE - 1,
+            INTNUMBER = SHORTNUMBER - 1,
 
             // To create and populate array to hold values for [] and {} literals
-            Icode_LITERAL_NEW_OBJECT = Icode_INTNUMBER - 1,
-            Icode_LITERAL_NEW_ARRAY = Icode_LITERAL_NEW_OBJECT - 1,
-            Icode_LITERAL_SET = Icode_LITERAL_NEW_ARRAY - 1,
-            Icode_METHOD_EXPR = Icode_LITERAL_SET - 1,
+            LITERAL_NEW_OBJECT = INTNUMBER - 1,
+            LITERAL_NEW_ARRAY = LITERAL_NEW_OBJECT - 1,
+            LITERAL_SET = LITERAL_NEW_ARRAY - 1,
+            METHOD_EXPR = LITERAL_SET - 1,
 
             // Array literal with skipped index like [1,,2]
-            Icode_SPARE_ARRAYLIT = Icode_METHOD_EXPR - 1,
+            SPARE_ARRAYLIT = METHOD_EXPR - 1,
 
             // Load index register to prepare for the following index operation
-            Icode_REG_IND_C0 = Icode_SPARE_ARRAYLIT - 1,
-            Icode_REG_IND_C1 = Icode_REG_IND_C0 - 1,
-            Icode_REG_IND_C2 = Icode_REG_IND_C1 - 1,
-            Icode_REG_IND_C3 = Icode_REG_IND_C2 - 1,
-            Icode_REG_IND_C4 = Icode_REG_IND_C3 - 1,
-            Icode_REG_IND_C5 = Icode_REG_IND_C4 - 1,
-            Icode_REG_IND1 = Icode_REG_IND_C5 - 1,
-            Icode_REG_IND2 = Icode_REG_IND1 - 1,
-            Icode_REG_IND4 = Icode_REG_IND2 - 1,
+            REG_IND_C0 = SPARE_ARRAYLIT - 1,
+            REG_IND_C1 = REG_IND_C0 - 1,
+            REG_IND_C2 = REG_IND_C1 - 1,
+            REG_IND_C3 = REG_IND_C2 - 1,
+            REG_IND_C4 = REG_IND_C3 - 1,
+            REG_IND_C5 = REG_IND_C4 - 1,
+            REG_IND1 = REG_IND_C5 - 1,
+            REG_IND2 = REG_IND1 - 1,
+            REG_IND4 = REG_IND2 - 1,
 
             // Load string register to prepare for the following string operation
-            Icode_REG_STR_C0 = Icode_REG_IND4 - 1,
-            Icode_REG_STR_C1 = Icode_REG_STR_C0 - 1,
-            Icode_REG_STR_C2 = Icode_REG_STR_C1 - 1,
-            Icode_REG_STR_C3 = Icode_REG_STR_C2 - 1,
-            Icode_REG_STR1 = Icode_REG_STR_C3 - 1,
-            Icode_REG_STR2 = Icode_REG_STR1 - 1,
-            Icode_REG_STR4 = Icode_REG_STR2 - 1,
+            REG_STR_C0 = REG_IND4 - 1,
+            REG_STR_C1 = REG_STR_C0 - 1,
+            REG_STR_C2 = REG_STR_C1 - 1,
+            REG_STR_C3 = REG_STR_C2 - 1,
+            REG_STR1 = REG_STR_C3 - 1,
+            REG_STR2 = REG_STR1 - 1,
+            REG_STR4 = REG_STR2 - 1,
 
             // Version of getvar/setvar that read var index directly from bytecode
-            Icode_GETVAR1 = Icode_REG_STR4 - 1,
-            Icode_SETVAR1 = Icode_GETVAR1 - 1,
+            GETVAR1 = REG_STR4 - 1,
+            SETVAR1 = GETVAR1 - 1,
 
             // Load undefined
-            Icode_UNDEF = Icode_SETVAR1 - 1,
-            Icode_ZERO = Icode_UNDEF - 1,
-            Icode_ONE = Icode_ZERO - 1,
+            UNDEF = SETVAR1 - 1,
+            ZERO = UNDEF - 1,
+            ONE = ZERO - 1,
 
             // entrance and exit from .()
-            Icode_ENTERDQ = Icode_ONE - 1,
-            Icode_LEAVEDQ = Icode_ENTERDQ - 1,
-            Icode_TAIL_CALL = Icode_LEAVEDQ - 1,
+            ENTERDQ = ONE - 1,
+            LEAVEDQ = ENTERDQ - 1,
+            TAIL_CALL = LEAVEDQ - 1,
 
             // Clear local to allow GC its context
-            Icode_LOCAL_CLEAR = Icode_TAIL_CALL - 1,
+            LOCAL_CLEAR = TAIL_CALL - 1,
 
             // Literal get/set
-            Icode_LITERAL_GETTER = Icode_LOCAL_CLEAR - 1,
-            Icode_LITERAL_SETTER = Icode_LITERAL_GETTER - 1,
+            LITERAL_GETTER = LOCAL_CLEAR - 1,
+            LITERAL_SETTER = LITERAL_GETTER - 1,
 
             // const
-            Icode_SETCONST = Icode_LITERAL_SETTER - 1,
-            Icode_SETCONSTVAR = Icode_SETCONST - 1,
-            Icode_SETCONSTVAR1 = Icode_SETCONSTVAR - 1,
+            SETCONST = LITERAL_SETTER - 1,
+            SETCONSTVAR = SETCONST - 1,
+            SETCONSTVAR1 = SETCONSTVAR - 1,
 
             // Generator opcodes (along with Token.YIELD)
-            Icode_GENERATOR = Icode_SETCONSTVAR1 - 1,
-            Icode_GENERATOR_END = Icode_GENERATOR - 1,
-            Icode_DEBUGGER = Icode_GENERATOR_END - 1,
-            Icode_GENERATOR_RETURN = Icode_DEBUGGER - 1,
-            Icode_YIELD_STAR = Icode_GENERATOR_RETURN - 1,
+            GENERATOR = SETCONSTVAR1 - 1,
+            GENERATOR_END = GENERATOR - 1,
+            DEBUGGER = GENERATOR_END - 1,
+            GENERATOR_RETURN = DEBUGGER - 1,
+            YIELD_STAR = GENERATOR_RETURN - 1,
 
             // Load BigInt register to prepare for the following BigInt operation
-            Icode_REG_BIGINT_C0 = Icode_YIELD_STAR - 1,
-            Icode_REG_BIGINT_C1 = Icode_REG_BIGINT_C0 - 1,
-            Icode_REG_BIGINT_C2 = Icode_REG_BIGINT_C1 - 1,
-            Icode_REG_BIGINT_C3 = Icode_REG_BIGINT_C2 - 1,
-            Icode_REG_BIGINT1 = Icode_REG_BIGINT_C3 - 1,
-            Icode_REG_BIGINT2 = Icode_REG_BIGINT1 - 1,
-            Icode_REG_BIGINT4 = Icode_REG_BIGINT2 - 1,
+            REG_BIGINT_C0 = YIELD_STAR - 1,
+            REG_BIGINT_C1 = REG_BIGINT_C0 - 1,
+            REG_BIGINT_C2 = REG_BIGINT_C1 - 1,
+            REG_BIGINT_C3 = REG_BIGINT_C2 - 1,
+            REG_BIGINT1 = REG_BIGINT_C3 - 1,
+            REG_BIGINT2 = REG_BIGINT1 - 1,
+            REG_BIGINT4 = REG_BIGINT2 - 1,
 
             // Call to GetTemplateLiteralCallSite
-            Icode_TEMPLATE_LITERAL_CALLSITE = Icode_REG_BIGINT4 - 1,
-            Icode_LITERAL_KEY_SET = Icode_TEMPLATE_LITERAL_CALLSITE - 1,
+            TEMPLATE_LITERAL_CALLSITE = REG_BIGINT4 - 1,
+            LITERAL_KEY_SET = TEMPLATE_LITERAL_CALLSITE - 1,
 
             // Jump if stack head is null or undefined
-            Icode_IF_NULL_UNDEF = Icode_LITERAL_KEY_SET - 1,
-            Icode_IF_NOT_NULL_UNDEF = Icode_IF_NULL_UNDEF - 1,
+            IF_NULL_UNDEF = LITERAL_KEY_SET - 1,
+            IF_NOT_NULL_UNDEF = IF_NULL_UNDEF - 1,
 
             // Call a method on the super object, i.e. super.foo()
-            Icode_CALL_ON_SUPER = Icode_IF_NOT_NULL_UNDEF - 1,
+            CALL_ON_SUPER = IF_NOT_NULL_UNDEF - 1,
 
             // delete super.prop
-            Icode_DELPROP_SUPER = Icode_CALL_ON_SUPER - 1,
+            DELPROP_SUPER = CALL_ON_SUPER - 1,
 
             // spread
-            Icode_SPREAD = Icode_DELPROP_SUPER - 1,
+            SPREAD = DELPROP_SUPER - 1,
 
             // object rest - create object excluding extracted keys
-            Icode_OBJECT_REST = Icode_SPREAD - 1,
+            OBJECT_REST = SPREAD - 1,
 
             // Last icode
-            MIN_ICODE = Icode_OBJECT_REST;
+            MIN_ICODE = OBJECT_REST;
 
     static String bytecodeName(int bytecode) {
         if (!validBytecode(bytecode)) {
@@ -185,183 +185,183 @@ abstract class Icode {
         }
 
         switch (bytecode) {
-            case Icode_DELNAME:
+            case DELNAME:
                 return "DELNAME";
-            case Icode_DUP:
+            case DUP:
                 return "DUP";
-            case Icode_DUP2:
+            case DUP2:
                 return "DUP2";
-            case Icode_SWAP:
+            case SWAP:
                 return "SWAP";
-            case Icode_POP:
+            case POP:
                 return "POP";
-            case Icode_POP_RESULT:
+            case POP_RESULT:
                 return "POP_RESULT";
-            case Icode_IFEQ_POP:
+            case IFEQ_POP:
                 return "IFEQ_POP";
-            case Icode_VAR_INC_DEC:
+            case VAR_INC_DEC:
                 return "VAR_INC_DEC";
-            case Icode_NAME_INC_DEC:
+            case NAME_INC_DEC:
                 return "NAME_INC_DEC";
-            case Icode_PROP_INC_DEC:
+            case PROP_INC_DEC:
                 return "PROP_INC_DEC";
-            case Icode_ELEM_INC_DEC:
+            case ELEM_INC_DEC:
                 return "ELEM_INC_DEC";
-            case Icode_REF_INC_DEC:
+            case REF_INC_DEC:
                 return "REF_INC_DEC";
-            case Icode_SCOPE_LOAD:
+            case SCOPE_LOAD:
                 return "SCOPE_LOAD";
-            case Icode_SCOPE_SAVE:
+            case SCOPE_SAVE:
                 return "SCOPE_SAVE";
-            case Icode_TYPEOFNAME:
+            case TYPEOFNAME:
                 return "TYPEOFNAME";
-            case Icode_NAME_AND_THIS:
+            case NAME_AND_THIS:
                 return "NAME_AND_THIS";
-            case Icode_PROP_AND_THIS:
+            case PROP_AND_THIS:
                 return "PROP_AND_THIS";
-            case Icode_ELEM_AND_THIS:
+            case ELEM_AND_THIS:
                 return "ELEM_AND_THIS";
-            case Icode_VALUE_AND_THIS:
+            case VALUE_AND_THIS:
                 return "VALUE_AND_THIS";
-            case Icode_NAME_AND_THIS_OPTIONAL:
+            case NAME_AND_THIS_OPTIONAL:
                 return "NAME_AND_THIS_OPTIONAL";
-            case Icode_PROP_AND_THIS_OPTIONAL:
+            case PROP_AND_THIS_OPTIONAL:
                 return "PROP_AND_THIS_OPTIONAL";
-            case Icode_ELEM_AND_THIS_OPTIONAL:
+            case ELEM_AND_THIS_OPTIONAL:
                 return "ELEM_AND_THIS_OPTIONAL";
-            case Icode_VALUE_AND_THIS_OPTIONAL:
+            case VALUE_AND_THIS_OPTIONAL:
                 return "VALUE_AND_THIS_OPTIONAL";
-            case Icode_CLOSURE_EXPR:
+            case CLOSURE_EXPR:
                 return "CLOSURE_EXPR";
-            case Icode_CLOSURE_STMT:
+            case CLOSURE_STMT:
                 return "CLOSURE_STMT";
-            case Icode_CALLSPECIAL:
+            case CALLSPECIAL:
                 return "CALLSPECIAL";
-            case Icode_CALLSPECIAL_OPTIONAL:
+            case CALLSPECIAL_OPTIONAL:
                 return "CALLSPECIAL_OPTIONAL";
-            case Icode_RETUNDEF:
+            case RETUNDEF:
                 return "RETUNDEF";
-            case Icode_GOSUB:
+            case GOSUB:
                 return "GOSUB";
-            case Icode_STARTSUB:
+            case STARTSUB:
                 return "STARTSUB";
-            case Icode_RETSUB:
+            case RETSUB:
                 return "RETSUB";
-            case Icode_LINE:
+            case LINE:
                 return "LINE";
-            case Icode_SHORTNUMBER:
+            case SHORTNUMBER:
                 return "SHORTNUMBER";
-            case Icode_INTNUMBER:
+            case INTNUMBER:
                 return "INTNUMBER";
-            case Icode_LITERAL_NEW_OBJECT:
+            case LITERAL_NEW_OBJECT:
                 return "LITERAL_NEW_OBJECT";
-            case Icode_LITERAL_NEW_ARRAY:
+            case LITERAL_NEW_ARRAY:
                 return "LITERAL_NEW_ARRAY";
-            case Icode_LITERAL_SET:
+            case LITERAL_SET:
                 return "LITERAL_SET";
-            case Icode_METHOD_EXPR:
+            case METHOD_EXPR:
                 return "METHOD_EXPR";
-            case Icode_SPARE_ARRAYLIT:
+            case SPARE_ARRAYLIT:
                 return "SPARE_ARRAYLIT";
-            case Icode_REG_IND_C0:
+            case REG_IND_C0:
                 return "REG_IND_C0";
-            case Icode_REG_IND_C1:
+            case REG_IND_C1:
                 return "REG_IND_C1";
-            case Icode_REG_IND_C2:
+            case REG_IND_C2:
                 return "REG_IND_C2";
-            case Icode_REG_IND_C3:
+            case REG_IND_C3:
                 return "REG_IND_C3";
-            case Icode_REG_IND_C4:
+            case REG_IND_C4:
                 return "REG_IND_C4";
-            case Icode_REG_IND_C5:
+            case REG_IND_C5:
                 return "REG_IND_C5";
-            case Icode_REG_IND1:
+            case REG_IND1:
                 return "LOAD_IND1";
-            case Icode_REG_IND2:
+            case REG_IND2:
                 return "LOAD_IND2";
-            case Icode_REG_IND4:
+            case REG_IND4:
                 return "LOAD_IND4";
-            case Icode_REG_STR_C0:
+            case REG_STR_C0:
                 return "REG_STR_C0";
-            case Icode_REG_STR_C1:
+            case REG_STR_C1:
                 return "REG_STR_C1";
-            case Icode_REG_STR_C2:
+            case REG_STR_C2:
                 return "REG_STR_C2";
-            case Icode_REG_STR_C3:
+            case REG_STR_C3:
                 return "REG_STR_C3";
-            case Icode_REG_STR1:
+            case REG_STR1:
                 return "LOAD_STR1";
-            case Icode_REG_STR2:
+            case REG_STR2:
                 return "LOAD_STR2";
-            case Icode_REG_STR4:
+            case REG_STR4:
                 return "LOAD_STR4";
-            case Icode_GETVAR1:
+            case GETVAR1:
                 return "GETVAR1";
-            case Icode_SETVAR1:
+            case SETVAR1:
                 return "SETVAR1";
-            case Icode_UNDEF:
+            case UNDEF:
                 return "UNDEF";
-            case Icode_ZERO:
+            case ZERO:
                 return "ZERO";
-            case Icode_ONE:
+            case ONE:
                 return "ONE";
-            case Icode_ENTERDQ:
+            case ENTERDQ:
                 return "ENTERDQ";
-            case Icode_LEAVEDQ:
+            case LEAVEDQ:
                 return "LEAVEDQ";
-            case Icode_TAIL_CALL:
+            case TAIL_CALL:
                 return "TAIL_CALL";
-            case Icode_LOCAL_CLEAR:
+            case LOCAL_CLEAR:
                 return "LOCAL_CLEAR";
-            case Icode_LITERAL_GETTER:
+            case LITERAL_GETTER:
                 return "LITERAL_GETTER";
-            case Icode_LITERAL_SETTER:
+            case LITERAL_SETTER:
                 return "LITERAL_SETTER";
-            case Icode_SETCONST:
+            case SETCONST:
                 return "SETCONST";
-            case Icode_SETCONSTVAR:
+            case SETCONSTVAR:
                 return "SETCONSTVAR";
-            case Icode_SETCONSTVAR1:
+            case SETCONSTVAR1:
                 return "SETCONSTVAR1";
-            case Icode_GENERATOR:
+            case GENERATOR:
                 return "GENERATOR";
-            case Icode_GENERATOR_END:
+            case GENERATOR_END:
                 return "GENERATOR_END";
-            case Icode_DEBUGGER:
+            case DEBUGGER:
                 return "DEBUGGER";
-            case Icode_GENERATOR_RETURN:
+            case GENERATOR_RETURN:
                 return "GENERATOR_RETURN";
-            case Icode_YIELD_STAR:
+            case YIELD_STAR:
                 return "YIELD_STAR";
-            case Icode_REG_BIGINT_C0:
+            case REG_BIGINT_C0:
                 return "REG_BIGINT_C0";
-            case Icode_REG_BIGINT_C1:
+            case REG_BIGINT_C1:
                 return "REG_BIGINT_C1";
-            case Icode_REG_BIGINT_C2:
+            case REG_BIGINT_C2:
                 return "REG_BIGINT_C2";
-            case Icode_REG_BIGINT_C3:
+            case REG_BIGINT_C3:
                 return "REG_BIGINT_C3";
-            case Icode_REG_BIGINT1:
+            case REG_BIGINT1:
                 return "LOAD_BIGINT1";
-            case Icode_REG_BIGINT2:
+            case REG_BIGINT2:
                 return "LOAD_BIGINT2";
-            case Icode_REG_BIGINT4:
+            case REG_BIGINT4:
                 return "LOAD_BIGINT4";
-            case Icode_TEMPLATE_LITERAL_CALLSITE:
+            case TEMPLATE_LITERAL_CALLSITE:
                 return "TEMPLATE_LITERAL_CALLSITE";
-            case Icode_LITERAL_KEY_SET:
+            case LITERAL_KEY_SET:
                 return "LITERAL_KEY_SET";
-            case Icode_IF_NULL_UNDEF:
+            case IF_NULL_UNDEF:
                 return "IF_NULL_UNDEF";
-            case Icode_IF_NOT_NULL_UNDEF:
+            case IF_NOT_NULL_UNDEF:
                 return "IF_NOT_NULL_UNDEF";
-            case Icode_CALL_ON_SUPER:
+            case CALL_ON_SUPER:
                 return "CALL_ON_SUPER";
-            case Icode_DELPROP_SUPER:
+            case DELPROP_SUPER:
                 return "DELPROP_SUPER";
-            case Icode_SPREAD:
+            case SPREAD:
                 return "SPREAD";
-            case Icode_OBJECT_REST:
+            case OBJECT_REST:
                 return "OBJECT_REST";
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -27,7 +27,7 @@ import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.debug.DebugFrame;
 import org.mozilla.javascript.debug.DebuggableScript;
 
-public final class Interpreter extends Icode implements Evaluator {
+public final class Interpreter implements Evaluator {
 
     static final int EXCEPTION_TRY_START_SLOT = 0;
     static final int EXCEPTION_TRY_END_SLOT = 1;
@@ -698,7 +698,7 @@ public final class Interpreter extends Icode implements Evaluator {
             System.err.println(str);
             throw new IllegalStateException(str);
         }
-        if (MIN_ICODE < -128) {
+        if (Icode.MIN_ICODE < -128) {
             String str = "Violation of Interpreter.MIN_ICODE >= -128";
             System.err.println(str);
             throw new IllegalStateException(str);
@@ -834,7 +834,7 @@ public final class Interpreter extends Icode implements Evaluator {
             int icodeLength = bytecodeSpan(token);
             String tname = Icode.bytecodeName(token);
             ctx.pc = pc + 1;
-            InstructionClass instr = instructionObjs[-MIN_ICODE + token];
+            InstructionClass instr = instructionObjs[-Icode.MIN_ICODE + token];
             instr.dumpICode(token, tname, ctx);
             if (pc + icodeLength != ctx.pc) Kit.codeBug();
             pc += icodeLength;
@@ -870,26 +870,26 @@ public final class Interpreter extends Icode implements Evaluator {
         switch (bytecode) {
             case Token.THROW:
             case Token.YIELD:
-            case Icode_YIELD_STAR:
-            case Icode_GENERATOR:
-            case Icode_GENERATOR_END:
-            case Icode_GENERATOR_RETURN:
+            case Icode.YIELD_STAR:
+            case Icode.GENERATOR:
+            case Icode.GENERATOR_END:
+            case Icode.GENERATOR_RETURN:
                 // source line
                 return 1 + 2;
 
-            case Icode_GOSUB:
+            case Icode.GOSUB:
             case Token.GOTO:
             case Token.IFEQ:
             case Token.IFNE:
-            case Icode_IFEQ_POP:
-            case Icode_IF_NULL_UNDEF:
-            case Icode_IF_NOT_NULL_UNDEF:
-            case Icode_LEAVEDQ:
+            case Icode.IFEQ_POP:
+            case Icode.IF_NULL_UNDEF:
+            case Icode.IF_NOT_NULL_UNDEF:
+            case Icode.LEAVEDQ:
                 // target pc offset
                 return 1 + 2;
 
-            case Icode_CALLSPECIAL:
-            case Icode_CALLSPECIAL_OPTIONAL:
+            case Icode.CALLSPECIAL:
+            case Icode.CALLSPECIAL_OPTIONAL:
                 // call type
                 // is new
                 // line number
@@ -899,85 +899,85 @@ public final class Interpreter extends Icode implements Evaluator {
                 // scope flag
                 return 1 + 1;
 
-            case Icode_VAR_INC_DEC:
-            case Icode_NAME_INC_DEC:
-            case Icode_PROP_INC_DEC:
-            case Icode_ELEM_INC_DEC:
-            case Icode_REF_INC_DEC:
+            case Icode.VAR_INC_DEC:
+            case Icode.NAME_INC_DEC:
+            case Icode.PROP_INC_DEC:
+            case Icode.ELEM_INC_DEC:
+            case Icode.REF_INC_DEC:
                 // type of ++/--
                 return 1 + 1;
 
-            case Icode_SHORTNUMBER:
+            case Icode.SHORTNUMBER:
                 // short number
                 return 1 + 2;
 
-            case Icode_INTNUMBER:
+            case Icode.INTNUMBER:
                 // int number
                 return 1 + 4;
 
-            case Icode_REG_IND1:
+            case Icode.REG_IND1:
                 // ubyte index
                 return 1 + 1;
 
-            case Icode_REG_IND2:
+            case Icode.REG_IND2:
                 // ushort index
                 return 1 + 2;
 
-            case Icode_REG_IND4:
+            case Icode.REG_IND4:
                 // int index
                 return 1 + 4;
 
-            case Icode_REG_STR1:
+            case Icode.REG_STR1:
                 // ubyte string index
                 return 1 + 1;
 
-            case Icode_REG_STR2:
+            case Icode.REG_STR2:
                 // ushort string index
                 return 1 + 2;
 
-            case Icode_REG_STR4:
+            case Icode.REG_STR4:
                 // int string index
                 return 1 + 4;
 
-            case Icode_GETVAR1:
-            case Icode_SETVAR1:
-            case Icode_SETCONSTVAR1:
+            case Icode.GETVAR1:
+            case Icode.SETVAR1:
+            case Icode.SETCONSTVAR1:
                 // byte var index
                 return 1 + 1;
 
-            case Icode_LINE:
+            case Icode.LINE:
                 // line number
                 return 1 + 2;
 
-            case Icode_LITERAL_NEW_OBJECT:
+            case Icode.LITERAL_NEW_OBJECT:
                 // make a copy or not flag
                 return 1 + 1;
 
-            case Icode_LITERAL_NEW_ARRAY:
+            case Icode.LITERAL_NEW_ARRAY:
                 // skip indexes ID (uint16)
                 return 1 + 2;
 
-            case Icode_SPREAD:
+            case Icode.SPREAD:
                 // 2-byte source position operand (always emitted, even when unused)
                 return 1 + 2;
 
-            case Icode_REG_BIGINT1:
+            case Icode.REG_BIGINT1:
                 // ubyte bigint index
                 return 1 + 1;
 
-            case Icode_REG_BIGINT2:
+            case Icode.REG_BIGINT2:
                 // ushort bigint index
                 return 1 + 2;
 
-            case Icode_REG_BIGINT4:
+            case Icode.REG_BIGINT4:
                 // uint bigint index
                 return 1 + 4;
 
-            case Icode_OBJECT_REST:
+            case Icode.OBJECT_REST:
                 // computedKeyCount byte
                 return 1 + 1;
         }
-        if (!validBytecode(bytecode)) throw Kit.codeBug();
+        if (!Icode.validBytecode(bytecode)) throw Kit.codeBug();
         return 1;
     }
 
@@ -1003,7 +1003,7 @@ public final class Interpreter extends Icode implements Evaluator {
         for (int pc = 0; pc != iCodeLength; ) {
             int bytecode = iCode[pc];
             int span = bytecodeSpan(bytecode);
-            if (bytecode == Icode_LINE) {
+            if (bytecode == Icode.LINE) {
                 if (span != 3) Kit.codeBug();
                 int line = getIndex(iCode, pc + 1);
                 presentLines.add(line);
@@ -1400,13 +1400,13 @@ public final class Interpreter extends Icode implements Evaluator {
     private static final InstructionClass[] instructionObjs;
 
     static {
-        instructionObjs = new InstructionClass[Token.LAST_BYTECODE_TOKEN + 1 - MIN_ICODE];
-        int base = -MIN_ICODE;
-        instructionObjs[base + Icode_GENERATOR] = new DoGenerator();
+        instructionObjs = new InstructionClass[Token.LAST_BYTECODE_TOKEN + 1 - Icode.MIN_ICODE];
+        int base = -Icode.MIN_ICODE;
+        instructionObjs[base + Icode.GENERATOR] = new DoGenerator();
         instructionObjs[base + Token.YIELD] = new DoYield();
-        instructionObjs[base + Icode_YIELD_STAR] = new DoYield();
-        instructionObjs[base + Icode_GENERATOR_END] = new DoGeneratorEnd();
-        instructionObjs[base + Icode_GENERATOR_RETURN] = new DoGeneratorReturn();
+        instructionObjs[base + Icode.YIELD_STAR] = new DoYield();
+        instructionObjs[base + Icode.GENERATOR_END] = new DoGeneratorEnd();
+        instructionObjs[base + Icode.GENERATOR_RETURN] = new DoGeneratorReturn();
         instructionObjs[base + Token.THROW] = new DoThrow();
         instructionObjs[base + Token.RETHROW] = new DoRethrow();
         instructionObjs[base + Token.GE] = new DoCompare();
@@ -1421,21 +1421,21 @@ public final class Interpreter extends Icode implements Evaluator {
         instructionObjs[base + Token.SHNE] = new DoShallowNotEquals();
         instructionObjs[base + Token.IFNE] = new DoIfNE();
         instructionObjs[base + Token.IFEQ] = new DoIfEQ();
-        instructionObjs[base + Icode_IFEQ_POP] = new DoIfEQPop();
-        instructionObjs[base + Icode_IF_NULL_UNDEF] = new DoIfNullUndef();
-        instructionObjs[base + Icode_IF_NOT_NULL_UNDEF] = new DoIfNotNullUndef();
+        instructionObjs[base + Icode.IFEQ_POP] = new DoIfEQPop();
+        instructionObjs[base + Icode.IF_NULL_UNDEF] = new DoIfNullUndef();
+        instructionObjs[base + Icode.IF_NOT_NULL_UNDEF] = new DoIfNotNullUndef();
         instructionObjs[base + Token.GOTO] = new DoGoto();
-        instructionObjs[base + Icode_GOSUB] = new DoGosub();
-        instructionObjs[base + Icode_STARTSUB] = new DoStartSub();
-        instructionObjs[base + Icode_RETSUB] = new DoRetsub();
-        instructionObjs[base + Icode_POP] = new DoPop();
-        instructionObjs[base + Icode_POP_RESULT] = new DoPopResult();
-        instructionObjs[base + Icode_DUP] = new DoDup();
-        instructionObjs[base + Icode_DUP2] = new DoDup2();
-        instructionObjs[base + Icode_SWAP] = new DoSwap();
+        instructionObjs[base + Icode.GOSUB] = new DoGosub();
+        instructionObjs[base + Icode.STARTSUB] = new DoStartSub();
+        instructionObjs[base + Icode.RETSUB] = new DoRetsub();
+        instructionObjs[base + Icode.POP] = new DoPop();
+        instructionObjs[base + Icode.POP_RESULT] = new DoPopResult();
+        instructionObjs[base + Icode.DUP] = new DoDup();
+        instructionObjs[base + Icode.DUP2] = new DoDup2();
+        instructionObjs[base + Icode.SWAP] = new DoSwap();
         instructionObjs[base + Token.RETURN] = new DoReturn();
         instructionObjs[base + Token.RETURN_RESULT] = new DoReturnResult();
-        instructionObjs[base + Icode_RETUNDEF] = new DoReturnUndef();
+        instructionObjs[base + Icode.RETUNDEF] = new DoReturnUndef();
         instructionObjs[base + Token.BITNOT] = new DoBitNot();
         instructionObjs[base + Token.BITAND] = new DoBitOp();
         instructionObjs[base + Token.BITOR] = new DoBitOp();
@@ -1456,68 +1456,68 @@ public final class Interpreter extends Icode implements Evaluator {
         instructionObjs[base + Token.STRICT_SETNAME] = new DoSetName();
         instructionObjs[base + Token.STRING_CONCAT] = new DoStringConcat();
         instructionObjs[base + Token.SETNAME] = new DoSetName();
-        instructionObjs[base + Icode_SETCONST] = new DoSetConst();
+        instructionObjs[base + Icode.SETCONST] = new DoSetConst();
         instructionObjs[base + Token.DELPROP] = new DoDelName();
-        instructionObjs[base + Icode_DELNAME] = new DoDelName();
-        instructionObjs[base + Icode_DELPROP_SUPER] = new DoDelPropSuper();
+        instructionObjs[base + Icode.DELNAME] = new DoDelName();
+        instructionObjs[base + Icode.DELPROP_SUPER] = new DoDelPropSuper();
         instructionObjs[base + Token.GETPROPNOWARN] = new DoGetPropNoWarn();
         instructionObjs[base + Token.GETPROP] = new DoGetProp();
         instructionObjs[base + Token.GETPROP_SUPER] = new DoGetPropSuper();
         instructionObjs[base + Token.GETPROPNOWARN_SUPER] = new DoGetPropSuper();
         instructionObjs[base + Token.SETPROP] = new DoSetProp();
         instructionObjs[base + Token.SETPROP_SUPER] = new DoSetPropSuper();
-        instructionObjs[base + Icode_PROP_INC_DEC] = new DoPropIncDec();
+        instructionObjs[base + Icode.PROP_INC_DEC] = new DoPropIncDec();
         instructionObjs[base + Token.GETELEM] = new DoGetElem();
         instructionObjs[base + Token.GETELEM_SUPER] = new DoGetElemSuper();
         instructionObjs[base + Token.SETELEM] = new DoSetElem();
         instructionObjs[base + Token.SETELEM_SUPER] = new DoSetElemSuper();
-        instructionObjs[base + Icode_ELEM_INC_DEC] = new DoElemIncDec();
+        instructionObjs[base + Icode.ELEM_INC_DEC] = new DoElemIncDec();
         instructionObjs[base + Token.GET_REF] = new DoGetRef();
         instructionObjs[base + Token.SET_REF] = new DoSetRef();
         instructionObjs[base + Token.DEL_REF] = new DoDelRef();
-        instructionObjs[base + Icode_REF_INC_DEC] = new DoRefIncDec();
+        instructionObjs[base + Icode.REF_INC_DEC] = new DoRefIncDec();
         instructionObjs[base + Token.LOCAL_LOAD] = new DoLocalLoad();
-        instructionObjs[base + Icode_LOCAL_CLEAR] = new DoLocalClear();
-        instructionObjs[base + Icode_NAME_AND_THIS] = new DoNameAndThis();
-        instructionObjs[base + Icode_NAME_AND_THIS_OPTIONAL] = new DoNameAndThisOptional();
-        instructionObjs[base + Icode_PROP_AND_THIS] = new DoPropAndThis();
-        instructionObjs[base + Icode_PROP_AND_THIS_OPTIONAL] = new DoPropAndThisOptional();
-        instructionObjs[base + Icode_ELEM_AND_THIS] = new DoElemAndThis();
-        instructionObjs[base + Icode_ELEM_AND_THIS_OPTIONAL] = new DoElemAndThisOptional();
-        instructionObjs[base + Icode_VALUE_AND_THIS] = new DoValueAndThis();
-        instructionObjs[base + Icode_VALUE_AND_THIS_OPTIONAL] = new DoValueAndThisOptional();
-        instructionObjs[base + Icode_CALLSPECIAL] = new DoCallSpecial();
-        instructionObjs[base + Icode_CALLSPECIAL_OPTIONAL] = new DoCallSpecial();
+        instructionObjs[base + Icode.LOCAL_CLEAR] = new DoLocalClear();
+        instructionObjs[base + Icode.NAME_AND_THIS] = new DoNameAndThis();
+        instructionObjs[base + Icode.NAME_AND_THIS_OPTIONAL] = new DoNameAndThisOptional();
+        instructionObjs[base + Icode.PROP_AND_THIS] = new DoPropAndThis();
+        instructionObjs[base + Icode.PROP_AND_THIS_OPTIONAL] = new DoPropAndThisOptional();
+        instructionObjs[base + Icode.ELEM_AND_THIS] = new DoElemAndThis();
+        instructionObjs[base + Icode.ELEM_AND_THIS_OPTIONAL] = new DoElemAndThisOptional();
+        instructionObjs[base + Icode.VALUE_AND_THIS] = new DoValueAndThis();
+        instructionObjs[base + Icode.VALUE_AND_THIS_OPTIONAL] = new DoValueAndThisOptional();
+        instructionObjs[base + Icode.CALLSPECIAL] = new DoCallSpecial();
+        instructionObjs[base + Icode.CALLSPECIAL_OPTIONAL] = new DoCallSpecial();
         instructionObjs[base + Token.CALL] = new DoCallByteCode();
-        instructionObjs[base + Icode_CALL_ON_SUPER] = new DoCallByteCode();
-        instructionObjs[base + Icode_TAIL_CALL] = new DoCallByteCode();
+        instructionObjs[base + Icode.CALL_ON_SUPER] = new DoCallByteCode();
+        instructionObjs[base + Icode.TAIL_CALL] = new DoCallByteCode();
         instructionObjs[base + Token.REF_CALL] = new DoCallByteCode();
         instructionObjs[base + Token.NEW] = new DoNew();
         instructionObjs[base + Token.TYPEOF] = new DoTypeOf();
-        instructionObjs[base + Icode_TYPEOFNAME] = new DoTypeOfName();
+        instructionObjs[base + Icode.TYPEOFNAME] = new DoTypeOfName();
         instructionObjs[base + Token.STRING] = new DoString();
-        instructionObjs[base + Icode_SHORTNUMBER] = new DoShortNumber();
-        instructionObjs[base + Icode_INTNUMBER] = new DoIntNumber();
+        instructionObjs[base + Icode.SHORTNUMBER] = new DoShortNumber();
+        instructionObjs[base + Icode.INTNUMBER] = new DoIntNumber();
         instructionObjs[base + Token.NUMBER] = new DoNumber();
         instructionObjs[base + Token.BIGINT] = new DoBigInt();
         instructionObjs[base + Token.NAME] = new DoName();
-        instructionObjs[base + Icode_NAME_INC_DEC] = new DoNameIncDec();
-        instructionObjs[base + Icode_SETCONSTVAR1] = new DoSetConstVar1();
-        instructionObjs[base + Icode_SETCONSTVAR] = new DoSetConstVar();
-        instructionObjs[base + Icode_SETVAR1] = new DoSetVar1();
+        instructionObjs[base + Icode.NAME_INC_DEC] = new DoNameIncDec();
+        instructionObjs[base + Icode.SETCONSTVAR1] = new DoSetConstVar1();
+        instructionObjs[base + Icode.SETCONSTVAR] = new DoSetConstVar();
+        instructionObjs[base + Icode.SETVAR1] = new DoSetVar1();
         instructionObjs[base + Token.SETVAR] = new DoSetVar();
-        instructionObjs[base + Icode_GETVAR1] = new DoGetVar1();
+        instructionObjs[base + Icode.GETVAR1] = new DoGetVar1();
         instructionObjs[base + Token.GETVAR] = new DoGetVar();
-        instructionObjs[base + Icode_VAR_INC_DEC] = new DoVarIncDec();
-        instructionObjs[base + Icode_ZERO] = new DoZero();
-        instructionObjs[base + Icode_ONE] = new DoOne();
+        instructionObjs[base + Icode.VAR_INC_DEC] = new DoVarIncDec();
+        instructionObjs[base + Icode.ZERO] = new DoZero();
+        instructionObjs[base + Icode.ONE] = new DoOne();
         instructionObjs[base + Token.NULL] = new DoNull();
         instructionObjs[base + Token.THIS] = new DoThis();
         instructionObjs[base + Token.SUPER] = new DoSuper();
         instructionObjs[base + Token.THISFN] = new DoThisFunction();
         instructionObjs[base + Token.FALSE] = new DoFalse();
         instructionObjs[base + Token.TRUE] = new DoTrue();
-        instructionObjs[base + Icode_UNDEF] = new DoUndef();
+        instructionObjs[base + Icode.UNDEF] = new DoUndef();
         instructionObjs[base + Token.ENTERWITH] = new DoEnterWith();
         instructionObjs[base + Token.LEAVEWITH] = new DoLeaveWith();
         instructionObjs[base + Token.CATCH_SCOPE] = new DoCatchScope();
@@ -1533,54 +1533,54 @@ public final class Interpreter extends Icode implements Evaluator {
         instructionObjs[base + Token.REF_NS_MEMBER] = new DoRefNsMember();
         instructionObjs[base + Token.REF_NAME] = new DoRefName();
         instructionObjs[base + Token.REF_NS_NAME] = new DoRefNsName();
-        instructionObjs[base + Icode_SCOPE_LOAD] = new DoScopeLoad();
-        instructionObjs[base + Icode_SCOPE_SAVE] = new DoScopeSave();
-        instructionObjs[base + Icode_SPREAD] = new DoSpread();
-        instructionObjs[base + Icode_OBJECT_REST] = new DoObjectRest();
-        instructionObjs[base + Icode_CLOSURE_EXPR] = new DoClosureExpr();
-        instructionObjs[base + Icode_METHOD_EXPR] = new DoMethodExpr();
-        instructionObjs[base + Icode_CLOSURE_STMT] = new DoClosureStatement();
+        instructionObjs[base + Icode.SCOPE_LOAD] = new DoScopeLoad();
+        instructionObjs[base + Icode.SCOPE_SAVE] = new DoScopeSave();
+        instructionObjs[base + Icode.SPREAD] = new DoSpread();
+        instructionObjs[base + Icode.OBJECT_REST] = new DoObjectRest();
+        instructionObjs[base + Icode.CLOSURE_EXPR] = new DoClosureExpr();
+        instructionObjs[base + Icode.METHOD_EXPR] = new DoMethodExpr();
+        instructionObjs[base + Icode.CLOSURE_STMT] = new DoClosureStatement();
         instructionObjs[base + Token.REGEXP] = new DoRegExp();
-        instructionObjs[base + Icode_TEMPLATE_LITERAL_CALLSITE] = new DoTemplateLiteralCallSite();
-        instructionObjs[base + Icode_LITERAL_NEW_OBJECT] = new DoLiteralNewObject();
-        instructionObjs[base + Icode_LITERAL_NEW_ARRAY] = new DoLiteralNewArray();
-        instructionObjs[base + Icode_LITERAL_SET] = new DoLiteralSet();
-        instructionObjs[base + Icode_LITERAL_GETTER] = new DoLiteralGetter();
-        instructionObjs[base + Icode_LITERAL_SETTER] = new DoLiteralSetter();
-        instructionObjs[base + Icode_LITERAL_KEY_SET] = new DoLiteralKeySet();
+        instructionObjs[base + Icode.TEMPLATE_LITERAL_CALLSITE] = new DoTemplateLiteralCallSite();
+        instructionObjs[base + Icode.LITERAL_NEW_OBJECT] = new DoLiteralNewObject();
+        instructionObjs[base + Icode.LITERAL_NEW_ARRAY] = new DoLiteralNewArray();
+        instructionObjs[base + Icode.LITERAL_SET] = new DoLiteralSet();
+        instructionObjs[base + Icode.LITERAL_GETTER] = new DoLiteralGetter();
+        instructionObjs[base + Icode.LITERAL_SETTER] = new DoLiteralSetter();
+        instructionObjs[base + Icode.LITERAL_KEY_SET] = new DoLiteralKeySet();
         instructionObjs[base + Token.OBJECTLIT] = new DoObjectLit();
         instructionObjs[base + Token.ARRAYLIT] = new DoArrayLiteral();
-        instructionObjs[base + Icode_SPARE_ARRAYLIT] = new DoArrayLiteral();
-        instructionObjs[base + Icode_ENTERDQ] = new DoEnterDotQuery();
-        instructionObjs[base + Icode_LEAVEDQ] = new DoLeaveDotQuery();
+        instructionObjs[base + Icode.SPARE_ARRAYLIT] = new DoArrayLiteral();
+        instructionObjs[base + Icode.ENTERDQ] = new DoEnterDotQuery();
+        instructionObjs[base + Icode.LEAVEDQ] = new DoLeaveDotQuery();
         instructionObjs[base + Token.DEFAULTNAMESPACE] = new DoDefaultNamespace();
         instructionObjs[base + Token.ESCXMLATTR] = new DoEscXMLAttr();
         instructionObjs[base + Token.ESCXMLTEXT] = new DoEscXMLText();
-        instructionObjs[base + Icode_DEBUGGER] = new DoDebug();
-        instructionObjs[base + Icode_LINE] = new DoLineChange();
-        instructionObjs[base + Icode_REG_IND_C0] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND_C1] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND_C2] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND_C3] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND_C4] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND_C5] = new DoIndexCn();
-        instructionObjs[base + Icode_REG_IND1] = new DoRegIndex1();
-        instructionObjs[base + Icode_REG_IND2] = new DoRegIndex2();
-        instructionObjs[base + Icode_REG_IND4] = new DoRegIndex4();
-        instructionObjs[base + Icode_REG_STR_C0] = new DoStringCn();
-        instructionObjs[base + Icode_REG_STR_C1] = new DoStringCn();
-        instructionObjs[base + Icode_REG_STR_C2] = new DoStringCn();
-        instructionObjs[base + Icode_REG_STR_C3] = new DoStringCn();
-        instructionObjs[base + Icode_REG_STR1] = new DoRegString1();
-        instructionObjs[base + Icode_REG_STR2] = new DoRegString2();
-        instructionObjs[base + Icode_REG_STR4] = new DoRegString4();
-        instructionObjs[base + Icode_REG_BIGINT_C0] = new DoBigIntCn();
-        instructionObjs[base + Icode_REG_BIGINT_C1] = new DoBigIntCn();
-        instructionObjs[base + Icode_REG_BIGINT_C2] = new DoBigIntCn();
-        instructionObjs[base + Icode_REG_BIGINT_C3] = new DoBigIntCn();
-        instructionObjs[base + Icode_REG_BIGINT1] = new DoRegBigInt1();
-        instructionObjs[base + Icode_REG_BIGINT2] = new DoRegBigInt2();
-        instructionObjs[base + Icode_REG_BIGINT4] = new DoRegBigInt4();
+        instructionObjs[base + Icode.DEBUGGER] = new DoDebug();
+        instructionObjs[base + Icode.LINE] = new DoLineChange();
+        instructionObjs[base + Icode.REG_IND_C0] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND_C1] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND_C2] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND_C3] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND_C4] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND_C5] = new DoIndexCn();
+        instructionObjs[base + Icode.REG_IND1] = new DoRegIndex1();
+        instructionObjs[base + Icode.REG_IND2] = new DoRegIndex2();
+        instructionObjs[base + Icode.REG_IND4] = new DoRegIndex4();
+        instructionObjs[base + Icode.REG_STR_C0] = new DoStringCn();
+        instructionObjs[base + Icode.REG_STR_C1] = new DoStringCn();
+        instructionObjs[base + Icode.REG_STR_C2] = new DoStringCn();
+        instructionObjs[base + Icode.REG_STR_C3] = new DoStringCn();
+        instructionObjs[base + Icode.REG_STR1] = new DoRegString1();
+        instructionObjs[base + Icode.REG_STR2] = new DoRegString2();
+        instructionObjs[base + Icode.REG_STR4] = new DoRegString4();
+        instructionObjs[base + Icode.REG_BIGINT_C0] = new DoBigIntCn();
+        instructionObjs[base + Icode.REG_BIGINT_C1] = new DoBigIntCn();
+        instructionObjs[base + Icode.REG_BIGINT_C2] = new DoBigIntCn();
+        instructionObjs[base + Icode.REG_BIGINT_C3] = new DoBigIntCn();
+        instructionObjs[base + Icode.REG_BIGINT1] = new DoRegBigInt1();
+        instructionObjs[base + Icode.REG_BIGINT2] = new DoRegBigInt2();
+        instructionObjs[base + Icode.REG_BIGINT4] = new DoRegBigInt4();
     }
 
     private static Object interpretLoop(Context cx, CallFrame frame, Object throwable) {
@@ -1862,7 +1862,7 @@ public final class Interpreter extends Icode implements Evaluator {
                     // exception handler
                     int op = iCode[frame.pc++];
 
-                    var insn = instructionObjs[-MIN_ICODE + op];
+                    var insn = instructionObjs[-Icode.MIN_ICODE + op];
 
                     nextState = insn.execute(cx, frame, state, op);
                 } while (nextState == null);
@@ -1928,7 +1928,7 @@ public final class Interpreter extends Icode implements Evaluator {
             if (!frame.frozen) {
                 return new YieldResult(
                         freezeGenerator(
-                                cx, frame, state, state.generatorState, op == Icode_YIELD_STAR));
+                                cx, frame, state, state.generatorState, op == Icode.YIELD_STAR));
             }
             Object obj = thawGenerator(frame, state, state.generatorState, op);
             if (obj != Scriptable.NOT_FOUND) {
@@ -2012,7 +2012,7 @@ public final class Interpreter extends Icode implements Evaluator {
             return generatorState.value;
         }
         if (generatorState.operation != NativeGenerator.GENERATOR_SEND) throw Kit.codeBug();
-        if ((op == Token.YIELD) || (op == Icode_YIELD_STAR)) {
+        if ((op == Token.YIELD) || (op == Icode.YIELD_STAR)) {
             frame.stack[state.stackTop] = generatorState.value;
         }
         return Scriptable.NOT_FOUND;
@@ -2027,7 +2027,7 @@ public final class Interpreter extends Icode implements Evaluator {
             if (!frame.frozen) {
                 return new YieldResult(
                         freezeGenerator(
-                                cx, frame, state, state.generatorState, op == Icode_YIELD_STAR));
+                                cx, frame, state, state.generatorState, op == Icode.YIELD_STAR));
             }
             Object obj = thawGenerator(frame, state, state.generatorState, op);
             if (obj != Scriptable.NOT_FOUND) {
@@ -2411,7 +2411,7 @@ public final class Interpreter extends Icode implements Evaluator {
             final double[] sDbl = frame.sDbl;
             final InterpreterData iData = frame.idata;
             if (state.stackTop == frame.emptyStackTop + 1) {
-                // Call from Icode_GOSUB: store return PC address in the local
+                // Call from Icode.GOSUB: store return PC address in the local
                 state.indexReg += iData.itsMaxVars;
                 stack[state.indexReg] = stack[state.stackTop];
                 sDbl[state.indexReg] = sDbl[state.stackTop];
@@ -2914,7 +2914,7 @@ public final class Interpreter extends Icode implements Evaluator {
             Object lhs = frame.stack[state.stackTop];
             if (lhs == DOUBLE_MARK) lhs = ScriptRuntime.wrapNumber(frame.sDbl[state.stackTop]);
             frame.stack[state.stackTop] =
-                    ScriptRuntime.delete(lhs, rhs, cx, frame.scope, op == Icode_DELNAME);
+                    ScriptRuntime.delete(lhs, rhs, cx, frame.scope, op == Icode.DELNAME);
             return null;
         }
     }
@@ -3335,7 +3335,7 @@ public final class Interpreter extends Icode implements Evaluator {
             Object[] stack = frame.stack;
             double[] sDbl = frame.sDbl;
             byte[] iCode = frame.idata.itsICode;
-            boolean isOptionalChainingCall = (op == Icode_CALLSPECIAL_OPTIONAL);
+            boolean isOptionalChainingCall = (op == Icode.CALLSPECIAL_OPTIONAL);
 
             if (state.instructionCounting) {
                 cx.instructionCount += INVOCATION_COST;
@@ -3414,7 +3414,7 @@ public final class Interpreter extends Icode implements Evaluator {
             Scriptable funThisObj = result.getThis();
             Scriptable funHomeObj =
                     (fun instanceof BaseFunction) ? ((BaseFunction) fun).getHomeObject() : null;
-            if (op == Icode_CALL_ON_SUPER) {
+            if (op == Icode.CALL_ON_SUPER) {
                 // funThisObj would have been the "super" object, which we
                 // used to lookup the function. Now that that's done, we
                 // discard it and invoke the function with the current
@@ -3555,7 +3555,7 @@ public final class Interpreter extends Icode implements Evaluator {
                 if (frame.fnOrScript.getDescriptor().getSecurityDomain()
                         == desc.getSecurityDomain()) {
                     CallFrame callParentFrame = frame;
-                    if (op == Icode_TAIL_CALL) {
+                    if (op == Icode.TAIL_CALL) {
                         // In principle tail call can re-use the current
                         // frame and its stack arrays but it is hard to
                         // do properly. Any exceptions that can legally
@@ -3594,7 +3594,7 @@ public final class Interpreter extends Icode implements Evaluator {
                                     ifun,
                                     idata,
                                     callParentFrame);
-                    if (op != Icode_TAIL_CALL) {
+                    if (op != Icode.TAIL_CALL) {
                         frame.savedStackTop = state.stackTop;
                         frame.savedCallOp = op;
                     }
@@ -4586,7 +4586,7 @@ public final class Interpreter extends Icode implements Evaluator {
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
             var store = (NewLiteralStorage) frame.stack[state.stackTop];
             int[] skipIndexes = null;
-            if (op == Icode_SPARE_ARRAYLIT) {
+            if (op == Icode.SPARE_ARRAYLIT) {
                 skipIndexes = store.getAdjustedSkipIndexes();
                 if (skipIndexes == null) {
                     skipIndexes = (int[]) frame.idata.literalIds[state.indexReg];
@@ -4599,7 +4599,7 @@ public final class Interpreter extends Icode implements Evaluator {
 
         @Override
         void dumpICode(int op, String tname, ICodeDumpContext ctx) {
-            if (op == Icode_SPARE_ARRAYLIT) {
+            if (op == Icode.SPARE_ARRAYLIT) {
                 ctx.out.println(tname + " " + ctx.idata.literalIds[ctx.indexReg]);
             } else {
                 ctx.out.println(tname);
@@ -4705,13 +4705,13 @@ public final class Interpreter extends Icode implements Evaluator {
     private static class DoIndexCn extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.indexReg = Icode_REG_IND_C0 - op;
+            state.indexReg = Icode.REG_IND_C0 - op;
             return null;
         }
 
         @Override
         void dumpICode(int op, String tname, ICodeDumpContext ctx) {
-            ctx.indexReg = Icode_REG_IND_C0 - op;
+            ctx.indexReg = Icode.REG_IND_C0 - op;
             ctx.out.println(tname);
         }
     }
@@ -4767,13 +4767,13 @@ public final class Interpreter extends Icode implements Evaluator {
     private static class DoStringCn extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.stringReg = frame.idata.itsStringTable[Icode_REG_STR_C0 - op];
+            state.stringReg = frame.idata.itsStringTable[Icode.REG_STR_C0 - op];
             return null;
         }
 
         @Override
         void dumpICode(int op, String tname, ICodeDumpContext ctx) {
-            String str = ctx.idata.itsStringTable[Icode_REG_STR_C0 - op];
+            String str = ctx.idata.itsStringTable[Icode.REG_STR_C0 - op];
             ctx.out.println(tname + " \"" + str + '"');
         }
     }
@@ -4829,7 +4829,7 @@ public final class Interpreter extends Icode implements Evaluator {
     private static class DoBigIntCn extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.bigIntReg = frame.idata.itsBigIntTable[Icode_REG_BIGINT_C0 - op];
+            state.bigIntReg = frame.idata.itsBigIntTable[Icode.REG_BIGINT_C0 - op];
             return null;
         }
 
@@ -4838,7 +4838,7 @@ public final class Interpreter extends Icode implements Evaluator {
             ctx.out.println(
                     tname
                             + " "
-                            + ctx.idata.itsBigIntTable[Icode_REG_BIGINT_C0 - op].toString()
+                            + ctx.idata.itsBigIntTable[Icode.REG_BIGINT_C0 - op].toString()
                             + 'n');
         }
     }
@@ -5138,7 +5138,7 @@ public final class Interpreter extends Icode implements Evaluator {
     }
 
     private static void setCallResult(CallFrame frame, Object callResult, double callResultDbl) {
-        if (frame.savedCallOp == Token.CALL || frame.savedCallOp == Icode_CALL_ON_SUPER) {
+        if (frame.savedCallOp == Token.CALL || frame.savedCallOp == Icode.CALL_ON_SUPER) {
             frame.stack[frame.savedStackTop] = callResult;
             frame.sDbl[frame.savedStackTop] = callResultDbl;
         } else if (frame.savedCallOp == Token.NEW) {
@@ -5177,7 +5177,7 @@ public final class Interpreter extends Icode implements Evaluator {
                 x.stack[i] = null;
                 x.stackAttributes[i] = ScriptableObject.EMPTY;
             }
-            if (x.savedCallOp == Token.CALL || x.savedCallOp == Icode_CALL_ON_SUPER) {
+            if (x.savedCallOp == Token.CALL || x.savedCallOp == Icode.CALL_ON_SUPER) {
                 // the call will always overwrite the stack top with the result
                 x.stack[x.savedStackTop] = null;
             } else {

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectLiteralSpreadBytecodeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/ObjectLiteralSpreadBytecodeTest.java
@@ -7,10 +7,10 @@ import org.mozilla.javascript.*;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
- * Regression tests for fixed-width Icode_SPREAD encoding in object literals.
+ * Regression tests for fixed-width Icode.SPREAD encoding in object literals.
  *
- * <p>visitObjectLiteralWithSpread() emitted Icode_SPREAD with no operand bytes. Once
- * bytecodeSpan(Icode_SPREAD) was fixed to return 1+2, the linear bytecode scanners would skip 2
+ * <p>visitObjectLiteralWithSpread() emitted Icode.SPREAD with no operand bytes. Once
+ * bytecodeSpan(Icode.SPREAD) was fixed to return 1+2, the linear bytecode scanners would skip 2
  * extra bytes after every object spread, misreading real opcodes as operand data.
  *
  * <p>The desync is tested indirectly: if bytecodeSpan is wrong, instructions after the spread are
@@ -68,7 +68,7 @@ public class ObjectLiteralSpreadBytecodeTest {
 
     // ------------------------------------------------------------------
     // 2. Code *after* the spread must execute correctly.
-    //    If bytecodeSpan(Icode_SPREAD) returns 1 instead of 3, the 2
+    //    If bytecodeSpan(Icode.SPREAD) returns 1 instead of 3, the 2
     //    operand bytes of the now-unconditional uint16 are misread as
     //    the next opcode(s), breaking any computation that follows.
     // ------------------------------------------------------------------
@@ -121,9 +121,9 @@ public class ObjectLiteralSpreadBytecodeTest {
     }
 
     // ------------------------------------------------------------------
-    // 3. Error line numbers: pcSourceLineStart is driven by Icode_LINE
+    // 3. Error line numbers: pcSourceLineStart is driven by Icode.LINE
     //    instructions found via bytecodeSpan(). If the span for
-    //    Icode_SPREAD is wrong, the line counter drifts.
+    //    Icode.SPREAD is wrong, the line counter drifts.
     // ------------------------------------------------------------------
 
     @Test
@@ -134,7 +134,7 @@ public class ObjectLiteralSpreadBytecodeTest {
             cx.evaluateString(
                     cx.initStandardObjects(),
                     "var a = {x:1};\n" // line 1
-                            + "var b = {...a};\n" // line 2 (Icode_SPREAD here)
+                            + "var b = {...a};\n" // line 2 (Icode.SPREAD here)
                             + "undefinedVar;\n", // line 3 ← must be reported
                     "test",
                     1,
@@ -145,7 +145,7 @@ public class ObjectLiteralSpreadBytecodeTest {
                     3,
                     e.lineNumber(),
                     "ReferenceError must be on line 3; "
-                            + "wrong line means bytecodeSpan(Icode_SPREAD) is incorrect");
+                            + "wrong line means bytecodeSpan(Icode.SPREAD) is incorrect");
         } finally {
             Context.exit();
         }
@@ -160,7 +160,7 @@ public class ObjectLiteralSpreadBytecodeTest {
                     cx.initStandardObjects(),
                     "var a = {x:1};\n" // line 1
                             + "var b = {y:2};\n" // line 2
-                            + "var c = {...a,...b};\n" // line 3 (two Icode_SPREADs)
+                            + "var c = {...a,...b};\n" // line 3 (two Icode.SPREADs)
                             + "undefinedVar;\n", // line 4 ← must be reported
                     "test",
                     1,
@@ -183,8 +183,8 @@ public class ObjectLiteralSpreadBytecodeTest {
                     cx.initStandardObjects(),
                     "var obj = {x:1};\n" // line 1
                             + "var arr = [1,2];\n" // line 2
-                            + "var o2 = {...obj, y:2};\n" // line 3 (object Icode_SPREAD)
-                            + "var a2 = [...arr, 3];\n" // line 4 (array Icode_SPREAD)
+                            + "var o2 = {...obj, y:2};\n" // line 3 (object Icode.SPREAD)
+                            + "var a2 = [...arr, 3];\n" // line 4 (array Icode.SPREAD)
                             + "undefinedVar;\n", // line 5 ← must be reported
                     "test",
                     1,

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/SpreadSparseArrayBytecodeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/SpreadSparseArrayBytecodeTest.java
@@ -7,10 +7,10 @@ import org.mozilla.javascript.*;
 import org.mozilla.javascript.testutils.Utils;
 
 /**
- * Regression tests for fixed-width Icode_SPREAD encoding in sparse array literals.
+ * Regression tests for fixed-width Icode.SPREAD encoding in sparse array literals.
  *
- * <p>Before the fix, Icode_SPREAD inside a sparse array literal emitted a conditional 2-byte
- * operand — present only when skipIndexes != null. bytecodeSpan(Icode_SPREAD) returned 1, so
+ * <p>Before the fix, Icode.SPREAD inside a sparse array literal emitted a conditional 2-byte
+ * operand — present only when skipIndexes != null. bytecodeSpan(Icode.SPREAD) returned 1, so
  * getLineNumbers() and dumpICode() were out of sync for any script containing a spread inside a
  * sparse array.
  *
@@ -50,7 +50,7 @@ public class SpreadSparseArrayBytecodeTest {
 
     // ------------------------------------------------------------------
     // 2. Code *after* the spread must execute correctly.
-    //    If bytecodeSpan(Icode_SPREAD) returns 1 instead of 3, the 2
+    //    If bytecodeSpan(Icode.SPREAD) returns 1 instead of 3, the 2
     //    operand bytes are misread as the next opcode(s), breaking any
     //    computation that follows.
     // ------------------------------------------------------------------
@@ -88,7 +88,7 @@ public class SpreadSparseArrayBytecodeTest {
 
     @Test
     public void testTwoSparseSpreadsBytecodeConsistent() {
-        // Two Icode_SPREAD instructions: 4 extra bytes if span == 1.
+        // Two Icode.SPREAD instructions: 4 extra bytes if span == 1.
         Utils.assertWithAllModes_ES6(
                 "10/absent/20",
                 "var a = [...[10], , ...[20]];\n"
@@ -109,7 +109,7 @@ public class SpreadSparseArrayBytecodeTest {
             cx.setLanguageVersion(Context.VERSION_ES6);
             cx.evaluateString(
                     cx.initStandardObjects(),
-                    "var a = [...[1], , 2];\n" // line 1 (Icode_SPREAD here)
+                    "var a = [...[1], , 2];\n" // line 1 (Icode.SPREAD here)
                             + "undefinedVar;\n", // line 2 ← must be reported
                     "test",
                     1,
@@ -120,7 +120,7 @@ public class SpreadSparseArrayBytecodeTest {
                     2,
                     e.lineNumber(),
                     "ReferenceError must be on line 2; "
-                            + "wrong line means bytecodeSpan(Icode_SPREAD) is incorrect");
+                            + "wrong line means bytecodeSpan(Icode.SPREAD) is incorrect");
         } finally {
             Context.exit();
         }
@@ -161,8 +161,8 @@ public class SpreadSparseArrayBytecodeTest {
                     cx.initStandardObjects(),
                     "var obj = {x:1};\n" // line 1
                             + "var arr = [1,2];\n" // line 2
-                            + "var sparse = [...arr, , 9];\n" // line 3 (array Icode_SPREAD)
-                            + "var merged = {...obj, y:2};\n" // line 4 (object Icode_SPREAD)
+                            + "var sparse = [...arr, , 9];\n" // line 3 (array Icode.SPREAD)
+                            + "var merged = {...obj, y:2};\n" // line 4 (object Icode.SPREAD)
                             + "undefinedVar;\n", // line 5 ← must be reported
                     "test",
                     1,


### PR DESCRIPTION
Next bit of prep for #2426.

`CodeGenerator` and `Interpreter` both inherited from `Icode` as an old trick to avoid large numbers of static imports. As part of introducing a new interpreter we want to be able to inherit from an abstract class which itself should not inherit from `Icode`.

I chose to fix this by removing all the initial `Icode_` prefixes. This allows all the use sites to change simply from `Icode_THING` to `Icode.THING` and avoids either starred static imports or large numbers of static imports.