### PR TITLE
Fix some warnings and make them appear in Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,37 +13,4 @@ test --jvmopt="-Duser.country=US"
 test --jvmopt="-Duser.timezone=America/Los_Angeles"
 test --jvmopt="-Dfile.encoding=UTF-8"
 
-# Default javac options
-build --javacopt="-encoding UTF-8"
-build --javacopt="-Xlint:deprecation"
-build --javacopt="-Xlint:unchecked"
-build --javacopt="-Xlint:-removal"
-test --javacopt="-Xlint:-deprecation"
-
-# Set up Errorprone for success
-build --javacopt="-Xep:JUnit4TestNotRun:OFF
-build --javacopt="-Xep:ReturnValueIgnored:OFF"
-build --javacopt="-Xep:IdentityBinaryExpression:OFF"
-build --javacopt="-Xep:ClassInitializationDeadlock:OFF"
-build --javacopt="-Xep:EffectivelyPrivate:OFF"
-build --javacopt="-Xep:BooleanLiteral:OFF"
-build --javacopt="-Xep:AssignmentExpression:OFF"
-build --javacopt="-Xep:DuplicateBranches:OFF"
-build --javacopt="-Xep:PatternMatchingInstanceof:OFF"
-build --javacopt="-Xep:StatementSwitchToExpressionSwitch:OFF"
-build --javacopt="-Xep:RedundantControlFlow:OFF"
-build --javacopt="-Xep:AlmostJavadoc:OFF"
-build --javacopt="-Xep:EmptyBlockTag:OFF"
-build --javacopt="-Xep:EscapedEntity:OFF"
-build --javacopt="-Xep:MissingSummary:OFF"
-build --javacopt="-Xep:InvalidBlockTag:OFF"
-build --javacopt="-Xep:NotJavadoc:OFF"
-build --javacopt="-Xep:UnicodeEscape:OFF"
-build --javacopt="-Xep:EmptyCatch:OFF"
-build --javacopt="-Xep:LabelledBreakTarget:OFF"
-build --javacopt="-Xep:JavaUtilDate:OFF"
-build --javacopt="-Xep:InlineMeSuggester:OFF"
-build --javacopt="-Xep:UnusedVariable:OFF"
-build --javacopt="-Xep:AnnotateFormatMethod:OFF"
-
 try-import %workspace%/.bazelrc.user

