### PR TITLE
Fix enter and exit of frames under generators to be matched pairs.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -1659,6 +1659,7 @@ public final class Interpreter extends Icode implements Evaluator {
                         interpreterResultDbl = frame.resultDbl;
                         break StateLoop;
                     } else if (result instanceof YieldResult) {
+                        exitFrame(cx, frame, null);
                         return ((YieldResult) result).yielding;
                     } else if (result instanceof ThrowableResult) {
                         ThrowableResult tr = (ThrowableResult) result;
@@ -1983,7 +1984,6 @@ public final class Interpreter extends Icode implements Evaluator {
         frame.resultDbl = frame.sDbl[state.stackTop];
         frame.savedStackTop = state.stackTop;
         frame.pc--; // we want to come back here when we resume
-        ScriptRuntime.exitActivationFunction(cx);
         final Object result =
                 (frame.result != DOUBLE_MARK)
                         ? frame.result

--- a/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/DebuggerTest.java
@@ -26,14 +26,28 @@ public class DebuggerTest {
                     + "\n"
                     + "new ScriptDebuggerTest().debug()";
 
+    private static final String GENERATOR_SCRIPT =
+            """
+                function *f() {
+                    for (var i = 0; i < 2; i++) {
+                        yield i;
+                    }
+                }
+
+                var iter = f.apply('hello');
+                var n = iter.next();
+                while (!n.done) {
+                    n = iter.next();
+                }""";
+
     static final int NUM_BREAKPOINTS = 10;
     static final int NUM_FRAMES = 3;
 
     private static class MockDebugger implements Debugger {
 
-        private static MockDebugFrame frame;
+        private MockDebugFrame frame;
 
-        public static synchronized MockDebugFrame getFrame() {
+        public synchronized MockDebugFrame getFrame() {
             if (frame == null) frame = new MockDebugFrame();
             return frame;
         }
@@ -48,6 +62,8 @@ public class DebuggerTest {
 
         private int breakPointsHit = 0;
         private ArrayList<Set<String>> frameIds = new ArrayList<>();
+
+        private ArrayList<String> events = new ArrayList<>();
 
         public int getBreakPointsHit() {
             return breakPointsHit;
@@ -73,13 +89,19 @@ public class DebuggerTest {
                 names.add(id.toString());
             }
             frameIds.add(names);
+            events.add(String.format("Enter %s", thisObj));
+        }
+
+        @Override
+        public void onExit(Context cx, boolean byThrow, Object resultOrException) {
+            events.add("Exit");
         }
     }
 
     @Test
     public void testThis() {
         MockDebugger debugger = new MockDebugger();
-        MockDebugFrame frame = MockDebugger.getFrame();
+        MockDebugFrame frame = debugger.getFrame();
         Context cx = Context.enter();
         TopLevel scope = cx.initSafeStandardObjects();
         try {
@@ -111,6 +133,38 @@ public class DebuggerTest {
                     Set.of("x", "y"),
                     frame.getFrameIds().get(2),
                     "The second frame to be {`x`, 'y'}");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            Context.exit();
+        }
+    }
+
+    @Test
+    public void testGenerator() {
+        MockDebugger debugger = new MockDebugger();
+        MockDebugFrame frame = debugger.getFrame();
+        Context cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        TopLevel scope = cx.initSafeStandardObjects();
+        try {
+            cx.setDebugger(debugger, cx);
+            cx.setGeneratingSource(true);
+            cx.setGeneratingDebug(true);
+            cx.setEvaluationMethod(EvaluationMethod.Interpreter);
+            Script script = cx.compileString(GENERATOR_SCRIPT, "this-klass", 0, null);
+            script.exec(cx, scope, scope.getGlobalThis());
+            Assertions.assertEquals(10, frame.events.size());
+            Assertions.assertEquals("Enter", frame.events.get(0).substring(0, 5));
+            Assertions.assertEquals("Enter hello", frame.events.get(1));
+            Assertions.assertEquals("Exit", frame.events.get(2));
+            Assertions.assertEquals("Enter hello", frame.events.get(3));
+            Assertions.assertEquals("Exit", frame.events.get(4));
+            Assertions.assertEquals("Enter hello", frame.events.get(5));
+            Assertions.assertEquals("Exit", frame.events.get(6));
+            Assertions.assertEquals("Enter hello", frame.events.get(7));
+            Assertions.assertEquals("Exit", frame.events.get(8));
+            Assertions.assertEquals("Exit", frame.events.get(9));
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {


### PR DESCRIPTION
This change fixed the calls of enter and exit frame with a generator to be more sensible. We enter the frame whether we enter or resume the generator, and we call exit frame whenever we yield or exit the generator.

This fixes #2099.