### PR TITLE
Extract abstract frame and interpreted function data ancestors.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/ACallFrame.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ACallFrame.java
@@ -1,0 +1,218 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import org.mozilla.javascript.debug.DebugFrame;
+import org.mozilla.javascript.debug.DebuggableScript;
+
+/**
+ * Interface representing a call frame in the interpreter. This abstraction allows both the original
+ * interpreter's CallFrame and InterpreterV2's CallFrameV2 to be used interchangeably for stack
+ * traces and debugging purposes.
+ */
+public abstract class ACallFrame<T extends ACallFrame<T, U>, U extends ACompilerData<?, U>>
+        implements Serializable {
+    private static final long serialVersionUID = 6100049821156242226L;
+
+    public final T parentFrame;
+    public final short frameIndex;
+    public final ACallFrame<?, ?> previousInterpreterFrame;
+    public final int parentPC;
+    public boolean frozen;
+
+    public ScriptOrFn<?> fnOrScript;
+    public U compilerData;
+
+    public final Object[] stack;
+    public final byte[] stackAttributes;
+    public final double[] doubleStack;
+
+    public Object result;
+    public double resultDbl;
+    public int pc;
+    public int stackTop = -1;
+    public VarScope scope;
+
+    // `this' might seem like it should be final, but is actually set
+    // by a call to a super constructor and so must be mutable.
+    public Scriptable thisObj;
+
+    public final DebugFrame debuggerFrame;
+    public final boolean useActivation;
+
+    public ACallFrame<T, U> varSource;
+    public final int localShift;
+    public final short emptyStackTop;
+    public Object throwable;
+    final boolean parentStrictness;
+
+    ACallFrame(
+            Context cx,
+            Scriptable thisObj,
+            ScriptOrFn<?> fnOrScript,
+            U code,
+            T parentFrame,
+            ACallFrame<?, ?> previousInterpreterFrame) {
+        compilerData = code;
+        debuggerFrame =
+                cx.debugger != null ? cx.debugger.getFrame(cx, fnOrScript.getDescriptor()) : null;
+        useActivation = fnOrScript.getDescriptor().requiresActivationFrame();
+
+        emptyStackTop = (short) (compilerData.maxVars + compilerData.maxLocals - 1);
+        int maxFrameArray = compilerData.maxFrameSize;
+        if (maxFrameArray != emptyStackTop + compilerData.maxStack + 1) Kit.codeBug();
+
+        stack = new Object[maxFrameArray];
+        stackAttributes = new byte[maxFrameArray];
+        doubleStack = new double[maxFrameArray];
+
+        this.fnOrScript = fnOrScript;
+        localShift = compilerData.maxVars;
+        varSource = this;
+        this.thisObj = thisObj;
+
+        this.parentFrame = parentFrame;
+        if (parentFrame == null) {
+            this.parentPC =
+                    previousInterpreterFrame == null
+                            ? -1
+                            : previousInterpreterFrame.getPcSourceLineStart();
+        } else {
+            this.parentPC = parentFrame.getPcSourceLineStart();
+        }
+        this.previousInterpreterFrame = previousInterpreterFrame;
+        frameIndex = (short) ((parentFrame == null) ? 0 : parentFrame.frameIndex + 1);
+        if (frameIndex > cx.getMaximumInterpreterStackDepth()) {
+            throw Context.reportRuntimeError("Exceeded maximum stack depth");
+        }
+
+        var desc = fnOrScript.getDescriptor();
+        if (desc.getFunctionType() != 0) {
+            this.parentStrictness =
+                    ScriptRuntime.enterFunctionStrictness(
+                            cx, fnOrScript.getDescriptor().isStrict());
+        } else {
+            this.parentStrictness = false;
+        }
+        // Initialize initial values of variables that change during
+        // interpretation.
+        result = Undefined.instance;
+    }
+
+    protected ACallFrame(T original, T parentFrame, ACallFrame<?, ?> previousInterpreterFrame) {
+        this(original, parentFrame, previousInterpreterFrame, true, false);
+    }
+
+    protected ACallFrame(
+            T original,
+            T parentFrame,
+            ACallFrame<?, ?> previousInterpreterFrame,
+            boolean copyStack,
+            boolean keepFrozen) {
+
+        if (!original.frozen) Kit.codeBug();
+
+        if (copyStack) {
+            stack = Arrays.copyOf(original.stack, original.stack.length);
+            stackAttributes =
+                    Arrays.copyOf(original.stackAttributes, original.stackAttributes.length);
+            doubleStack = Arrays.copyOf(original.doubleStack, original.doubleStack.length);
+        } else {
+            stack = original.stack;
+            stackAttributes = original.stackAttributes;
+            doubleStack = original.doubleStack;
+        }
+
+        localShift = original.localShift;
+
+        frozen = keepFrozen;
+        this.parentFrame = parentFrame;
+        this.previousInterpreterFrame = previousInterpreterFrame;
+        if (parentFrame == null) {
+            frameIndex = 0;
+            parentPC =
+                    previousInterpreterFrame == null
+                            ? -1
+                            : previousInterpreterFrame.getPcSourceLineStart();
+        } else {
+            frameIndex = original.frameIndex;
+            parentPC = parentFrame.parentPC;
+        }
+
+        fnOrScript = original.fnOrScript;
+        compilerData = original.compilerData;
+
+        if (original.varSource == original) {
+            varSource = this;
+        } else {
+            varSource = original.varSource;
+        }
+        emptyStackTop = original.emptyStackTop;
+
+        debuggerFrame = original.debuggerFrame;
+        useActivation = original.useActivation;
+
+        thisObj = original.thisObj;
+
+        result = original.result;
+        resultDbl = original.resultDbl;
+        pc = original.pc;
+        scope = original.scope;
+        parentStrictness = original.parentStrictness;
+        stackTop = original.stackTop;
+    }
+
+    /** Returns the index of this frame in the call stack (0 for the top-level frame). */
+    public abstract int getFrameIndex();
+
+    /** Returns the parent frame, or null if this is the top-level frame. */
+    public abstract ACallFrame<T, U> getParentFrame();
+
+    /**
+     * Returns the program counter position for source line information. For the original
+     * interpreter, this is the PC at the start of the current source line. For InterpreterV2, this
+     * may be the current PC.
+     */
+    public abstract int getPcSourceLineStart();
+
+    /** Returns the debuggable script data associated with this frame. */
+    public abstract DebuggableScript getData();
+
+    public int getParentPC() {
+        return -1;
+    }
+
+    public ACallFrame<?, ?> getPreviousInterpreterFrame() {
+        return null;
+    }
+
+    public ScriptOrFn<?> getFnOrScript() {
+        return null;
+    }
+
+    Object getFromVars(int offset) {
+        Object value = stack[offset];
+        if (value == UniqueTag.DOUBLE_MARK) {
+            return doubleStack[offset];
+        } else {
+            return value;
+        }
+    }
+
+    void setInVars(int offset, Object value) {
+        if (value instanceof Double && Double.isFinite((Double) value)) {
+            stack[offset] = UniqueTag.DOUBLE_MARK;
+            doubleStack[offset] = ((Double) value);
+        } else {
+            stack[offset] = value;
+        }
+    }
+
+    abstract T cloneFrozen();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ACompilerData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ACompilerData.java
@@ -1,0 +1,26 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+
+public abstract class ACompilerData<T extends ScriptOrFn<T>, U extends ACompilerData<?, U>>
+        extends JSCode<T> implements Serializable {
+    private static final long serialVersionUID = -2825944169262416223L;
+
+    public final int[] exceptionTable;
+
+    public final int maxVars;
+    public final int maxLocals;
+    public final int maxStack;
+    public final int maxFrameSize;
+
+    protected ACompilerData(
+            int maxVars, int maxLocals, int maxStack, int maxFrameSize, int[] exceptionTable) {
+        this.maxVars = maxVars;
+        this.maxLocals = maxLocals;
+        this.maxStack = maxStack;
+        this.maxFrameSize = maxFrameSize;
+        this.exceptionTable = exceptionTable;
+    }
+
+    public abstract int getLineNumberFromPc(int pc, int pcLineStart);
+}

--- a/rhino/src/main/java/org/mozilla/javascript/CallFrame.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CallFrame.java
@@ -70,9 +70,9 @@ class CallFrame implements Cloneable, Serializable {
                 cx.debugger != null ? cx.debugger.getFrame(cx, fnOrScript.getDescriptor()) : null;
         useActivation = fnOrScript.getDescriptor().requiresActivationFrame();
 
-        emptyStackTop = (short) (compilerData.itsMaxVars + compilerData.itsMaxLocals - 1);
-        int maxFrameArray = compilerData.itsMaxFrameArray;
-        if (maxFrameArray != emptyStackTop + compilerData.itsMaxStack + 1) Kit.codeBug();
+        emptyStackTop = (short) (compilerData.maxVars + compilerData.maxLocals - 1);
+        int maxFrameArray = compilerData.maxFrameArray;
+        if (maxFrameArray != emptyStackTop + compilerData.maxStack + 1) Kit.codeBug();
 
         stack = new Object[maxFrameArray];
         stackAttributes = new byte[maxFrameArray];
@@ -306,7 +306,7 @@ class CallFrame implements Cloneable, Serializable {
         if (argdoubleStack != null) {
             System.arraycopy(argdoubleStack, argShift, doubleStack, blen, definedArgs - blen);
         }
-        for (int i = definedArgs; i != compilerData.itsMaxVars; ++i) {
+        for (int i = definedArgs; i != compilerData.maxVars; ++i) {
             stack[i] = Undefined.instance;
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/CallFrame.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CallFrame.java
@@ -1,105 +1,30 @@
 package org.mozilla.javascript;
 
-import java.io.Serializable;
 import java.util.Arrays;
 import org.mozilla.javascript.ast.FunctionNode;
-import org.mozilla.javascript.debug.DebugFrame;
+import org.mozilla.javascript.debug.DebuggableScript;
 
 /** Class to hold data corresponding to one interpreted call stack frame. */
-class CallFrame implements Cloneable, Serializable {
+final class CallFrame extends ACallFrame<CallFrame, InterpreterData<?>> implements Cloneable {
     private static final long serialVersionUID = -2843792508994958978L;
 
-    // fields marked "final" in a comment are effectively final except when they're
-    // modified
-    // immediately after cloning.
-
-    final CallFrame parentFrame;
-    // amount of stack frames before this one on the interpretation stack
-    final short frameIndex;
-    // The frame that the iterator was executing.
-    final CallFrame previousInterpreterFrame;
-    final int parentPC;
-    // If true indicates read-only frame that is a part of continuation
-    boolean frozen;
-
-    final ScriptOrFn<?> fnOrScript;
-    final InterpreterData<?> compilerData;
-
-    // Stack structure
-    // stack[0 <= i < localShift]: arguments and local variables
-    // stack[localShift <= i <= emptyStackTop]: used for local temporaries
-    // stack[emptyStackTop < i < stack.length]: stack data
-    // doubleStack[i]: if stack[i] is UniqueTag.DOUBLE_MARK, doubleStack[i] holds the number value
-
-    final Object[] stack;
-    final byte[] stackAttributes;
-    final double[] doubleStack;
-
-    final CallFrame varSource; // defaults to this unless continuation frame
-    final short emptyStackTop;
-
-    final DebugFrame debuggerFrame;
-    final boolean useActivation;
     boolean isContinuationsTopFrame;
-
-    final Scriptable thisObj;
 
     // The values that change during interpretation
 
-    Object result;
-    double resultDbl;
-    int pc;
     int pcPrevBranch;
     int pcSourceLineStart;
-    VarScope scope;
 
-    int stackTop;
     int savedCallOp;
-    Object throwable;
-    boolean parentStrictness;
 
     CallFrame(
             Context cx,
             Scriptable thisObj,
-            ScriptOrFn fnOrScript,
-            InterpreterData code,
+            ScriptOrFn<?> fnOrScript,
+            InterpreterData<?> code,
             CallFrame parentFrame,
-            CallFrame previousInterpreterFrame) {
-        compilerData = code;
-        debuggerFrame =
-                cx.debugger != null ? cx.debugger.getFrame(cx, fnOrScript.getDescriptor()) : null;
-        useActivation = fnOrScript.getDescriptor().requiresActivationFrame();
-
-        emptyStackTop = (short) (compilerData.maxVars + compilerData.maxLocals - 1);
-        int maxFrameArray = compilerData.maxFrameArray;
-        if (maxFrameArray != emptyStackTop + compilerData.maxStack + 1) Kit.codeBug();
-
-        stack = new Object[maxFrameArray];
-        stackAttributes = new byte[maxFrameArray];
-        doubleStack = new double[maxFrameArray];
-
-        this.fnOrScript = fnOrScript;
-        varSource = this;
-        this.thisObj = thisObj;
-
-        this.parentFrame = parentFrame;
-        if (parentFrame == null) {
-            this.parentPC =
-                    previousInterpreterFrame == null
-                            ? -1
-                            : previousInterpreterFrame.pcSourceLineStart;
-        } else {
-            this.parentPC = parentFrame.pcSourceLineStart;
-        }
-        this.previousInterpreterFrame = previousInterpreterFrame;
-        frameIndex = (short) ((parentFrame == null) ? 0 : parentFrame.frameIndex + 1);
-        if (frameIndex > cx.getMaximumInterpreterStackDepth()) {
-            throw Context.reportRuntimeError("Exceeded maximum stack depth");
-        }
-
-        // Initialize initial values of variables that change during
-        // interpretation.
-        result = Undefined.instance;
+            ACallFrame<?, ?> previousInterpreterFrame) {
+        super(cx, thisObj, fnOrScript, code, parentFrame, previousInterpreterFrame);
         pcSourceLineStart = compilerData.firstLinePC;
 
         stackTop = emptyStackTop;
@@ -112,104 +37,34 @@ class CallFrame implements Cloneable, Serializable {
                 makeOrphan ? null : original.previousInterpreterFrame);
     }
 
-    /*
-     * Copy the frame for *continuations*. Here we want to make
-     * fresh copies of the stack and everything related to it.
-     */
-    private CallFrame(
-            CallFrame original, CallFrame parentFrame, CallFrame previousInterpreterFrame) {
-        if (!original.frozen) Kit.codeBug();
-
-        stack = Arrays.copyOf(original.stack, original.stack.length);
-        stackAttributes = Arrays.copyOf(original.stackAttributes, original.stackAttributes.length);
-        doubleStack = Arrays.copyOf(original.doubleStack, original.doubleStack.length);
-
-        frozen = false;
-        this.parentFrame = parentFrame;
-        this.previousInterpreterFrame = previousInterpreterFrame;
-        if (parentFrame == null) {
-            frameIndex = 0;
-            parentPC =
-                    previousInterpreterFrame == null
-                            ? -1
-                            : previousInterpreterFrame.pcSourceLineStart;
-        } else {
-            frameIndex = original.frameIndex;
-            parentPC = parentFrame.pcSourceLineStart;
-        }
-
-        fnOrScript = original.fnOrScript;
-        compilerData = original.compilerData;
-
-        varSource = original.varSource;
-        emptyStackTop = original.emptyStackTop;
-
-        debuggerFrame = original.debuggerFrame;
-        useActivation = original.useActivation;
+    /* Copy the frame for *continuations*. Here we want to make
+    fresh copies of the stack and everything related to it. */
+    CallFrame(
+            CallFrame original, CallFrame parentFrame, ACallFrame<?, ?> previousInterpreterFrame) {
+        super(original, parentFrame, previousInterpreterFrame);
         isContinuationsTopFrame = original.isContinuationsTopFrame;
 
-        thisObj = original.thisObj;
-
-        result = original.result;
-        resultDbl = original.resultDbl;
-        pc = original.pc;
-        pcPrevBranch = original.pcPrevBranch;
         pcSourceLineStart = original.pcSourceLineStart;
-        scope = original.scope;
+        pcPrevBranch = original.pcPrevBranch;
 
         stackTop = original.stackTop;
         savedCallOp = original.savedCallOp;
         throwable = original.throwable;
     }
 
-    /*
-     * Copy the stack for running a generator. We're only doing
-     * this to maintain the correct chain of parents for exception
-     * stacks, so we'll reuse the existing stack arrays.
-     */
-    private CallFrame(
+    /* Copy the stack for running a generator. We're only doing
+    this to maintain the correct chain of parents for exception
+    stacks, so we'll reuse the existing stack arrays. */
+    CallFrame(
             CallFrame original,
             CallFrame parentFrame,
-            CallFrame previousInterpreterFrame,
+            ACallFrame<?, ?> previousInterpreterFrame,
             boolean keepFrozen) {
-        if (!original.frozen) Kit.codeBug();
-
-        stack = original.stack;
-        stackAttributes = original.stackAttributes;
-        doubleStack = original.doubleStack;
-
-        frozen = keepFrozen;
-        this.parentFrame = parentFrame;
-        this.previousInterpreterFrame = previousInterpreterFrame;
-        if (parentFrame == null) {
-            frameIndex = 0;
-            parentPC =
-                    previousInterpreterFrame == null
-                            ? -1
-                            : previousInterpreterFrame.pcSourceLineStart;
-        } else {
-            frameIndex = original.frameIndex;
-            parentPC = parentFrame.pcSourceLineStart;
-        }
-
-        fnOrScript = original.fnOrScript;
-        compilerData = original.compilerData;
-
-        varSource = original.varSource;
-        emptyStackTop = original.emptyStackTop;
-
-        debuggerFrame = original.debuggerFrame;
-        useActivation = original.useActivation;
+        super(original, parentFrame, previousInterpreterFrame, false, keepFrozen);
         isContinuationsTopFrame = original.isContinuationsTopFrame;
 
-        thisObj = original.thisObj;
-
-        result = original.result;
-        resultDbl = original.resultDbl;
-        pc = original.pc;
-        pcPrevBranch = original.pcPrevBranch;
         pcSourceLineStart = original.pcSourceLineStart;
-        scope = original.scope;
+        pcPrevBranch = original.pcPrevBranch;
 
         stackTop = original.stackTop;
         savedCallOp = original.savedCallOp;
@@ -220,7 +75,7 @@ class CallFrame implements Cloneable, Serializable {
             Context cx,
             VarScope callerScope,
             Object[] args,
-            double[] argdoubleStack,
+            double[] argsDbl,
             Object[] boundArgs,
             int argShift,
             int argCount,
@@ -229,20 +84,17 @@ class CallFrame implements Cloneable, Serializable {
         if (useActivation) {
             // Copy args to new array to pass to enterActivationFunction
             // or debuggerFrame.onEnter
-            if (argdoubleStack != null || boundArgs != null) {
+            if (argsDbl != null || boundArgs != null) {
                 int blen = boundArgs == null ? 0 : boundArgs.length;
-                args =
-                        Interpreter.getArgsArray(
-                                args, argdoubleStack, boundArgs, blen, argShift, argCount);
+                args = Interpreter.getArgsArray(args, argsDbl, boundArgs, blen, argShift, argCount);
             }
             argShift = 0;
-            argdoubleStack = null;
+            argsDbl = null;
             boundArgs = null;
         }
 
         if (desc.getFunctionType() != 0) {
             scope = fnOrScript.getDeclarationScope();
-            this.parentStrictness = ScriptRuntime.enterFunctionStrictness(cx, desc.isStrict());
 
             if (useActivation) {
                 if (desc.getFunctionType() == FunctionNode.ARROW_FUNCTION) {
@@ -270,15 +122,14 @@ class CallFrame implements Cloneable, Serializable {
             ScriptRuntime.initScript(fnOrScript, thisObj, cx, scope, desc.isEvalFunction());
         }
 
-        // Defer default parameters and nested function declarations until activation
-        // scope
+        // Defer default parameters and nested function declarations until activation scope
         // creation
         // Ref: Ecma 2026, 10.2.11, FunctionDeclarationInstantiation
 
         if (desc.getFunctionCount() != 0 && !desc.isES6Generator()) {
             if (desc.getFunctionType() != 0 && !desc.requiresActivationFrame()) Kit.codeBug();
             for (int i = 0; i < desc.getFunctionCount(); i++) {
-                JSDescriptor fdesc = desc.getFunction(i);
+                JSDescriptor<?> fdesc = desc.getFunction(i);
                 if (fdesc.getFunctionType() == FunctionNode.FUNCTION_STATEMENT) {
                     Interpreter.initFunction(cx, scope, fnOrScript.getDescriptor(), i);
                 }
@@ -303,8 +154,8 @@ class CallFrame implements Cloneable, Serializable {
         }
 
         System.arraycopy(args, argShift, stack, blen, definedArgs - blen);
-        if (argdoubleStack != null) {
-            System.arraycopy(argdoubleStack, argShift, doubleStack, blen, definedArgs - blen);
+        if (argsDbl != null) {
+            System.arraycopy(argsDbl, argShift, doubleStack, blen, definedArgs - blen);
         }
         for (int i = definedArgs; i != compilerData.maxVars; ++i) {
             stack[i] = Undefined.instance;
@@ -320,7 +171,7 @@ class CallFrame implements Cloneable, Serializable {
                 for (int valsIdx = 0; valsIdx != vals.length; ++argShift, ++valsIdx) {
                     Object val = args[argShift];
                     if (val == UniqueTag.DOUBLE_MARK) {
-                        val = ScriptRuntime.wrapNumber(argdoubleStack[argShift]);
+                        val = ScriptRuntime.wrapNumber(argsDbl[argShift]);
                     }
                     vals[valsIdx] = val;
                 }
@@ -331,11 +182,12 @@ class CallFrame implements Cloneable, Serializable {
         }
     }
 
+    @Override
     CallFrame cloneFrozen() {
         return new CallFrame(this, false);
     }
 
-    CallFrame shallowCloneFrozen(CallFrame newPreviousInterpreeterFrame) {
+    CallFrame shallowCloneFrozen(ACallFrame<?, ?> newPreviousInterpreeterFrame) {
         return new CallFrame(this, this.parentFrame, newPreviousInterpreeterFrame, true);
     }
 
@@ -449,21 +301,40 @@ class CallFrame implements Cloneable, Serializable {
         return new CallFrame(this, true);
     }
 
-    Object getFromVars(int offset) {
-        Object value = stack[offset];
-        if (value == UniqueTag.DOUBLE_MARK) {
-            return doubleStack[offset];
-        } else {
-            return value;
-        }
+    // ACallFrame implementation
+
+    @Override
+    public int getFrameIndex() {
+        return frameIndex;
     }
 
-    void setInVars(int offset, Object value) {
-        if (value instanceof Double && Double.isFinite((Double) value)) {
-            stack[offset] = UniqueTag.DOUBLE_MARK;
-            doubleStack[offset] = ((Double) value);
-        } else {
-            stack[offset] = value;
-        }
+    @Override
+    public CallFrame getParentFrame() {
+        return parentFrame;
+    }
+
+    @Override
+    public int getPcSourceLineStart() {
+        return pcSourceLineStart;
+    }
+
+    @Override
+    public DebuggableScript getData() {
+        return fnOrScript.getDescriptor();
+    }
+
+    @Override
+    public int getParentPC() {
+        return parentPC;
+    }
+
+    @Override
+    public ACallFrame<?, ?> getPreviousInterpreterFrame() {
+        return previousInterpreterFrame;
+    }
+
+    @Override
+    public ScriptOrFn<?> getFnOrScript() {
+        return fnOrScript;
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -187,10 +187,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
                 itsData.itsBigIntTable[index] = bigInt;
             }
         }
-        if (exceptionTableTop != 0 && itsData.itsExceptionTable.length != exceptionTableTop) {
+        if (exceptionTableTop != 0 && itsData.exceptionTable.length != exceptionTableTop) {
             int[] tmp = new int[exceptionTableTop];
-            System.arraycopy(itsData.itsExceptionTable, 0, tmp, 0, exceptionTableTop);
-            itsData.itsExceptionTable = tmp;
+            System.arraycopy(itsData.exceptionTable, 0, tmp, 0, exceptionTableTop);
+            itsData.exceptionTable = tmp;
         }
 
         itsData.maxVars = scriptOrFn.getParamAndVarCount();
@@ -1955,15 +1955,15 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
             int exceptionObjectLocal,
             int scopeLocal) {
         int top = exceptionTableTop;
-        int[] table = itsData.itsExceptionTable;
+        int[] table = itsData.exceptionTable;
         if (table == null) {
             if (top != 0) Kit.codeBug();
             table = new int[Interpreter.EXCEPTION_SLOT_SIZE * 2];
-            itsData.itsExceptionTable = table;
+            itsData.exceptionTable = table;
         } else if (table.length == top) {
             table = new int[table.length * 2];
-            System.arraycopy(itsData.itsExceptionTable, 0, table, 0, top);
-            itsData.itsExceptionTable = table;
+            System.arraycopy(itsData.exceptionTable, 0, table, 0, top);
+            itsData.exceptionTable = table;
         }
         table[top + Interpreter.EXCEPTION_TRY_START_SLOT] = icodeStart;
         table[top + Interpreter.EXCEPTION_TRY_END_SLOT] = icodeEnd;

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -193,10 +193,10 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
             itsData.itsExceptionTable = tmp;
         }
 
-        itsData.itsMaxVars = scriptOrFn.getParamAndVarCount();
-        // itsMaxFrameArray: interpret method needs this amount for its
+        itsData.maxVars = scriptOrFn.getParamAndVarCount();
+        // maxFrameArray: interpret method needs this amount for its
         // stack and sDbl arrays
-        itsData.itsMaxFrameArray = itsData.itsMaxVars + itsData.itsMaxLocals + itsData.itsMaxStack;
+        itsData.maxFrameArray = itsData.maxVars + itsData.maxLocals + itsData.maxStack;
 
         if (literalIds.size() != 0) {
             itsData.literalIds = literalIds.toArray();
@@ -706,8 +706,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
                         // ref_call: f, thisObj, args -> ref
                         stackChange(-1 - argCount);
                     }
-                    if (argCount > itsData.itsMaxCalleeArgs) {
-                        itsData.itsMaxCalleeArgs = argCount;
+                    if (argCount > itsData.maxCalleeArgs) {
+                        itsData.maxCalleeArgs = argCount;
                     }
 
                     if (completeOptionalCallJump != null) {
@@ -1994,8 +1994,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
             stackDepth += change;
         } else {
             int newDepth = stackDepth + change;
-            if (newDepth > itsData.itsMaxStack) {
-                itsData.itsMaxStack = newDepth;
+            if (newDepth > itsData.maxStack) {
+                itsData.maxStack = newDepth;
             }
             stackDepth = newDepth;
         }
@@ -2004,8 +2004,8 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
     private int allocLocal() {
         int localSlot = localTop;
         ++localTop;
-        if (localTop > itsData.itsMaxLocals) {
-            itsData.itsMaxLocals = localTop;
+        if (localTop > itsData.maxLocals) {
+            itsData.maxLocals = localTop;
         }
         return localSlot;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -314,7 +314,7 @@ public final class Interpreter implements Evaluator {
     }
 
     private static int getExceptionHandler(CallFrame frame, boolean onlyFinally) {
-        int[] exceptionTable = frame.compilerData.itsExceptionTable;
+        int[] exceptionTable = frame.compilerData.exceptionTable;
         if (exceptionTable == null) {
             // No exception handlers
             return -1;
@@ -383,7 +383,7 @@ public final class Interpreter implements Evaluator {
             pc += icodeLength;
         }
 
-        int[] table = compilerData.itsExceptionTable;
+        int[] table = compilerData.exceptionTable;
         if (table != null) {
             out.println("Exception handlers: " + table.length / EXCEPTION_SLOT_SIZE);
             for (int i = 0; i != table.length; i += EXCEPTION_SLOT_SIZE) {
@@ -4492,7 +4492,7 @@ public final class Interpreter implements Evaluator {
                 frame = frame.cloneFrozen();
             }
 
-            int[] table = frame.compilerData.itsExceptionTable;
+            int[] table = frame.compilerData.exceptionTable;
 
             frame.stackTop = frame.emptyStackTop;
 

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -366,7 +366,7 @@ public final class Interpreter implements Evaluator {
         int iCodeLength = iCode.length;
         PrintStream out = interpreterBytecodePrintStream;
         out.println("ICode dump, for " + desc.name + ", length = " + iCodeLength);
-        out.println("MaxStack = " + compilerData.itsMaxStack);
+        out.println("MaxStack = " + compilerData.maxStack);
 
         ICodeDumpContext ctx = new ICodeDumpContext(out, compilerData);
 
@@ -1638,7 +1638,7 @@ public final class Interpreter implements Evaluator {
     private static class DoRethrow extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             state.throwable = frame.stack[state.indexReg];
             return BREAK_WITHOUT_EXTENSION;
         }
@@ -1951,7 +1951,7 @@ public final class Interpreter implements Evaluator {
             final InterpreterData compilerData = frame.compilerData;
             if (frame.stackTop == frame.emptyStackTop + 1) {
                 // Call from Icode.GOSUB: store return PC address in the local
-                state.indexReg += compilerData.itsMaxVars;
+                state.indexReg += compilerData.maxVars;
                 stack[state.indexReg] = stack[frame.stackTop];
                 sDbl[state.indexReg] = sDbl[frame.stackTop];
                 --frame.stackTop;
@@ -1972,7 +1972,7 @@ public final class Interpreter implements Evaluator {
             if (state.instructionCounting) {
                 addInstructionCount(cx, frame, 0);
             }
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             Object value = frame.stack[state.indexReg];
             if (value != DOUBLE_MARK) {
                 // Invocation from exception handler, restore object to
@@ -2750,7 +2750,7 @@ public final class Interpreter implements Evaluator {
             final double[] sDbl = frame.doubleStack;
             final InterpreterData compilerData = frame.compilerData;
             ++frame.stackTop;
-            state.indexReg += compilerData.itsMaxVars;
+            state.indexReg += compilerData.maxVars;
             stack[frame.stackTop] = stack[state.indexReg];
             sDbl[frame.stackTop] = sDbl[state.indexReg];
             return null;
@@ -2762,7 +2762,7 @@ public final class Interpreter implements Evaluator {
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
             final Object[] stack = frame.stack;
             final InterpreterData compilerData = frame.compilerData;
-            state.indexReg += compilerData.itsMaxVars;
+            state.indexReg += compilerData.maxVars;
             stack[state.indexReg] = null;
             return null;
         }
@@ -3692,7 +3692,7 @@ public final class Interpreter implements Evaluator {
             // state.stringReg: name of exception variable
             // state.indexReg: local for exception scope
             --frame.stackTop;
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
 
             boolean afterFirstScope = (frame.compilerData.itsICode[frame.pc] != 0);
             Throwable caughtException = (Throwable) frame.stack[frame.stackTop + 1];
@@ -3723,7 +3723,7 @@ public final class Interpreter implements Evaluator {
             Object lhs = frame.stack[frame.stackTop];
             if (lhs == DOUBLE_MARK)
                 lhs = ScriptRuntime.wrapNumber(frame.doubleStack[frame.stackTop]);
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             int enumType =
                     op == Token.ENUM_INIT_KEYS
                             ? cx.getLanguageVersion() <= Context.VERSION_1_8
@@ -3743,7 +3743,7 @@ public final class Interpreter implements Evaluator {
     private static class DoEnumOp extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             Object val = frame.stack[state.indexReg];
             frame.stack[++frame.stackTop] =
                     (op == Token.ENUM_NEXT)
@@ -3831,7 +3831,7 @@ public final class Interpreter implements Evaluator {
     private static class DoScopeLoad extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             frame.scope = (VarScope) frame.stack[state.indexReg];
             return null;
         }
@@ -3840,7 +3840,7 @@ public final class Interpreter implements Evaluator {
     private static class DoScopeSave extends InstructionClass {
         @Override
         NewState execute(Context cx, CallFrame frame, InterpreterState state, int op) {
-            state.indexReg += frame.compilerData.itsMaxVars;
+            state.indexReg += frame.compilerData.maxVars;
             frame.stack[state.indexReg] = frame.scope;
             return null;
         }
@@ -4501,7 +4501,7 @@ public final class Interpreter implements Evaluator {
                 frame.pcPrevBranch = frame.pc;
             }
 
-            int localShift = frame.compilerData.itsMaxVars;
+            int localShift = frame.compilerData.maxVars;
             int scopeLocal = localShift + table[indexReg + EXCEPTION_SCOPE_SLOT];
             int exLocal = localShift + table[indexReg + EXCEPTION_LOCAL_SLOT];
             frame.scope = (VarScope) frame.stack[scopeLocal];

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -12,7 +12,8 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Map;
 
-final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implements Serializable {
+final class InterpreterData<T extends ScriptOrFn<T>> extends ACompilerData<T, InterpreterData<?>>
+        implements Serializable {
     @Serial private static final long serialVersionUID = 5067677351589230234L;
 
     static final int INITIAL_MAX_ICODE_LENGTH = 1024;
@@ -24,7 +25,6 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             String[] itsStringTable,
             double[] itsDoubleTable,
             BigInteger[] itsBigIntTable,
-            InterpreterData<JSFunction>[] itsNestedFunctions,
             Object[] itsRegExpLiterals,
             Object[] itsTemplateLiterals,
             byte[] itsICode,
@@ -37,18 +37,13 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             Object[] literalIds,
             Map<Integer, Integer> longJumps,
             int firstLinePC) {
+        super(maxVars, maxLocals, maxStack, maxFrameArray, exceptionTable);
         this.itsStringTable = itsStringTable;
         this.itsDoubleTable = itsDoubleTable;
         this.itsBigIntTable = itsBigIntTable;
-        this.itsNestedFunctions = itsNestedFunctions;
         this.itsRegExpLiterals = itsRegExpLiterals;
         this.itsTemplateLiterals = itsTemplateLiterals;
         this.itsICode = itsICode;
-        this.exceptionTable = exceptionTable;
-        this.maxVars = maxVars;
-        this.maxLocals = maxLocals;
-        this.maxStack = maxStack;
-        this.maxFrameArray = maxFrameArray;
         this.maxCalleeArgs = maxCalleeArgs;
         this.literalIds = literalIds;
         this.longJumps = longJumps;
@@ -58,18 +53,10 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
     final String[] itsStringTable;
     final double[] itsDoubleTable;
     final BigInteger[] itsBigIntTable;
-    final InterpreterData<JSFunction>[] itsNestedFunctions;
     final Object[] itsRegExpLiterals;
     final Object[] itsTemplateLiterals;
 
     final byte[] itsICode;
-
-    final int[] exceptionTable;
-
-    final int maxVars;
-    final int maxLocals;
-    final int maxStack;
-    final int maxFrameArray;
 
     final int maxCalleeArgs;
 
@@ -80,6 +67,16 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
     final int firstLinePC;
 
     private int icodeHashCode = 0;
+
+    @Override
+    public int getLineNumberFromPc(int pc, int pcSourceLineStart) {
+        if (pcSourceLineStart >= 0) {
+            return ((itsICode[pcSourceLineStart] & 0xFF) << 8)
+                    | (itsICode[pcSourceLineStart + 1] & 0xFF);
+        } else {
+            return 0;
+        }
+    }
 
     public int icodeHashCode() {
         int h = icodeHashCode;
@@ -120,7 +117,6 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
         String[] itsStringTable;
         double[] itsDoubleTable;
         BigInteger[] itsBigIntTable;
-        InterpreterData<JSFunction>[] itsNestedFunctions;
         Object[] itsRegExpLiterals;
         Object[] itsTemplateLiterals;
 
@@ -158,7 +154,6 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
                                 itsStringTable,
                                 itsDoubleTable,
                                 itsBigIntTable,
-                                itsNestedFunctions,
                                 itsRegExpLiterals,
                                 itsTemplateLiterals,
                                 itsICode,

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -28,7 +28,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             Object[] itsRegExpLiterals,
             Object[] itsTemplateLiterals,
             byte[] itsICode,
-            int[] itsExceptionTable,
+            int[] exceptionTable,
             int maxVars,
             int maxLocals,
             int maxStack,
@@ -44,7 +44,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
         this.itsRegExpLiterals = itsRegExpLiterals;
         this.itsTemplateLiterals = itsTemplateLiterals;
         this.itsICode = itsICode;
-        this.itsExceptionTable = itsExceptionTable;
+        this.exceptionTable = exceptionTable;
         this.maxVars = maxVars;
         this.maxLocals = maxLocals;
         this.maxStack = maxStack;
@@ -64,7 +64,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
 
     final byte[] itsICode;
 
-    final int[] itsExceptionTable;
+    final int[] exceptionTable;
 
     final int maxVars;
     final int maxLocals;
@@ -126,7 +126,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
 
         byte[] itsICode;
 
-        int[] itsExceptionTable;
+        int[] exceptionTable;
 
         int maxVars;
         int maxLocals;
@@ -162,7 +162,7 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
                                 itsRegExpLiterals,
                                 itsTemplateLiterals,
                                 itsICode,
-                                itsExceptionTable,
+                                exceptionTable,
                                 maxVars,
                                 maxLocals,
                                 maxStack,

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterData.java
@@ -29,11 +29,11 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
             Object[] itsTemplateLiterals,
             byte[] itsICode,
             int[] itsExceptionTable,
-            int itsMaxVars,
-            int itsMaxLocals,
-            int itsMaxStack,
-            int itsMaxFrameArray,
-            int itsMaxCalleeArgs,
+            int maxVars,
+            int maxLocals,
+            int maxStack,
+            int maxFrameArray,
+            int maxCalleeArgs,
             Object[] literalIds,
             Map<Integer, Integer> longJumps,
             int firstLinePC) {
@@ -45,11 +45,11 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
         this.itsTemplateLiterals = itsTemplateLiterals;
         this.itsICode = itsICode;
         this.itsExceptionTable = itsExceptionTable;
-        this.itsMaxVars = itsMaxVars;
-        this.itsMaxLocals = itsMaxLocals;
-        this.itsMaxStack = itsMaxStack;
-        this.itsMaxFrameArray = itsMaxFrameArray;
-        this.itsMaxCalleeArgs = itsMaxCalleeArgs;
+        this.maxVars = maxVars;
+        this.maxLocals = maxLocals;
+        this.maxStack = maxStack;
+        this.maxFrameArray = maxFrameArray;
+        this.maxCalleeArgs = maxCalleeArgs;
         this.literalIds = literalIds;
         this.longJumps = longJumps;
         this.firstLinePC = firstLinePC;
@@ -66,12 +66,12 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
 
     final int[] itsExceptionTable;
 
-    final int itsMaxVars;
-    final int itsMaxLocals;
-    final int itsMaxStack;
-    final int itsMaxFrameArray;
+    final int maxVars;
+    final int maxLocals;
+    final int maxStack;
+    final int maxFrameArray;
 
-    final int itsMaxCalleeArgs;
+    final int maxCalleeArgs;
 
     final Object[] literalIds;
 
@@ -128,12 +128,12 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
 
         int[] itsExceptionTable;
 
-        int itsMaxVars;
-        int itsMaxLocals;
-        int itsMaxStack;
-        int itsMaxFrameArray;
+        int maxVars;
+        int maxLocals;
+        int maxStack;
+        int maxFrameArray;
 
-        int itsMaxCalleeArgs;
+        int maxCalleeArgs;
 
         Object[] literalIds;
 
@@ -163,11 +163,11 @@ final class InterpreterData<T extends ScriptOrFn<T>> extends JSCode<T> implement
                                 itsTemplateLiterals,
                                 itsICode,
                                 itsExceptionTable,
-                                itsMaxVars,
-                                itsMaxLocals,
-                                itsMaxStack,
-                                itsMaxFrameArray,
-                                itsMaxCalleeArgs,
+                                maxVars,
+                                maxLocals,
+                                maxStack,
+                                maxFrameArray,
+                                maxCalleeArgs,
                                 literalIds,
                                 jumpMap,
                                 firstLinePC);


### PR DESCRIPTION
This moves a bunch of fields and functionality that will be common between the two interpreters to abstract parent classes. These classes are parameterised to ensure the correct relationship between the various elements. This is the next part of #2426.