--- a/bazel/errorprone.bzl
+++ b/bazel/errorprone.bzl
@@ -14,7 +14,6 @@ LIBRARY_OPTS = DEFAULT_OPTS + [
     "-Xep:AssignmentExpression:OFF",
     "-Xep:DuplicateBranches:OFF",
     "-Xep:PatternMatchingInstanceof:OFF",
-    "-Xep:RedundantControlFlow:OFF",
     "-Xep:StatementSwitchToExpressionSwitch:OFF",
     "-Xep:EmptyBlockTag:OFF",
     "-Xep:EscapedEntity:OFF",
@@ -32,7 +31,8 @@ LIBRARY_OPTS = DEFAULT_OPTS + [
     # Additional useful checks
     "-Xep:RemoveUnusedImports:WARN",
     "-Xep:RemoveWildcardImport:WARN",
-    "-Xep:UnusedMethod:WARN", 
+    "-Xep:UnusedMethod:WARN",
+    "-Xep:RedundantControlFlow:WARN",
 ]
 
 TEST_OPTS = DEFAULT_OPTS + [

--- a/bazel/errorprone.bzl
+++ b/bazel/errorprone.bzl
@@ -1,0 +1,41 @@
+DEFAULT_OPTS = [
+    "-XepAllErrorsAsWarnings",
+]
+
+LIBRARY_OPTS = DEFAULT_OPTS + [
+    "-XepAllSuggestionsAsWarnings",
+    "-Xlint:deprecation",
+    "-Xlint:unchecked",
+    "-Xlint:-removal",
+    # Checks we aren't ready to fix yet
+    "-Xep:ClassInitializationDeadlock:OFF",
+    "-Xep:EffectivelyPrivate:OFF",
+    "-Xep:BooleanLiteral:OFF",
+    "-Xep:AssignmentExpression:OFF",
+    "-Xep:DuplicateBranches:OFF",
+    "-Xep:PatternMatchingInstanceof:OFF",
+    "-Xep:RedundantControlFlow:OFF",
+    "-Xep:StatementSwitchToExpressionSwitch:OFF",
+    "-Xep:EmptyBlockTag:OFF",
+    "-Xep:EscapedEntity:OFF",
+    "-Xep:MissingSummary:OFF",
+    "-Xep:InvalidBlockTag:OFF",
+    "-Xep:UnicodeEscape:OFF",
+    "-Xep:EmptyCatch:OFF",
+    "-Xep:LabelledBreakTarget:OFF",
+    "-Xep:JavaUtilDate:OFF",
+    "-Xep:InlineMeSuggester:OFF",
+    "-Xep:UnusedVariable:OFF",
+    "-Xep:AnnotateFormatMethod:OFF",
+    "-Xep:ImmutableEnumChecker:OFF",
+    "-Xep:DoNotCallSuggester:OFF",
+    # Additional useful checks
+    "-Xep:RemoveUnusedImports:WARN",
+    "-Xep:RemoveWildcardImport:WARN",
+    "-Xep:UnusedMethod:WARN", 
+]
+
+TEST_OPTS = DEFAULT_OPTS + [
+    "-Xlint:-deprecation",
+    "-XepDisableAllChecks",
+]

--- a/buildSrc/src/main/groovy/rhino.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.library-conventions.gradle
@@ -31,7 +31,6 @@ tasks.withType(JavaCompile).configureEach {
                 "AssignmentExpression",
                 "DuplicateBranches",
                 "PatternMatchingInstanceof",
-                "RedundantControlFlow",
                 "StatementSwitchToExpressionSwitch",
                 "ImmutableEnumChecker",
                 "DoNotCallSuggester",
@@ -51,7 +50,7 @@ tasks.withType(JavaCompile).configureEach {
                 // or spuriously for local variables in my opinion.
                 "UnusedVariable",
                 // This requires annotations that are difficult to incorporate
-                // without adding a dependency for everyon who uses Rhino.
+                // without adding a dependency for everyone who uses Rhino.
                 "AnnotateFormatMethod"
         )
         options.errorprone.enable(

--- a/buildSrc/src/main/groovy/rhino.library-conventions.gradle
+++ b/buildSrc/src/main/groovy/rhino.library-conventions.gradle
@@ -33,13 +33,13 @@ tasks.withType(JavaCompile).configureEach {
                 "PatternMatchingInstanceof",
                 "RedundantControlFlow",
                 "StatementSwitchToExpressionSwitch",
+                "ImmutableEnumChecker",
+                "DoNotCallSuggester",
                 // JavaDoc stuff -- not going to fix unless we do a big JavaDoc update
-                "AlmostJavadoc",
                 "EmptyBlockTag",
                 "EscapedEntity",
                 "MissingSummary",
                 "InvalidBlockTag",
-                "NotJavadoc",
                 "UnicodeEscape",
                 // Stuff that we just love to do but should do less of eventually
                 "EmptyCatch",

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -7,3 +7,8 @@ dependencies {
     implementation project(':rhino-tools')
     implementation project(':rhino-xml')
 }
+
+tasks.withType(Javadoc) {
+    failOnError = false
+    options.addStringOption('Xdoclint:all,-missing', '-quiet')
+}

--- a/examples/src/main/java/Shell.java
+++ b/examples/src/main/java/Shell.java
@@ -99,7 +99,7 @@ public class Shell extends ScriptableObject {
             if (arg.equals("-version")) {
                 if (++i == args.length) usage(arg);
                 double d = Context.toNumber(args[i]);
-                if (d != d) usage(arg);
+                if (Double.isNaN(d)) usage(arg);
                 cx.setLanguageVersion((int) d);
                 continue;
             }

--- a/rhino-engine/BUILD.bazel
+++ b/rhino-engine/BUILD.bazel
@@ -1,9 +1,11 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_test_suite")
 load("@rules_java//java:defs.bzl", "java_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "rhino-engine",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
     deps = ["//rhino"],
@@ -17,8 +19,8 @@ java_test_suite(
         exclude = ["**/module-info.java"],
     ),
     data = ["//tests:testsrc"],
+    javacopts = TEST_OPTS,
     runner = "junit5",
-    tags = ["no-agent"],
     test_suffixes = ["Test.java"],
     deps = [
         ":rhino-engine",

--- a/rhino-kotlin/BUILD.bazel
+++ b/rhino-kotlin/BUILD.bazel
@@ -1,10 +1,12 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_junit5_test")
 load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "rhino-kotlin",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
     deps = [
@@ -28,7 +30,7 @@ java_junit5_test(
     name = "rhino-kotlin_test",
     size = "small",
     srcs = ["src/test/java/org/mozilla/kotlin/tests/KotlinNullabilityDetectorTest.java"],
-    tags = ["no-agent"],
+    javacopts = TEST_OPTS,
     test_class = "org.mozilla.kotlin.tests.KotlinNullabilityDetectorTest",
     deps = [
         ":rhino-kotlin",

--- a/rhino-tools/BUILD.bazel
+++ b/rhino-tools/BUILD.bazel
@@ -1,9 +1,11 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_test_suite")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "rhino-tools",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
     deps = [
@@ -15,6 +17,7 @@ java_library(
 
 java_binary(
     name = "shell",
+    javacopts = LIBRARY_OPTS,
     main_class = "org.mozilla.javascript.tools.shell.Main",
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -30,6 +33,7 @@ java_binary(
 
 java_binary(
     name = "debugger",
+    javacopts = LIBRARY_OPTS,
     main_class = "org.mozilla.javascript.tools.debugger.Main",
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -41,6 +45,7 @@ java_binary(
 
 java_binary(
     name = "jsc",
+    javacopts = LIBRARY_OPTS,
     main_class = "org.mozilla.javascript.tools.jsc.Main",
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -56,8 +61,8 @@ java_test_suite(
         ["src/test/java/**/*.java"],
         exclude = ["**/module-info.java"],
     ),
+    javacopts = TEST_OPTS,
     runner = "junit5",
-    tags = ["no-agent"],
     test_suffixes = ["Test.java"],
     deps = [
         ":rhino-tools",

--- a/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/treetable/AbstractCellEditor.java
+++ b/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/treetable/AbstractCellEditor.java
@@ -74,9 +74,9 @@ public class AbstractCellEditor implements CellEditor {
         listenerList.remove(CellEditorListener.class, l);
     }
 
-    /*
-     * Notify all listeners that have registered interest for
-     * notification on this event type.
+    /**
+     * Notify all listeners that have registered interest for notification on this event type.
+     *
      * @see EventListenerList
      */
     protected void fireEditingStopped() {
@@ -91,9 +91,9 @@ public class AbstractCellEditor implements CellEditor {
         }
     }
 
-    /*
-     * Notify all listeners that have registered interest for
-     * notification on this event type.
+    /**
+     * Notify all listeners that have registered interest for notification on this event type.
+     *
      * @see EventListenerList
      */
     protected void fireEditingCanceled() {

--- a/rhino-xml/BUILD.bazel
+++ b/rhino-xml/BUILD.bazel
@@ -1,9 +1,11 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_junit5_test")
 load("@rules_java//java:defs.bzl", "java_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "rhino-xml",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
     deps = ["//rhino"],
@@ -12,6 +14,7 @@ java_library(
 java_library(
     name = "rhino-xml-tests",
     srcs = glob(["src/test/java/**/*.java"]),
+    javacopts = TEST_OPTS,
     deps = [
         ":rhino-xml",
         "//rhino",
@@ -30,6 +33,7 @@ java_junit5_test(
     name = "XMLSecureParserTest",
     size = "small",
     srcs = glob(["**/XMLSecureParserTest.java"]),
+    javacopts = TEST_OPTS,
     tags = ["no-agent"],
     test_class = "org.mozilla.javascript.tests.XMLSecureParserTest",
     deps = [
@@ -46,7 +50,7 @@ java_junit5_test(
     name = "E4XBasicTest",
     size = "small",
     srcs = glob(["**/E4XBasicTest.java"]),
-    tags = ["no-agent"],
+    javacopts = TEST_OPTS,
     test_class = "org.mozilla.javascript.xmlimpl.tests.E4XBasicTest",
     deps = [
         ":rhino-xml",
@@ -62,7 +66,7 @@ java_junit5_test(
     name = "XmlNonResettableDocumentBuilderTest",
     size = "small",
     srcs = glob(["**/XmlNonResettableDocumentBuilderTest.java"]),
-    tags = ["no-agent"],
+    javacopts = TEST_OPTS,
     test_class = "org.mozilla.javascript.xmlimpl.tests.XmlNonResettableDocumentBuilderTest",
     deps = [
         ":rhino-xml",

--- a/rhino/BUILD.bazel
+++ b/rhino/BUILD.bazel
@@ -1,9 +1,11 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_test_suite")
 load("@rules_java//java:defs.bzl", "java_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "rhino",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     resources = glob(["src/main/resources/**"]),
     visibility = ["//visibility:public"],
 )
@@ -16,9 +18,9 @@ java_test_suite(
         "//:rhino-test.config",
         "//tests:testsrc",
     ],
+    javacopts = TEST_OPTS,
     resources = glob(["src/test/resources/**"]),
     runner = "junit5",
-    tags = ["no-agent"],
     test_suffixes = ["Test.java"],
     deps = [
         ":rhino",

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -550,13 +550,11 @@ public class NativeObject extends ScriptableObject implements Map {
         }
         for (Object key : ids) {
             var desc = obj.getOwnPropertyDescriptor(cx, key);
-            if (desc == null) {
-                continue;
-            } else if (key instanceof Symbol) {
+            if (key instanceof Symbol) {
                 descs.put((Symbol) key, descs, desc.toObject(s));
             } else if (key instanceof Integer) {
                 descs.put((Integer) key, descs, desc.toObject(s));
-            } else {
+            } else if (desc != null) {
                 descs.put(ScriptRuntime.toString(key), descs, desc.toObject(s));
             }
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Parser.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Parser.java
@@ -259,18 +259,6 @@ public class Parser {
             this.offset = offset;
         }
 
-        public int getLine() {
-            return line;
-        }
-
-        public String getLineSource() {
-            return lineSource;
-        }
-
-        public int getOffset() {
-            return offset;
-        }
-
         @Override
         public boolean equals(Object obj) {
             if (obj == this) return true;

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -4638,7 +4638,6 @@ public class ScriptRuntime {
                     }
                 }
                 y = toPrimitive(y);
-                continue;
             } else {
                 warnAboutNonJSObject(y);
                 return false;

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeFormatContext.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeFormatContext.java
@@ -7,9 +7,10 @@ import org.mozilla.javascript.lc.type.impl.ClassNameFormatContext;
  */
 public interface TypeFormatContext {
     /**
-     * Full feature formatting context
+     *
      *
      * <table>
+     *   <caption>Full feature formatting context</caption>
      *   <tr><th>Type</th><th>Full representation</th><th>Representation using this context</th></tr>
      *   <tr><td>Class</td><td>java.lang.String</td><td>java.lang.String</td></tr>
      *   <tr><td>Primitive Class</td><td>char</td><td>char</td></tr>
@@ -24,9 +25,10 @@ public interface TypeFormatContext {
     TypeFormatContext DEFAULT = Class::getName;
 
     /**
-     * Full feature formatting context with class name simplified
+     *
      *
      * <table>
+     *   <caption>Full feature formatting context with class name simplified</caption>
      *   <tr><th>Type</th><th>Full representation</th><th>Representation using this context</th></tr>
      *   <tr><td>Class</td><td>java.lang.String</td><td>String</td></tr>
      *   <tr><td>Primitive Class</td><td>char</td><td>char</td></tr>
@@ -43,9 +45,10 @@ public interface TypeFormatContext {
     TypeFormatContext SIMPLE = Class::getSimpleName;
 
     /**
-     * Formatting context that formats every type as the result of {@code type.asClass().getName()}
+     *
      *
      * <table>
+     *   <caption>Formatting context that formats every type as the result of {@code type.asClass().getName()}</caption>
      *   <tr><th>Type</th><th>Full representation</th><th>Representation using this context</th></tr>
      *   <tr><td>Class</td><td>java.lang.String</td><td>java.lang.String</td></tr>
      *   <tr><td>Primitive Class</td><td>char</td><td>char</td></tr>

--- a/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeFormatContext.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/type/TypeFormatContext.java
@@ -69,8 +69,9 @@ public interface TypeFormatContext {
     /**
      * Format a type and push the result to provided {@link StringBuilder}.
      *
-     * @implNote Implementations are encouraged to override {@link #append(StringBuilder, TypeInfo,
-     *     boolean)} , instead of this method
+     * <p>Note that implementations are encouraged to override {@link #append(StringBuilder,
+     * TypeInfo, boolean)} , instead of this method
+     *
      * @param builder Formatted string of {@code type} will be pushed to this builder
      * @param type The type to be formatted
      */

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/OptRuntime.java
@@ -91,9 +91,9 @@ public final class OptRuntime extends ScriptRuntime {
         return f.call(cx, scope, thisObj, ScriptRuntime.emptyArgs);
     }
 
+    /** Implement x.property() call shrinking optimizer code. */
     @Deprecated(since = "1.8.1", forRemoval = true)
     @SuppressWarnings("removal")
-    /** Implement x.property() call shrinking optimizer code. */
     public static Object callProp0(Object value, String property, Context cx, VarScope scope) {
         Callable f = getPropFunctionAndThis(value, property, cx, scope);
         Scriptable thisObj = lastStoredScriptable(cx);

--- a/rhino/src/main/java/org/mozilla/javascript/sourcemap/SourceMapper.java
+++ b/rhino/src/main/java/org/mozilla/javascript/sourcemap/SourceMapper.java
@@ -27,7 +27,7 @@ public interface SourceMapper {
      * Returns the text of the given line within the named original source file. Used to populate
      * parser error messages with the offending line from the original source.
      *
-     * @param sourcePath the resolved source path (as returned in {@link Position#sourcePath()})
+     * @param sourcePath the resolved source path (as returned in {@link Position#getSourcePath()})
      * @param lineNumber 1-indexed line number in the original source
      * @return the line text, or {@code null} if the source is unknown, the line is out of range, or
      *     no original-source content is available

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeDataView.java
@@ -166,22 +166,6 @@ public class NativeDataView extends NativeArrayBufferView {
         return arrayBuffer.getLength() - offset;
     }
 
-    private static Object js_getByteOffset(Scriptable thisObj) {
-        NativeDataView self = realThis(thisObj);
-        if (self.isDataViewOutOfBounds()) {
-            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
-        }
-        return self.offset;
-    }
-
-    private static Object js_getByteLength(Scriptable thisObj) {
-        NativeDataView self = realThis(thisObj);
-        if (self.isDataViewOutOfBounds()) {
-            throw ScriptRuntime.typeErrorById("msg.dataview.bounds");
-        }
-        return self.getByteLength();
-    }
-
     private static Object js_getInt8(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         NativeDataView realThis = realThis(thisObj);

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeFloat16Array.java
@@ -14,10 +14,8 @@ import java.io.Serial;
 import org.mozilla.javascript.ClassDescriptor;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.JSFunction;
-import org.mozilla.javascript.LambdaConstructor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.ScriptRuntimeES6;
-import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
@@ -75,10 +73,6 @@ public class NativeFloat16Array extends NativeTypedArrayView<Float> {
     @Override
     public int getBytesPerElement() {
         return BYTES_PER_ELEMENT;
-    }
-
-    private static NativeFloat16Array realThis(Scriptable thisObj) {
-        return LambdaConstructor.convertThisObject(thisObj, NativeFloat16Array.class);
     }
 
     @Override

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_junit5_test", "java_test_suite")
 load("@rules_java//java:defs.bzl", "java_library")
+load("//bazel:errorprone.bzl", "TEST_OPTS")
 load("//bazel:sharded_test.bzl", "sharded_parameterized_test")
 
 filegroup(
@@ -23,6 +24,7 @@ java_library(
         "src/test/java/org/mozilla/javascript/tests/commonjs/**/*.java",
         "src/test/java/org/mozilla/javascript/drivers/**/*.java",
     ]),
+    javacopts = TEST_OPTS,
     deps = [
         "//rhino",
         "//rhino-tools",
@@ -50,6 +52,7 @@ java_test_suite(
         ],
     ),
     data = [":testsrc"],
+    javacopts = TEST_OPTS,
     jvm_flags = [
         "-Xmx1g",
         "-Djava.awt.headless=true",
@@ -62,7 +65,6 @@ java_test_suite(
     ],
     resources = glob(["src/test/resources/**"]),
     runner = "junit5",
-    tags = ["no-agent"],
     test_suffixes = ["Test.java"],
     deps = [
         ":rhino-tests-lib",
@@ -87,6 +89,7 @@ sharded_parameterized_test(
     size = "medium",
     srcs = ["src/test/java/org/mozilla/javascript/tests/MozillaSuiteTest.java"],
     data = [":testsrc"],
+    javacopts = TEST_OPTS,
     jvm_flags = [
         "-Xmx1g",
         "-Xss4m",
@@ -95,7 +98,6 @@ sharded_parameterized_test(
     ],
     resources = glob(["src/test/resources/**"]),
     shard_count = 16,
-    tags = ["no-agent"],
     test_class = "org.mozilla.javascript.tests.MozillaSuiteTest",
     deps = [
         ":rhino-tests-lib",
@@ -112,11 +114,11 @@ java_junit5_test(
     name = "SourceMapSpecSuiteTest",
     size = "small",
     srcs = ["src/test/java/org/mozilla/javascript/sourcemap/SourceMapSpecSuiteTest.java"],
-    data = [":testsrc"] + glob(["source-map-tests/**"]),
+    data = ["testsrc/source-map-tests-excludelist.txt"] + glob(["source-map-tests/**"]),
+    javacopts = TEST_OPTS,
     jvm_flags = [
         "-Xmx1g",
     ],
-    tags = ["no-agent"],
     test_class = "org.mozilla.javascript.sourcemap.SourceMapSpecSuiteTest",
     deps = [
         "//rhino",
@@ -130,12 +132,12 @@ sharded_parameterized_test(
     # "small" will result in build timeouts on GitHub Actions runners
     size = "medium",
     srcs = ["src/test/java/org/mozilla/javascript/tests/Test262SuiteTest.java"],
-    data = [":testsrc"] + glob(["test262/**"]),
+    data = ["testsrc/test262.properties"] + glob(["test262/**"]),
+    javacopts = TEST_OPTS,
     jvm_flags = [
         "-Xmx1g",
     ],
     shard_count = 32,
-    tags = ["no-agent"],
     test_class = "org.mozilla.javascript.tests.Test262SuiteTest",
     deps = [
         ":rhino-tests-lib",

--- a/testutils/BUILD.bazel
+++ b/testutils/BUILD.bazel
@@ -1,9 +1,11 @@
 load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_junit5_test")
 load("@rules_java//java:defs.bzl", "java_library")
+load("//bazel:errorprone.bzl", "LIBRARY_OPTS", "TEST_OPTS")
 
 java_library(
     name = "testutils",
     srcs = glob(["src/main/java/**/*.java"]),
+    javacopts = LIBRARY_OPTS,
     visibility = ["//visibility:public"],
     deps = [
         "//rhino",
@@ -16,6 +18,7 @@ java_junit5_test(
     size = "small",
     srcs = glob(["**/TestSourceTest.java"]),
     data = ["//tests:testsrc"],
+    javacopts = TEST_OPTS,
     tags = ["no-agent"],
     test_class = "org.mozilla.javascript.testutils.tests.TestSourceTest",
     deps = [

--- a/testutils/build.gradle
+++ b/testutils/build.gradle
@@ -10,3 +10,8 @@ dependencies {
     // with tests in other projects, code in here must be in "main".
     implementation libs.junit.jupiter.api
 }
+
+tasks.withType(Javadoc) {
+    failOnError = false
+    options.addStringOption('Xdoclint:all,-missing', '-quiet')
+}


### PR DESCRIPTION
Make Errorprone checks more consistent between Gradle and Bazel builds

Clean up some errors in code and in Javadoc that we let creep in recently that
Errorprone has been trying to tell us about.

Making them more likely to show up in Bazel also makes it more likely that I 
will notice them during code review!
