### PR TITLE
Complete FinalizationRegistry

### DIFF
--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellContextFactory.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/shell/ShellContextFactory.java
@@ -49,6 +49,7 @@ public class ShellContextFactory extends ContextFactory {
             cx.setErrorReporter(errorReporter);
         }
         cx.setGeneratingDebug(generatingDebug);
+        cx.setFinalizationEnabled(true);
         super.onContextCreated(cx);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -16,6 +16,8 @@ import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -508,7 +510,7 @@ public class Context implements Closeable {
         }
         if (cx.enterCount < 1) Kit.codeBug();
         if (--cx.enterCount == 0) {
-            releaseContext(cx);
+            cx.releaseContext();
         }
     }
 
@@ -518,15 +520,17 @@ public class Context implements Closeable {
         if (--enterCount == 0) {
             assert (currentContext.get() == this)
                     : "currentContext: " + currentContext.get() + ", this: " + this;
-            releaseContext(this);
+            releaseContext();
         }
     }
 
-    private static void releaseContext(Context cx) {
+    private void releaseContext() {
+        // Drain the reference queue to prevent memory leaks
+        cleanUpReferences();
         // do not use contextLocal.remove() here, as this might be much slower, when the same thread
         // creates a new context. See ContextThreadLocalBenchmark.
         currentContext.set(null);
-        cx.factory.onContextReleased(cx);
+        factory.onContextReleased(this);
     }
 
     /**
@@ -2530,16 +2534,39 @@ public class Context implements Closeable {
      * Run all the microtasks for the current context to completion. This is called by the various
      * "evaluate" functions. Frameworks that call Function objects directly should call this
      * function to ensure that everything completes if they want all Promises to eventually resolve.
-     * This function is idempotent, but the microtask queue is not thread-safe.
+     * This function is idempotent, but the microtask queue is not thread-safe. If references are
+     * registered using a FinalizationRegistry, finalization callbacks will be called in this method
+     * as well.
      *
      * <p>Nothing will happen if suspendMicrotaskProcessing was called.
      *
      * @see #suspendMicrotaskProcessing()
      */
     public void processMicrotasks() {
+        if (microtaskSuspendCount > 0) {
+            return;
+        }
+        // Clean up references in a microtask in case a finalization call
+        // registers a microtask
+        microtasks.add(this::cleanUpReferences);
         Runnable head;
-        while (microtaskSuspendCount == 0 && (head = microtasks.poll()) != null) {
+        while ((head = microtasks.poll()) != null) {
             head.run();
+        }
+    }
+
+    /**
+     * Clean up an item that has been removed from the reference queue and check if there are more.
+     */
+    private void cleanUpReferences() {
+        Reference<?> ref;
+        while ((ref = referenceQueue.poll()) != null) {
+            if (ref instanceof NativeFinalizationRegistry.Registration registration) {
+                var registry = registration.getRegistry();
+                if (registry != null) {
+                    registry.cleanup(this, registration);
+                }
+            }
         }
     }
 
@@ -2571,6 +2598,10 @@ public class Context implements Closeable {
         }
     }
 
+    ReferenceQueue<Object> getReferenceQueue() {
+        return referenceQueue;
+    }
+
     /**
      * Control whether to track unhandled promise rejections. If "track" is set to true, then the
      * tracker returned by "getUnhandledPromiseTracker" must be periodically used to process the
@@ -2589,6 +2620,23 @@ public class Context implements Closeable {
      */
     public UnhandledRejectionTracker getUnhandledPromiseTracker() {
         return unhandledPromises;
+    }
+
+    /**
+     * Control whether finalization callbacks are dispatched when registered targets are garbage
+     * collected. Defaults to false. If set to true, then "processMicrotasks" must periodically be
+     * called to ensure that finalization callbacks are fired, or a memory leak may result.
+     * (Microtasks are always processed before scripts exit and as a normal part of handling
+     * Promises.) It set to false (the default) then the FinalizationRegistry API will still work as
+     * the spec describes but callbacks will never fire.
+     */
+    public void setFinalizationEnabled(boolean enabled) {
+        finalizationEnabled = enabled;
+    }
+
+    /** Returns whether cleanup callbacks will be dispatched at microtask checkpoints. */
+    public boolean isFinalizationEnabled() {
+        return finalizationEnabled;
     }
 
     /* ******** end of API ********* */
@@ -3024,8 +3072,10 @@ public class Context implements Closeable {
     private ClassLoader applicationClassLoader;
     private UnaryOperator<Object> javaToJSONConverter;
     private final ArrayDeque<Runnable> microtasks = new ArrayDeque<>();
+    private final ReferenceQueue<Object> referenceQueue = new ReferenceQueue<>();
     private int microtaskSuspendCount;
     private final UnhandledRejectionTracker unhandledPromises = new UnhandledRejectionTracker();
+    private boolean finalizationEnabled = false;
 
     /** This is the list of names of objects forcing the creation of function activation records. */
     Set<String> activationNames;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeFinalizationRegistry.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeFinalizationRegistry.java
@@ -1,0 +1,297 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Implementation of ECMAScript 2021 FinalizationRegistry.
+ *
+ * <p>Allows registering cleanup callbacks that are invoked when registered objects are garbage
+ * collected. Uses {@link PhantomReference} for GC detection, which is available on all platforms
+ * including Android.
+ *
+ * @see <a
+ *     href="https://tc39.es/ecma262/#sec-finalization-registry-objects">ECMAScript
+ *     FinalizationRegistry Objects</a>
+ */
+public class NativeFinalizationRegistry extends ScriptableObject {
+    private static final long serialVersionUID = 1L;
+    private static final String CLASS_NAME = "FinalizationRegistry";
+
+    // Shared reference queue for efficient GC detection across all registries
+    private static final ReferenceQueue<Object> SHARED_QUEUE = new ReferenceQueue<>();
+
+    private final Function cleanupCallback;
+    private final Scriptable parentScope;
+    private final Set<RegistrationReference> activeRegistrations = ConcurrentHashMap.newKeySet();
+    private final Map<TokenKey, Set<RegistrationReference>> tokenIndex =
+            new ConcurrentHashMap<>();
+
+    /** Initialize FinalizationRegistry constructor and prototype. */
+    static Object init(Context cx, Scriptable scope, boolean sealed) {
+        LambdaConstructor constructor =
+                new LambdaConstructor(
+                        scope,
+                        CLASS_NAME,
+                        1,
+                        LambdaConstructor.CONSTRUCTOR_NEW,
+                        NativeFinalizationRegistry::jsConstructor);
+
+        constructor.definePrototypeMethod(
+                scope, "register", 2, NativeFinalizationRegistry::js_register);
+        constructor.definePrototypeMethod(
+                scope, "unregister", 1, NativeFinalizationRegistry::js_unregister);
+
+        constructor.definePrototypeProperty(
+                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
+
+        if (sealed) {
+            constructor.sealObject();
+            ScriptableObject prototype = (ScriptableObject) constructor.getPrototypeProperty();
+            if (prototype != null) {
+                prototype.sealObject();
+            }
+        }
+        return constructor;
+    }
+
+    /** JavaScript constructor implementation. */
+    private static Scriptable jsConstructor(Context cx, Scriptable scope, Object[] args) {
+        if (args.length < 1 || !(args[0] instanceof Function)) {
+            throw ScriptRuntime.typeErrorById("msg.finalization.callback.required");
+        }
+
+        NativeFinalizationRegistry registry =
+                new NativeFinalizationRegistry((Function) args[0], scope);
+        return registry;
+    }
+
+    private NativeFinalizationRegistry(Function cleanupCallback, Scriptable scope) {
+        this.cleanupCallback = cleanupCallback;
+        this.parentScope = scope;
+    }
+
+    /** JavaScript register() method implementation. */
+    private static Object js_register(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!(thisObj instanceof NativeFinalizationRegistry)) {
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", CLASS_NAME + ".register");
+        }
+        NativeFinalizationRegistry registry = (NativeFinalizationRegistry) thisObj;
+        return registry.register(cx, scope, args);
+    }
+
+    private Object register(Context cx, Scriptable scope, Object[] args) {
+        if (args.length < 2) {
+            throw ScriptRuntime.typeErrorById(
+                    "msg.method.missing.parameter",
+                    CLASS_NAME + ".register",
+                    "2",
+                    String.valueOf(args.length));
+        }
+
+        Object target = args[0];
+        Object heldValue = args[1];
+        Object unregisterToken = args.length > 2 ? args[2] : Undefined.instance;
+
+        if (!isValidTarget(target)) {
+            throw ScriptRuntime.typeErrorById(
+                    "msg.finalization.invalid.target", ScriptRuntime.typeof(target));
+        }
+
+        // Per spec: target and heldValue cannot be the same
+        if (target == heldValue) {
+            throw ScriptRuntime.typeErrorById("msg.finalization.target.same.as.held");
+        }
+
+        // Per spec: target and unregisterToken cannot be the same
+        if (!Undefined.isUndefined(unregisterToken) && target == unregisterToken) {
+            throw ScriptRuntime.typeErrorById("msg.finalization.target.same.as.token");
+        }
+
+        // Validate unregisterToken if provided
+        if (!Undefined.isUndefined(unregisterToken) && !isValidToken(unregisterToken)) {
+            throw ScriptRuntime.typeErrorById(
+                    "msg.finalization.invalid.token", ScriptRuntime.typeof(unregisterToken));
+        }
+
+        // Create registration reference
+        RegistrationReference ref = new RegistrationReference(target, this, heldValue);
+        activeRegistrations.add(ref);
+
+        if (!Undefined.isUndefined(unregisterToken)) {
+            TokenKey key = new TokenKey(unregisterToken);
+            Set<RegistrationReference> refs =
+                    tokenIndex.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
+            refs.add(ref);
+        }
+
+        // Process any pending finalizations
+        processCleanups(cx, 10);
+
+        return Undefined.instance;
+    }
+
+    /** JavaScript unregister() method implementation. */
+    private static Object js_unregister(
+            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
+        if (!(thisObj instanceof NativeFinalizationRegistry)) {
+            throw ScriptRuntime.typeErrorById("msg.incompat.call", CLASS_NAME + ".unregister");
+        }
+        NativeFinalizationRegistry registry = (NativeFinalizationRegistry) thisObj;
+
+        if (args.length < 1) {
+            throw ScriptRuntime.typeErrorById(
+                    "msg.method.missing.parameter",
+                    CLASS_NAME + ".unregister",
+                    "1",
+                    String.valueOf(args.length));
+        }
+
+        Object token = args[0];
+        if (!registry.isValidToken(token)) {
+            throw ScriptRuntime.typeErrorById(
+                    "msg.finalization.invalid.token", ScriptRuntime.typeof(token));
+        }
+
+        TokenKey key = new TokenKey(token);
+        Set<RegistrationReference> refs = registry.tokenIndex.remove(key);
+        if (refs != null && !refs.isEmpty()) {
+            for (RegistrationReference ref : refs) {
+                registry.activeRegistrations.remove(ref);
+                ref.clear();
+            }
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+
+    /**
+     * Process pending cleanup callbacks for finalized objects.
+     *
+     * @param cx the JavaScript execution context
+     * @param maxCleanups maximum number of cleanups to process
+     */
+    private void processCleanups(Context cx, int maxCleanups) {
+        int processed = 0;
+        java.lang.ref.Reference<?> ref;
+
+        while (processed < maxCleanups && (ref = SHARED_QUEUE.poll()) != null) {
+            if (ref instanceof RegistrationReference) {
+                RegistrationReference regRef = (RegistrationReference) ref;
+                if (regRef.registry == this && activeRegistrations.remove(regRef)) {
+                    executeCleanup(cx, regRef.heldValue);
+                    processed++;
+                }
+            }
+            ref.clear();
+        }
+    }
+
+    /**
+     * Execute the cleanup callback for a finalized object.
+     *
+     * @param cx the JavaScript execution context
+     * @param heldValue the value to pass to the cleanup callback
+     */
+    private void executeCleanup(Context cx, Object heldValue) {
+        try {
+            cleanupCallback.call(cx, parentScope, this, new Object[] {heldValue});
+        } catch (RhinoException e) {
+            // Per spec, errors in cleanup callbacks don't propagate
+            Context.reportWarning(
+                    "FinalizationRegistry cleanup callback threw: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Check if the given object can be used as a FinalizationRegistry target.
+     *
+     * <p>Per ECMAScript spec, FinalizationRegistry targets can be:
+     * - Any object (Scriptable)
+     * - Unregistered symbols (created with Symbol(), not Symbol.for())
+     * - Registered symbols (Symbol.for()) cannot be registered as they persist globally
+     *
+     * @param target the target object to validate
+     * @return true if target is a valid object or unregistered symbol that can be registered
+     */
+    private static boolean isValidTarget(Object target) {
+        if (target instanceof Scriptable && !(target instanceof Symbol)) {
+            return true;
+        }
+        if (target instanceof Symbol) {
+            Symbol symbol = (Symbol) target;
+            // Only unregistered symbols can be used as targets
+            return symbol.getKind() != Symbol.Kind.REGISTERED;
+        }
+        return false;
+    }
+
+    /**
+     * Check if the given value can be used as an unregister token.
+     *
+     * <p>Per ECMAScript spec, registered symbols (created with Symbol.for()) cannot be held
+     * weakly because they persist in the global registry.
+     *
+     * @param token the token to validate
+     * @return true if token can be used as an unregister token
+     */
+    private boolean isValidToken(Object token) {
+        if (token instanceof Scriptable && !(token instanceof Symbol)) {
+            return true;
+        }
+        if (token instanceof Symbol) {
+            Symbol symbol = (Symbol) token;
+            return symbol.getKind() != Symbol.Kind.REGISTERED;
+        }
+        return false;
+    }
+
+    @Override
+    public String getClassName() {
+        return CLASS_NAME;
+    }
+
+    /** PhantomReference that tracks registered objects for finalization. */
+    private static class RegistrationReference extends PhantomReference<Object> {
+        private final NativeFinalizationRegistry registry;
+        private final Object heldValue;
+
+        RegistrationReference(
+                Object target, NativeFinalizationRegistry registry, Object heldValue) {
+            super(target, SHARED_QUEUE);
+            this.registry = registry;
+            this.heldValue = heldValue;
+        }
+    }
+
+    /** Wrapper for unregister tokens providing identity-based equality. */
+    private static class TokenKey {
+        private final Object token;
+
+        TokenKey(Object token) {
+            this.token = token;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) return true;
+            if (!(obj instanceof TokenKey)) return false;
+            return token == ((TokenKey) obj).token;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(token);
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeFinalizationRegistry.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeFinalizationRegistry.java
@@ -6,10 +6,15 @@
 
 package org.mozilla.javascript;
 
+import static org.mozilla.javascript.ClassDescriptor.Builder.value;
+import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
+
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
+import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -19,135 +24,126 @@ import java.util.concurrent.ConcurrentHashMap;
  * collected. Uses {@link PhantomReference} for GC detection, which is available on all platforms
  * including Android.
  *
- * @see <a
- *     href="https://tc39.es/ecma262/#sec-finalization-registry-objects">ECMAScript
+ * @see <a href="https://tc39.es/ecma262/#sec-finalization-registry-objects">ECMAScript
  *     FinalizationRegistry Objects</a>
  */
 public class NativeFinalizationRegistry extends ScriptableObject {
     private static final long serialVersionUID = 1L;
     private static final String CLASS_NAME = "FinalizationRegistry";
 
-    // Shared reference queue for efficient GC detection across all registries
-    private static final ReferenceQueue<Object> SHARED_QUEUE = new ReferenceQueue<>();
+    private static final ClassDescriptor DESCRIPTOR;
 
-    private final Function cleanupCallback;
-    private final Scriptable parentScope;
-    private final Set<RegistrationReference> activeRegistrations = ConcurrentHashMap.newKeySet();
-    private final Map<TokenKey, Set<RegistrationReference>> tokenIndex =
-            new ConcurrentHashMap<>();
+    private final Callable cleanupCallback;
+    private final VarScope parentScope;
+
+    /**
+     * Keep track of registered references, so we only invoke callbacks when they are still
+     * registered. Not used unless finalizations are enabled on the context.
+     */
+    private final Map<Registration, Boolean> activeRegistrations = new ConcurrentHashMap<>();
+
+    /**
+     * Keep track of unregistration tokens. Must be a Weak map to prevent memory leaks in case
+     * unregistration tokens are GCed, which is consistent with how other engines do it.
+     */
+    private final Map<Object, Unregistration> tokenIndex =
+            Collections.synchronizedMap(new WeakHashMap<>());
+
+    static {
+        DESCRIPTOR =
+                new ClassDescriptor.Builder(
+                                CLASS_NAME, 1, NativeFinalizationRegistry::jsConstructor)
+                        .withMethod(PROTO, "register", 2, NativeFinalizationRegistry::register)
+                        .withMethod(PROTO, "unregister", 1, NativeFinalizationRegistry::unregister)
+                        .withProp(
+                                PROTO,
+                                SymbolKey.TO_STRING_TAG,
+                                value(CLASS_NAME, DONTENUM | READONLY))
+                        .build();
+    }
 
     /** Initialize FinalizationRegistry constructor and prototype. */
-    static Object init(Context cx, Scriptable scope, boolean sealed) {
-        LambdaConstructor constructor =
-                new LambdaConstructor(
-                        scope,
-                        CLASS_NAME,
-                        1,
-                        LambdaConstructor.CONSTRUCTOR_NEW,
-                        NativeFinalizationRegistry::jsConstructor);
-
-        constructor.definePrototypeMethod(
-                scope, "register", 2, NativeFinalizationRegistry::js_register);
-        constructor.definePrototypeMethod(
-                scope, "unregister", 1, NativeFinalizationRegistry::js_unregister);
-
-        constructor.definePrototypeProperty(
-                SymbolKey.TO_STRING_TAG, CLASS_NAME, DONTENUM | READONLY);
-
-        if (sealed) {
-            constructor.sealObject();
-            ScriptableObject prototype = (ScriptableObject) constructor.getPrototypeProperty();
-            if (prototype != null) {
-                prototype.sealObject();
-            }
-        }
-        return constructor;
+    static JSFunction init(Context cx, VarScope s, boolean sealed) {
+        return DESCRIPTOR.buildConstructor(cx, s, new NativeObject(), sealed);
     }
 
     /** JavaScript constructor implementation. */
-    private static Scriptable jsConstructor(Context cx, Scriptable scope, Object[] args) {
-        if (args.length < 1 || !(args[0] instanceof Function)) {
+    private static Scriptable jsConstructor(
+            Context cx, JSFunction f, Object nt, VarScope s, Object to, Object[] args) {
+        if (args.length < 1 || !(args[0] instanceof Callable)) {
             throw ScriptRuntime.typeErrorById("msg.finalization.callback.required");
         }
 
-        NativeFinalizationRegistry registry =
-                new NativeFinalizationRegistry((Function) args[0], scope);
-        return registry;
+        NativeFinalizationRegistry r = new NativeFinalizationRegistry((Function) args[0], s);
+        r.setParentScope(f.getDeclarationScope());
+        r.setPrototype((Scriptable) f.getPrototypeProperty());
+        return r;
     }
 
-    private NativeFinalizationRegistry(Function cleanupCallback, Scriptable scope) {
+    private NativeFinalizationRegistry(Callable cleanupCallback, VarScope s) {
         this.cleanupCallback = cleanupCallback;
-        this.parentScope = scope;
+        this.parentScope = s;
     }
 
-    /** JavaScript register() method implementation. */
-    private static Object js_register(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        if (!(thisObj instanceof NativeFinalizationRegistry)) {
-            throw ScriptRuntime.typeErrorById("msg.incompat.call", CLASS_NAME + ".register");
-        }
-        NativeFinalizationRegistry registry = (NativeFinalizationRegistry) thisObj;
-        return registry.register(cx, scope, args);
-    }
-
-    private Object register(Context cx, Scriptable scope, Object[] args) {
-        if (args.length < 2) {
+    private static Object register(
+            Context cx, JSFunction f, Object nt, VarScope s, Object to, Object[] args) {
+        var self = LambdaConstructor.convertThisObject(to, NativeFinalizationRegistry.class);
+        if (args.length < 1) {
             throw ScriptRuntime.typeErrorById(
-                    "msg.method.missing.parameter",
-                    CLASS_NAME + ".register",
-                    "2",
-                    String.valueOf(args.length));
+                    "msg.method.missing.parameter", CLASS_NAME + ".register", 1, args.length);
         }
 
-        Object target = args[0];
-        Object heldValue = args[1];
-        Object unregisterToken = args.length > 2 ? args[2] : Undefined.instance;
-
-        if (!isValidTarget(target)) {
+        var target = args[0];
+        if (!NativeWeakRef.canBeHeldWeakly(target)) {
             throw ScriptRuntime.typeErrorById(
                     "msg.finalization.invalid.target", ScriptRuntime.typeof(target));
         }
 
-        // Per spec: target and heldValue cannot be the same
-        if (target == heldValue) {
+        var heldValue = args.length > 1 ? args[1] : Undefined.instance;
+        if (heldValue == target) {
             throw ScriptRuntime.typeErrorById("msg.finalization.target.same.as.held");
         }
 
-        // Per spec: target and unregisterToken cannot be the same
-        if (!Undefined.isUndefined(unregisterToken) && target == unregisterToken) {
-            throw ScriptRuntime.typeErrorById("msg.finalization.target.same.as.token");
-        }
-
-        // Validate unregisterToken if provided
-        if (!Undefined.isUndefined(unregisterToken) && !isValidToken(unregisterToken)) {
+        var unregisterToken = args.length > 2 ? args[2] : Undefined.instance;
+        if (!Undefined.isUndefined(unregisterToken)
+                && !NativeWeakRef.canBeHeldWeakly(unregisterToken)) {
             throw ScriptRuntime.typeErrorById(
                     "msg.finalization.invalid.token", ScriptRuntime.typeof(unregisterToken));
         }
 
-        // Create registration reference
-        RegistrationReference ref = new RegistrationReference(target, this, heldValue);
-        activeRegistrations.add(ref);
-
-        if (!Undefined.isUndefined(unregisterToken)) {
-            TokenKey key = new TokenKey(unregisterToken);
-            Set<RegistrationReference> refs =
-                    tokenIndex.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
-            refs.add(ref);
+        Registration ref;
+        if (cx.isFinalizationEnabled()) {
+            // Register the reference in the reference queue associated with the current Context.
+            ref = new Registration(target, self, heldValue, cx.getReferenceQueue());
+            // Track it so that we can be only fire callbacks on registered objects
+            self.activeRegistrations.put(ref, true);
+        } else {
+            ref = null;
         }
 
-        // Process any pending finalizations
-        processCleanups(cx, 10);
+        if (!Undefined.isUndefined(unregisterToken)) {
+            // Register this callback using the unregister token
+            self.tokenIndex.compute(
+                    unregisterToken,
+                    (k, v) -> {
+                        var reg = v;
+                        if (reg == null) {
+                            reg = new Unregistration();
+                        }
+                        reg.count++;
+                        if (ref != null) {
+                            reg.registrations.add(ref);
+                        }
+                        return reg;
+                    });
+        }
 
         return Undefined.instance;
     }
 
-    /** JavaScript unregister() method implementation. */
-    private static Object js_unregister(
-            Context cx, Scriptable scope, Scriptable thisObj, Object[] args) {
-        if (!(thisObj instanceof NativeFinalizationRegistry)) {
-            throw ScriptRuntime.typeErrorById("msg.incompat.call", CLASS_NAME + ".unregister");
-        }
-        NativeFinalizationRegistry registry = (NativeFinalizationRegistry) thisObj;
+    private static Object unregister(
+            Context cx, JSFunction f, Object nt, VarScope s, Object to, Object[] args) {
+        var self = LambdaConstructor.convertThisObject(to, NativeFinalizationRegistry.class);
 
         if (args.length < 1) {
             throw ScriptRuntime.typeErrorById(
@@ -158,102 +154,38 @@ public class NativeFinalizationRegistry extends ScriptableObject {
         }
 
         Object token = args[0];
-        if (!registry.isValidToken(token)) {
+        if (!NativeWeakRef.canBeHeldWeakly(token)) {
             throw ScriptRuntime.typeErrorById(
                     "msg.finalization.invalid.token", ScriptRuntime.typeof(token));
         }
 
-        TokenKey key = new TokenKey(token);
-        Set<RegistrationReference> refs = registry.tokenIndex.remove(key);
-        if (refs != null && !refs.isEmpty()) {
-            for (RegistrationReference ref : refs) {
-                registry.activeRegistrations.remove(ref);
+        // Count registrations for this token. We won't return a count
+        // if the token itself has been GCed.
+        var reg = self.tokenIndex.remove(token);
+        if (reg != null) {
+            for (var ref : reg.registrations) {
+                self.activeRegistrations.remove(ref);
                 ref.clear();
             }
-            return Boolean.TRUE;
+            return reg.count > 0;
         }
-        return Boolean.FALSE;
+        return false;
     }
 
     /**
-     * Process pending cleanup callbacks for finalized objects.
-     *
-     * @param cx the JavaScript execution context
-     * @param maxCleanups maximum number of cleanups to process
+     * Called by Context during microtask processing whenever anything comes off the reference
+     * queue.
      */
-    private void processCleanups(Context cx, int maxCleanups) {
-        int processed = 0;
-        java.lang.ref.Reference<?> ref;
-
-        while (processed < maxCleanups && (ref = SHARED_QUEUE.poll()) != null) {
-            if (ref instanceof RegistrationReference) {
-                RegistrationReference regRef = (RegistrationReference) ref;
-                if (regRef.registry == this && activeRegistrations.remove(regRef)) {
-                    executeCleanup(cx, regRef.heldValue);
-                    processed++;
-                }
+    void cleanup(Context cx, Registration ref) {
+        if (activeRegistrations.remove(ref)) {
+            try {
+                cleanupCallback.call(cx, parentScope, null, new Object[] {ref.heldValue});
+            } catch (RhinoException e) {
+                // Per spec, errors in cleanup callbacks don't propagate
+                Context.reportWarning(
+                        "FinalizationRegistry cleanup callback threw: " + e.getMessage());
             }
-            ref.clear();
         }
-    }
-
-    /**
-     * Execute the cleanup callback for a finalized object.
-     *
-     * @param cx the JavaScript execution context
-     * @param heldValue the value to pass to the cleanup callback
-     */
-    private void executeCleanup(Context cx, Object heldValue) {
-        try {
-            cleanupCallback.call(cx, parentScope, this, new Object[] {heldValue});
-        } catch (RhinoException e) {
-            // Per spec, errors in cleanup callbacks don't propagate
-            Context.reportWarning(
-                    "FinalizationRegistry cleanup callback threw: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Check if the given object can be used as a FinalizationRegistry target.
-     *
-     * <p>Per ECMAScript spec, FinalizationRegistry targets can be:
-     * - Any object (Scriptable)
-     * - Unregistered symbols (created with Symbol(), not Symbol.for())
-     * - Registered symbols (Symbol.for()) cannot be registered as they persist globally
-     *
-     * @param target the target object to validate
-     * @return true if target is a valid object or unregistered symbol that can be registered
-     */
-    private static boolean isValidTarget(Object target) {
-        if (target instanceof Scriptable && !(target instanceof Symbol)) {
-            return true;
-        }
-        if (target instanceof Symbol) {
-            Symbol symbol = (Symbol) target;
-            // Only unregistered symbols can be used as targets
-            return symbol.getKind() != Symbol.Kind.REGISTERED;
-        }
-        return false;
-    }
-
-    /**
-     * Check if the given value can be used as an unregister token.
-     *
-     * <p>Per ECMAScript spec, registered symbols (created with Symbol.for()) cannot be held
-     * weakly because they persist in the global registry.
-     *
-     * @param token the token to validate
-     * @return true if token can be used as an unregister token
-     */
-    private boolean isValidToken(Object token) {
-        if (token instanceof Scriptable && !(token instanceof Symbol)) {
-            return true;
-        }
-        if (token instanceof Symbol) {
-            Symbol symbol = (Symbol) token;
-            return symbol.getKind() != Symbol.Kind.REGISTERED;
-        }
-        return false;
     }
 
     @Override
@@ -262,36 +194,30 @@ public class NativeFinalizationRegistry extends ScriptableObject {
     }
 
     /** PhantomReference that tracks registered objects for finalization. */
-    private static class RegistrationReference extends PhantomReference<Object> {
+    static class Registration extends PhantomReference<Object> {
         private final NativeFinalizationRegistry registry;
         private final Object heldValue;
 
-        RegistrationReference(
-                Object target, NativeFinalizationRegistry registry, Object heldValue) {
-            super(target, SHARED_QUEUE);
+        Registration(
+                Object target,
+                NativeFinalizationRegistry registry,
+                Object heldValue,
+                ReferenceQueue<Object> queue) {
+            super(target, queue);
             this.registry = registry;
             this.heldValue = heldValue;
         }
+
+        NativeFinalizationRegistry getRegistry() {
+            return registry;
+        }
     }
 
-    /** Wrapper for unregister tokens providing identity-based equality. */
-    private static class TokenKey {
-        private final Object token;
+    /** The record that we register in the unregistration table */
+    private static class Unregistration {
+        int count;
+        final HashSet<Registration> registrations = new HashSet<>();
 
-        TokenKey(Object token) {
-            this.token = token;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (this == obj) return true;
-            if (!(obj instanceof TokenKey)) return false;
-            return token == ((TokenKey) obj).token;
-        }
-
-        @Override
-        public int hashCode() {
-            return System.identityHashCode(token);
-        }
+        Unregistration() {}
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeWeakRef.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeWeakRef.java
@@ -76,7 +76,7 @@ public class NativeWeakRef extends ScriptableObject {
         return nr;
     }
 
-    private static boolean canBeHeldWeakly(Object o) {
+    static boolean canBeHeldWeakly(Object o) {
         return ScriptRuntime.isObject(o)
                 || (o instanceof Symbol s && s.getKind() != Symbol.Kind.REGISTERED);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -305,6 +305,8 @@ public class ScriptRuntime {
             new LazilyLoadedCtor<>(scope, "Proxy", sealed, true, NativeProxy::init);
             new LazilyLoadedCtor<>(scope, "Reflect", sealed, true, NativeReflect::init);
             new LazilyLoadedCtor<>(scope, "WeakRef", sealed, true, NativeWeakRef::init);
+            new LazilyLoadedCtor<>(
+                    scope, "FinalizationRegistry", sealed, true, NativeFinalizationRegistry::init);
         }
 
         scope.cacheBuiltins(sealed);

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -1105,5 +1105,25 @@ msg.dataview.offset.range =\
 msg.dataview.length.range =\
   DataView length is out of range
 
+# WeakRef
+msg.weakref.invalid.target =\
+  WeakRef: invalid target. Object expected, but got {0}
+
+# FinalizationRegistry
+msg.finalization.callback.required =\
+  FinalizationRegistry: cleanup callback must be a function
+
+msg.finalization.invalid.target =\
+  FinalizationRegistry: invalid target. Object expected, but got {0}
+
+msg.finalization.target.same.as.held =\
+  FinalizationRegistry: target and holdings must not be the same object
+
+msg.finalization.target.same.as.token =\
+  FinalizationRegistry: target and unregister token must not be the same object
+
+msg.finalization.invalid.token =\
+  FinalizationRegistry: invalid unregister token. Object or unregistered symbol expected, but got {0}
+
 msg.weakref.cant.hold.weakly =\
   The target of the operation cannot be held weakly

--- a/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
+++ b/rhino/src/main/resources/org/mozilla/javascript/resources/Messages.properties
@@ -1105,10 +1105,6 @@ msg.dataview.offset.range =\
 msg.dataview.length.range =\
   DataView length is out of range
 
-# WeakRef
-msg.weakref.invalid.target =\
-  WeakRef: invalid target. Object expected, but got {0}
-
 # FinalizationRegistry
 msg.finalization.callback.required =\
   FinalizationRegistry: cleanup callback must be a function

--- a/tests/src/test/java/org/mozilla/javascript/tests/es2021/NativeFinalizationRegistryTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es2021/NativeFinalizationRegistryTest.java
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests.es2021;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.testutils.TestSource;
+import org.mozilla.javascript.tools.shell.Global;
+
+public class NativeFinalizationRegistryTest {
+
+    @Test
+    public void testFinalizationRegistryEnabled() throws IOException {
+        try (var cx = Context.enter()) {
+            cx.setFinalizationEnabled(true);
+            try (var script =
+                    new InputStreamReader(
+                            new FileInputStream(
+                                    TestSource.resolve(
+                                            "testsrc/jstests/es2021/finalization-registry.js")),
+                            StandardCharsets.UTF_8)) {
+                var global = new Global(cx);
+                global.setFileLoadPrefix(TestSource.getPrefix());
+                var scope = TopLevel.createIsolate(global);
+                cx.evaluateReader(scope, script, "finalization-registry.js", 1, null);
+                // ScriptTestsBase does not necessarily do this so call it here
+                cx.processMicrotasks();
+            }
+        }
+    }
+
+    @Test
+    public void testFinalizationRegistryDisabled() throws IOException {
+        try (var cx = Context.enter()) {
+            cx.setFinalizationEnabled(false);
+            try (var script =
+                    new InputStreamReader(
+                            new FileInputStream(
+                                    TestSource.resolve(
+                                            "testsrc/jstests/es2021/finalization-registry-disabled.js")),
+                            StandardCharsets.UTF_8)) {
+                var global = new Global(cx);
+                global.setFileLoadPrefix(TestSource.getPrefix());
+                var scope = TopLevel.createIsolate(global);
+                cx.evaluateReader(scope, script, "finalization-registry.js", 1, null);
+                // ScriptTestsBase does not necessarily do this so call it here
+                cx.processMicrotasks();
+            }
+        }
+    }
+
+    @Test
+    public void testCleanupDuringContextClose() throws IOException {
+        try (var cx = Context.enter()) {
+            var global = new Global(cx);
+            var scope = TopLevel.createIsolate(global);
+
+            // Set up a JS holder object via the Global scope.
+            cx.evaluateString(
+                    scope,
+                    "globalThis._finalizerTest = {};"
+                            + "var reg = new FinalizationRegistry(function(hv) { "
+                            + "_finalizerTest.finalized = true; "
+                            + "_finalizerTest.heldValue = hv;"
+                            + "});\n"
+                            + "var target = {};\n"
+                            + "reg.register(target, 'test-hold-value');\n",
+                    "test",
+                    1,
+                    null);
+
+            // Force GC to enqueue the PhantomReference.
+            System.gc();
+        }
+        // Context close via try-with-resources should complete without throwing or deadlocking.
+    }
+}

--- a/tests/testsrc/jstests/es2021/finalization-registry-disabled.js
+++ b/tests/testsrc/jstests/es2021/finalization-registry-disabled.js
@@ -1,0 +1,63 @@
+'use strict';
+
+load('testsrc/assert.js');
+
+// Test the FinalizationRegistry. This is designed to test
+// in the default mode where finalizations are never actually called.
+
+const m = new Map();
+const reg = new FinalizationRegistry((n) => {
+    console.error(`Finalization called incorrectly for ${n} because finalization is disabled`); 
+});
+const fooUnregister = {};
+const barUnregister = {};
+
+// Do some operations with promises so that microtasks run.
+// This way the reference queue will actually be cleared.
+const p = new Promise((resolve) => {
+    // Create an object that we can GC later
+    m.set('foo', {name: 'foo'});
+    m.set('bar', {name: 'bar'});
+    // Put it in the finalization registry
+    reg.register(m.get('foo'), 'foo', fooUnregister);
+    reg.register(m.get('bar'), 'bar', barUnregister);
+    resolve();
+}).then(() => {
+    // On second thought forget about bar
+    assert(reg.unregister(barUnregister));
+    // Drop the reference, making it eligible for GC,
+    // and indicate that we're expecting it to be finalized
+    m.delete('foo');
+    m.delete('bar');
+    gc();
+}).then(() => {
+    // One more gc for good measure since this is nondeterministic
+    gc();
+});
+
+const thingUnregister = {};
+
+// Do it again but unregister a group of things
+const p1 = new Promise((resolve) => {
+    m.set('thing1', {id: 1});
+    m.set('thing2', {id: 2});
+    m.set('thing3', {id: 3});
+    reg.register(m.get('thing1'), 1, thingUnregister);
+    reg.register(m.get('thing2'), 2);
+    reg.register(m.get('thing3'), 3, thingUnregister);
+    resolve();
+}).then(() => {
+    assert(reg.unregister(thingUnregister));
+    m.delete('thing1');
+    m.delete('thing2');
+    m.delete('thing3');
+    gc();
+}).then(() => {
+    gc();
+});
+
+Promise.all([p, p1]).then(() => {
+    console.log('All tests completed');
+});
+
+'success';

--- a/tests/testsrc/jstests/es2021/finalization-registry.js
+++ b/tests/testsrc/jstests/es2021/finalization-registry.js
@@ -1,0 +1,94 @@
+'use strict';
+
+load('testsrc/assert.js');
+
+// Test the FinalizationRegistry. Since garbage collection is non-deterministic,
+// these tests will not fail if the garbage collector never runs. However,
+// we try to encourage it to run, and the callbacks are there so that we can
+// exercise all the cleanup logic.
+
+const pending = new Set();
+const m = new Map();
+const reg = new FinalizationRegistry((n) => { 
+    // Can't assert here because errors are swallowed deliberately
+    if (!pending.delete(n)) {
+        console.error(`Did not expect finalization of ${n}`);
+    }
+    console.log(`Finalized ${n}, ${pending.size} left`);
+    // Do something that will result in a microtask being enqueued
+    // while we're in the microtask queue
+    new Promise((resolve) => {
+        resolve();
+    }).then(() => {
+        console.log(`${n} finalized`);
+    });
+});
+const fooUnregister = {};
+const barUnregister = {};
+
+// Do some operations with promises so that microtasks run.
+// This way the reference queue will actually be cleared.
+const p = new Promise((resolve) => {
+    // Create an object that we can GC later
+    m.set('foo', {name: 'foo'});
+    m.set('bar', {name: 'bar'});
+    // Put it in the finalization registry
+    reg.register(m.get('foo'), 'foo', fooUnregister);
+    reg.register(m.get('bar'), 'bar', barUnregister);
+    resolve();
+}).then(() => {
+    // On second thought forget about bar
+    assert(reg.unregister(barUnregister));
+    // Drop the reference, making it eligible for GC,
+    // and indicate that we're expecting it to be finalized
+    pending.add('foo');
+    m.delete('foo');
+    m.delete('bar');
+    gc();
+}).then(() => {
+    // One more gc for good measure since this is nondeterministic
+    gc();
+});
+
+const thingUnregister = {};
+
+// Do it again but unregister a group of things
+const p1 = new Promise((resolve) => {
+    m.set('thing1', {id: 1});
+    m.set('thing2', {id: 2});
+    m.set('thing3', {id: 3});
+    reg.register(m.get('thing1'), 1, thingUnregister);
+    reg.register(m.get('thing2'), 2);
+    reg.register(m.get('thing3'), 3, thingUnregister);
+    resolve();
+}).then(() => {
+    assert(reg.unregister(thingUnregister));
+    pending.add(2);
+    m.delete('thing1');
+    m.delete('thing2');
+    m.delete('thing3');
+    gc();
+}).then(() => {
+    gc();
+});
+
+// Set up an invalid cleanup callback.
+const reg2 = new FinalizationRegistry((v) => {
+    throw 'Deliberate error raised by FinalizationRegistry test';
+});
+const p2 = new Promise((resolve) => {
+    m.set('error1', {error: true});
+    reg2.register(m.get('error1'), 'error');
+    resolve();
+}).then(() => {
+    m.delete('error1');
+    gc();
+}).then(() => {
+    gc();
+});
+
+Promise.all([p, p1, p2]).then(() => {
+    console.log('All tests completed');
+});
+
+'success';

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1489,7 +1489,6 @@ built-ins/Object 111/3411 (3.25%)
     seal/seal-asyncarrowfunction.js
     seal/seal-asyncfunction.js
     seal/seal-asyncgeneratorfunction.js
-    seal/seal-finalizationregistry.js
     seal/seal-sharedarraybuffer.js {unsupported: [SharedArrayBuffer]}
     values/observable-operations.js
     proto-from-ctor-realm.js

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -745,7 +745,10 @@ built-ins/Error 3/58 (5.17%)
     cause_abrupt.js
     proto-from-ctor-realm.js
 
-~built-ins/FinalizationRegistry 47/47 (100.0%)
+built-ins/FinalizationRegistry 3/47 (6.38%)
+    proto-from-ctor-realm.js
+    prototype-from-newtarget-abrupt.js
+    prototype-from-newtarget-custom.js
 
 built-ins/Function 125/509 (24.56%)
     internals/Call 2/2 (100.0%)
@@ -1382,7 +1385,7 @@ built-ins/Number 4/340 (1.18%)
     S9.3.1_A3_T1_U180E.js {unsupported: [u180e]}
     S9.3.1_A3_T2_U180E.js {unsupported: [u180e]}
 
-built-ins/Object 111/3411 (3.25%)
+built-ins/Object 110/3411 (3.22%)
     assign/assignment-to-readonly-property-of-target-must-throw-a-typeerror-exception.js
     assign/source-own-prop-error.js
     assign/strings-and-symbol-order-proxy.js
@@ -2891,8 +2894,7 @@ built-ins/WeakMap 40/141 (28.37%)
     prototype/getOrInsert 17/17 (100.0%)
     proto-from-ctor-realm.js
 
-built-ins/WeakRef 4/29 (13.79%)
-    prototype/deref/this-does-not-have-internal-target-throws.js
+built-ins/WeakRef 3/29 (10.34%)
     proto-from-ctor-realm.js
     prototype-from-newtarget-abrupt.js
     prototype-from-newtarget-custom.js


### PR DESCRIPTION
This builds on the work already done in https://github.com/mozilla/rhino/pull/2058
and https://github.com/mozilla/rhino/pull/2431 to complete the implementation
of the FinalizationRegistry.

The all-important reference queue where finalization callbacks are called is
invoked as part of microtask processing by the Context. Applications that have
many Contexts in use at once will see finalizations happening in the one where
the registry was originally created. It uses PhantomReference and a 
reference queue to ensure that finalizations happen when the JVM needs them
to happen.
