### PR TITLE
Introduce interpreter V2 infrastructure.

### DIFF
--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -122,6 +122,18 @@ decycle {
     // accepted cycle: o.m.j.ast is strongly coupled to o.m.j
     ignoring from: "org.mozilla.javascript.*", to: "org.mozilla.javascript.ast.*"
 
+    // accepted cycle: o.m.j.interpreterv2 is strongly coupled to o.m.j
+    ignoring from: "org.mozilla.javascript.*", to: "org.mozilla.javascript.interpreterv2.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.*", to: "org.mozilla.javascript.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.instruction.*", to: "org.mozilla.javascript.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.operand.*", to: "org.mozilla.javascript.*"
+    // accepted cycle: interpreterv2 sub-packages are tightly coupled
+    ignoring from: "org.mozilla.javascript.interpreterv2.*", to: "org.mozilla.javascript.interpreterv2.instruction.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.*", to: "org.mozilla.javascript.interpreterv2.operand.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.instruction.*", to: "org.mozilla.javascript.interpreterv2.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.instruction.*", to: "org.mozilla.javascript.interpreterv2.operand.*"
+    ignoring from: "org.mozilla.javascript.interpreterv2.operand.*", to: "org.mozilla.javascript.interpreterv2.*"
+
     // accepted cycle: typedarrays are strongly coupled. (See #1893 of an idea, how to remove)
     ignoring from: "org.mozilla.javascript.ScriptRuntime", to: "org.mozilla.javascript.typedarrays.*"
     ignoring from: "org.mozilla.javascript.NativeArrayIterator", to: "org.mozilla.javascript.typedarrays.NativeTypedArrayView"

--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -26,4 +26,9 @@ module org.mozilla.rhino {
     requires java.compiler;
     requires jdk.dynalink;
     requires transitive java.desktop;
+    requires java.logging;
+
+    exports org.mozilla.javascript.interpreterv2;
+    exports org.mozilla.javascript.interpreterv2.instruction;
+    exports org.mozilla.javascript.interpreterv2.operand;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/CallFrameV2.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CallFrameV2.java
@@ -1,0 +1,420 @@
+package org.mozilla.javascript;
+
+import static org.mozilla.javascript.UniqueTag.DOUBLE_MARK;
+
+import java.io.Serializable;
+import org.mozilla.javascript.ast.FunctionNode;
+import org.mozilla.javascript.debug.DebuggableScript;
+import org.mozilla.javascript.interpreterv2.CompilerData;
+import org.mozilla.javascript.interpreterv2.GeneratorState;
+import org.mozilla.javascript.interpreterv2.operand.Operand;
+
+public class CallFrameV2 extends ACallFrame<CallFrameV2, CompilerData<?>> implements Serializable {
+
+    public int pcPrevBranch;
+    public boolean shouldYieldToParent;
+    public GeneratorState generatorState;
+
+    public CallFrameV2(
+            Context cx,
+            VarScope callerScope,
+            Scriptable thisObj,
+            Scriptable homeObj,
+            Object[] args,
+            double[] doubleArgs,
+            int argShift,
+            int argCount,
+            ScriptOrFn<?> fnOrScript,
+            CallFrameV2 parentFrame,
+            ACallFrame<?, ?> previousInterpreterFrame) {
+        super(
+                cx,
+                thisObj,
+                fnOrScript,
+                (CompilerData<?>) fnOrScript.getDescriptor().getCode(),
+                parentFrame,
+                previousInterpreterFrame);
+        stackTop = emptyStackTop;
+
+        // Start of initializeArgs()
+        if (useActivation) {
+            // Copy args to new array to pass to enterActivationFunction or debuggerFrame.onEnter
+            if (doubleArgs != null) {
+                args = wrapArguments(args, doubleArgs, argShift, argCount);
+            }
+            argShift = 0;
+            doubleArgs = null;
+        }
+
+        JSDescriptor<?> desc = fnOrScript.getDescriptor();
+        if (!(fnOrScript instanceof JSScript)) {
+            scope = fnOrScript.getDeclarationScope();
+
+            if (useActivation) {
+                if (desc.getFunctionType() == FunctionNode.ARROW_FUNCTION) {
+                    scope =
+                            ScriptRuntime.createArrowFunctionActivation(
+                                    (JSFunction) fnOrScript,
+                                    cx,
+                                    scope,
+                                    args,
+                                    desc.hasRestArg(),
+                                    desc.requiresArgumentObject());
+                } else {
+                    scope =
+                            ScriptRuntime.createFunctionActivation(
+                                    (JSFunction) fnOrScript,
+                                    cx,
+                                    scope,
+                                    args,
+                                    desc.hasRestArg(),
+                                    desc.requiresArgumentObject());
+                }
+            }
+        } else {
+            scope = callerScope;
+            ScriptRuntime.initScript(fnOrScript, thisObj, cx, scope, desc.isEvalFunction());
+        }
+
+        if (desc.nestedFunctions != null) {
+            // Generators emit explicit ClosureStatement instructions for nested function
+            // declarations after evaluating their default parameter expressions, so that
+            // 'arguments' in a default-param scope binds to the arguments object rather
+            // than to a hoisted inner `function arguments(){}`. Skip frame-init hoisting
+            // for them.
+            if (desc.getFunctionCount() != 0 && !desc.isES6Generator()) {
+                if (desc.getFunctionType() != 0 && !desc.requiresActivationFrame()) Kit.codeBug();
+                for (int i = 0; i < desc.getFunctionCount(); i++) {
+                    JSDescriptor<?> fdesc = desc.getFunction(i);
+                    if (fdesc.getFunctionType() == FunctionNode.FUNCTION_STATEMENT) {
+                        // Commented out for now to avoid pulling everything at once.
+                        // initFunction(cx, this.scope, desc, i);
+                    }
+                }
+            }
+        }
+
+        int varCount = desc.getParamAndVarCount();
+        for (int i = 0; i < varCount; i++) {
+            if (desc.getParamOrVarConst(i)) {
+                this.stackAttributes[i] = (byte) ScriptableObject.CONST;
+            }
+        }
+        int definedArgs = desc.getParamCount();
+        if (definedArgs > argCount) {
+            definedArgs = argCount;
+        }
+
+        // Fill the frame structure
+
+        if (frameIndex > cx.getMaximumInterpreterStackDepth()) {
+            throw Context.reportRuntimeError("Exceeded maximum stack depth");
+        }
+
+        frozen = false;
+
+        System.arraycopy(args, argShift, stack, 0, definedArgs);
+        if (doubleArgs != null) {
+            System.arraycopy(doubleArgs, argShift, doubleStack, 0, definedArgs);
+        }
+        for (int i = definedArgs; i != compilerData.maxVars; ++i) {
+            stack[i] = Undefined.instance;
+        }
+
+        if (desc.hasRestArg()) {
+            Object[] vals;
+            int offset = desc.getParamCount() - 1;
+            if (argCount >= desc.getParamCount()) {
+                vals = new Object[argCount - offset];
+
+                argShift = argShift + offset;
+                for (int valsIdx = 0; valsIdx != vals.length; ++argShift, ++valsIdx) {
+                    Object val = args[argShift];
+                    if (val == UniqueTag.DOUBLE_MARK) {
+                        val = ScriptRuntime.wrapNumber(doubleArgs[argShift]);
+                    }
+                    vals[valsIdx] = val;
+                }
+            } else {
+                vals = ScriptRuntime.emptyArgs;
+            }
+            stack[offset] = cx.newArray(scope, vals);
+        }
+    }
+
+    // Orphan copy (for generators) or regular copy
+    private CallFrameV2(CallFrameV2 original, boolean makeOrphan) {
+        this(
+                original,
+                makeOrphan ? null : original.parentFrame,
+                makeOrphan ? null : original.previousInterpreterFrame);
+    }
+
+    // Full copy with new linkage
+    private CallFrameV2(
+            CallFrameV2 original,
+            CallFrameV2 parentFrame,
+            ACallFrame<?, ?> previousInterpreterFrame) {
+        super(original, parentFrame, previousInterpreterFrame);
+        pcPrevBranch = original.pcPrevBranch;
+        shouldYieldToParent = original.shouldYieldToParent;
+        generatorState = original.generatorState;
+    }
+
+    /* Shallow copy for running a generator. Reuses the existing stack arrays. */
+    private CallFrameV2(
+            CallFrameV2 original,
+            CallFrameV2 parentFrame,
+            ACallFrame<?, ?> previousInterpreterFrame,
+            boolean keepFrozen) {
+        super(original, parentFrame, previousInterpreterFrame, false, keepFrozen);
+        pcPrevBranch = original.pcPrevBranch;
+        shouldYieldToParent = original.shouldYieldToParent;
+        generatorState = original.generatorState;
+    }
+
+    public void push(Object val) {
+        stackTop += 1;
+        stack[stackTop] = val;
+    }
+
+    public void push(int val) {
+        stackTop += 1;
+        stack[stackTop] = val;
+    }
+
+    public void push(double val) {
+        stackTop += 1;
+        stack[stackTop] = DOUBLE_MARK;
+        doubleStack[stackTop] = val;
+    }
+
+    public void push(Object val, double doubleVal) {
+        stackTop += 1;
+        stack[stackTop] = val;
+        doubleStack[stackTop] = doubleVal;
+    }
+
+    public void popResult() {
+        result = stack[stackTop];
+        resultDbl = doubleStack[stackTop];
+        stack[stackTop] = null;
+        stackTop -= 1;
+    }
+
+    public Object pop() {
+        var value = stack[stackTop];
+        stack[stackTop] = null;
+        stackTop -= 1;
+        return value;
+    }
+
+    public double popDouble() {
+        assert stack[stackTop] == DOUBLE_MARK;
+        var value = doubleStack[stackTop];
+        stack[stackTop] = null;
+        stackTop -= 1;
+        return value;
+    }
+
+    public Object peek(int offset) {
+        return stack[stackTop + offset];
+    }
+
+    public Object peek() {
+        return peek(0);
+    }
+
+    public double peekDouble(int offset) {
+        return doubleStack[stackTop + offset];
+    }
+
+    public double peekDouble() {
+        return peekDouble(0);
+    }
+
+    public boolean isStackEmpty() {
+        return stackTop == emptyStackTop;
+    }
+
+    public void saveExceptionScope(int exceptionIndex, VarScope scope) {
+        stack[localShift + exceptionIndex] = scope;
+    }
+
+    public void saveSubRoutineReturnPC(int returnPcOffset, double subRoutineReturnPC) {
+        stack[localShift + returnPcOffset] = DOUBLE_MARK;
+        doubleStack[localShift + returnPcOffset] = subRoutineReturnPC;
+    }
+
+    public boolean hasSubRoutineReturnPC(int returnPcOffset) {
+        return stack[localShift + returnPcOffset] == DOUBLE_MARK;
+    }
+
+    public double getSubRoutineReturnPC(int returnPcOffset) {
+        if (stack[localShift + returnPcOffset] != DOUBLE_MARK) {
+            throw new IllegalStateException("Use hasSubRoutineReturnPC first");
+        }
+        return doubleStack[localShift + returnPcOffset];
+    }
+
+    public Object getVarAndWrap(int index) {
+        var value = getVar(index);
+        if (value == DOUBLE_MARK) {
+            return ScriptRuntime.wrapNumber(getVarDouble(index));
+        }
+        return value;
+    }
+
+    public Object getVar(int index) {
+        return varSource.stack[index];
+    }
+
+    public boolean isVarDouble(int index) {
+        return getVar(index) == DOUBLE_MARK;
+    }
+
+    public double getVarDouble(int index) {
+        return varSource.doubleStack[index];
+    }
+
+    public void setVar(int index, Object value) {
+        varSource.stack[index] = value;
+    }
+
+    public void setVar(int index, double value) {
+        varSource.stack[index] = DOUBLE_MARK;
+        varSource.doubleStack[index] = value;
+    }
+
+    public void setVar(int index, Object value, double doubleValue) {
+        varSource.stack[index] = value;
+        varSource.doubleStack[index] = doubleValue;
+    }
+
+    public int getVarAttribute(int index) {
+        return varSource.stackAttributes[index];
+    }
+
+    public void setVarAttribute(int index, int attributes) {
+        varSource.stackAttributes[index] &= (byte) ~attributes;
+    }
+
+    public Object getLocal(int index) {
+        return stack[localShift + index];
+    }
+
+    public double getLocalDouble(int index) {
+        return doubleStack[localShift + index];
+    }
+
+    public void setLocal(int index, Object value) {
+        stack[localShift + index] = value;
+    }
+
+    public void setResult(Object value) {
+        result = value;
+    }
+
+    public void setResult(double value) {
+        result = DOUBLE_MARK;
+        resultDbl = value;
+    }
+
+    // TODO(Cam): For object literals, we want to wrap literal values, but not getters and setters
+    public Object[] getArguments(Context cx, Operand[] arguments) {
+        if (arguments.length == 0) {
+            return ScriptRuntime.emptyArgs;
+        }
+        Object[] args = new Object[arguments.length];
+        for (int i = arguments.length - 1; i >= 0; i--) {
+            args[i] = arguments[i].retrieveAndWrap(cx, this);
+        }
+        return args;
+    }
+
+    private static Object[] wrapArguments(Object[] stack, double[] sDbl, int shift, int count) {
+        if (count == 0) {
+            return ScriptRuntime.emptyArgs;
+        }
+        Object[] args = new Object[count];
+        for (int i = 0; i != count; ++i, ++shift) {
+            Object val = stack[shift];
+            if (val == UniqueTag.DOUBLE_MARK) {
+                val = ScriptRuntime.wrapNumber(sDbl[shift]);
+            }
+            args[i] = val;
+        }
+        return args;
+    }
+
+    @Override
+    public int getFrameIndex() {
+        return frameIndex;
+    }
+
+    @Override
+    public CallFrameV2 getParentFrame() {
+        return parentFrame;
+    }
+
+    @Override
+    public int getPcSourceLineStart() {
+        // This is not equivalent to frame v1, but it is still correct. This is used to find the
+        // line number from the pc, which for frame v1 requires having the pc corresponding to the
+        // LINE instruction, basically. However, with the line number table implementation that we
+        // use in v2, it's ok if we use _any_ pc that corresponds to that same line number. So we
+        // can simply return the current pc and get the correct behavior.
+        return pc;
+    }
+
+    @Override
+    public DebuggableScript getData() {
+        return fnOrScript.getDescriptor();
+    }
+
+    @Override
+    public ScriptOrFn<?> getFnOrScript() {
+        return fnOrScript;
+    }
+
+    @Override
+    public int getParentPC() {
+        return parentPC;
+    }
+
+    @Override
+    public CallFrameV2 cloneFrozen() {
+        return new CallFrameV2(this, false);
+    }
+
+    public CallFrameV2 captureForGenerator() {
+        return new CallFrameV2(this, true);
+    }
+
+    /* Shallow clone for running a generator. We're only doing
+    this to maintain the correct chain of parents for exception
+    stacks, so we'll reuse the existing stack arrays. */
+    public CallFrameV2 shallowCloneFrozen(ACallFrame newPreviousInterpreterFrame) {
+        return new CallFrameV2(this, this.parentFrame, newPreviousInterpreterFrame, true);
+    }
+
+    public void syncStateToFrame(CallFrameV2 otherFrame) {
+        otherFrame.frozen = frozen;
+        otherFrame.result = result;
+        otherFrame.resultDbl = resultDbl;
+        otherFrame.pc = pc;
+        otherFrame.pcPrevBranch = pcPrevBranch;
+        otherFrame.scope = scope;
+
+        otherFrame.stackTop = stackTop;
+        otherFrame.throwable = throwable;
+        otherFrame.shouldYieldToParent = shouldYieldToParent;
+        otherFrame.generatorState = generatorState;
+    }
+
+    public void popN(int n) {
+        for (int i = 0; i < n; i++) {
+            pop();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/CompilerData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/CompilerData.java
@@ -113,7 +113,7 @@ public class CompilerData<T extends ScriptOrFn<T>> extends ACompilerData<T, Comp
         return LineNumberTable.getFirstLineNumber(lineNumberTable);
     }
 
-    public short getPcFirstLineNumber() {
+    public int getPcFirstLineNumber() {
         return LineNumberTable.getPcFirstLineNumber(lineNumberTable);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/CompilerData.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/CompilerData.java
@@ -1,0 +1,212 @@
+package org.mozilla.javascript.interpreterv2;
+
+import java.io.PrintStream;
+import java.util.List;
+import org.mozilla.javascript.ACompilerData;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.JSCode;
+import org.mozilla.javascript.JSDescriptor;
+import org.mozilla.javascript.ScriptOrFn;
+import org.mozilla.javascript.VarScope;
+import org.mozilla.javascript.config.RhinoConfig;
+import org.mozilla.javascript.interpreterv2.instruction.Instruction;
+
+public class CompilerData<T extends ScriptOrFn<T>> extends ACompilerData<T, CompilerData<?>> {
+
+    static boolean shouldDumpInstructions = RhinoConfig.get("rhino.printICodeV2", false);
+
+    public static final int EXCEPTION_TRY_START_SLOT = 0;
+    public static final int EXCEPTION_TRY_END_SLOT = 1;
+    public static final int EXCEPTION_HANDLER_SLOT = 2;
+    public static final int EXCEPTION_TYPE_SLOT = 3;
+    public static final int EXCEPTION_LOCAL_SLOT = 4;
+    public static final int EXCEPTION_SCOPE_SLOT = 5;
+    // SLOT_SIZE: space for try start/end, handler, start, handler type,
+    //            exception local and scope local
+    public static final int EXCEPTION_SLOT_SIZE = 6;
+
+    public final Instruction[] instructions;
+
+    /**
+     * @see LineNumberTable
+     */
+    private final LineNumberTable lineNumberTable;
+
+    private CompilerData(Builder<T> b) {
+        super(b.maxVars, b.maxLocals, b.maxStack, b.maxFrameSize, b.exceptionTable);
+        this.instructions = b.instructions;
+        this.lineNumberTable = b.builtLineNumberTable;
+    }
+
+    public Instruction[] getInstructions() {
+        if (instructions == null) {
+            throw new IllegalStateException("Instructions not set");
+        }
+        return instructions;
+    }
+
+    public int[] getLineNumbers() {
+        return LineNumberTable.getLineNumbers(lineNumberTable);
+    }
+
+    public int getInstructionCount() {
+        if (instructions == null) {
+            return 0;
+        }
+        return instructions.length;
+    }
+
+    public void dumpInstructions(PrintStream out, JSDescriptor.Builder<?> desc) {
+        if (!shouldDumpInstructions) {
+            return;
+        }
+
+        // Function header with metadata
+        String functionName = desc.name != null ? desc.name : "<anonymous>";
+        out.printf(
+                "function %s [maxStack=%d, locals=%d, instructions=%d]:%n",
+                functionName, maxStack, maxLocals, getInstructionCount());
+        out.println("  line number table: " + getLineNumberTableForDebug());
+
+        // Instructions with virtual register numbering
+        if (instructions != null) {
+            for (int pc = 0; pc < instructions.length; pc++) {
+                out.printf("%%%-3d: %s%n", pc, instructions[pc].toDebugString());
+            }
+        }
+
+        // Exception handlers (if any)
+        if (hasExceptionHandlers()) {
+            out.println();
+            out.println("exception handlers:");
+            dumpExceptionHandlers(out);
+        }
+
+        out.println();
+        out.flush();
+    }
+
+    private boolean hasExceptionHandlers() {
+        return exceptionTable != null && exceptionTable.length > 0;
+    }
+
+    private void dumpExceptionHandlers(PrintStream out) {
+        if (exceptionTable == null) {
+            return;
+        }
+
+        for (int i = 0; i < exceptionTable.length; i += EXCEPTION_SLOT_SIZE) {
+            int tryStart = exceptionTable[i + EXCEPTION_TRY_START_SLOT];
+            int tryEnd = exceptionTable[i + EXCEPTION_TRY_END_SLOT];
+            int handler = exceptionTable[i + EXCEPTION_HANDLER_SLOT];
+            int type = exceptionTable[i + EXCEPTION_TYPE_SLOT];
+            int local = exceptionTable[i + EXCEPTION_LOCAL_SLOT];
+            int scope = exceptionTable[i + EXCEPTION_SCOPE_SLOT];
+
+            out.printf(
+                    "  try %%%-3d..%%%-3d -> %%%-3d (type=%d, local=%d, scope=%d)%n",
+                    tryStart, tryEnd, handler, type, local, scope);
+        }
+    }
+
+    public int getFirstLineNumber() {
+        return LineNumberTable.getFirstLineNumber(lineNumberTable);
+    }
+
+    public short getPcFirstLineNumber() {
+        return LineNumberTable.getPcFirstLineNumber(lineNumberTable);
+    }
+
+    /**
+     * Get the set of line numbers associated with a given PC.
+     *
+     * @param pc The program counter
+     * @return List of line numbers, or null if PC has no associated lines
+     */
+    public List<Integer> getLineSetFromPc(int pc) {
+        return LineNumberTable.getLineSetFromPc(lineNumberTable, pc);
+    }
+
+    @Override
+    public int getLineNumberFromPc(int pc, int pcLineStart) {
+        return LineNumberTable.getLineNumberFromPc(lineNumberTable, pc);
+    }
+
+    public String getLineNumberTableForDebug() {
+        return LineNumberTable.getDebugString(lineNumberTable);
+    }
+
+    @Override
+    public Object execute(
+            Context cx,
+            T executableObject,
+            Object newTarget,
+            VarScope scope,
+            Object thisObj,
+            Object[] args) {
+        return null;
+        // return InterpreterV2.interpret(
+        //         executableObject, this, cx, scope, (Scriptable) thisObj, args);
+    }
+
+    @Override
+    public Object resume(
+            Context cx,
+            T executableObject,
+            Object state,
+            VarScope scope,
+            int operation,
+            Object value) {
+        return null;
+        // return InterpreterV2.resumeGenerator(cx, scope, operation, state, value);
+    }
+
+    @Override
+    public String toString() {
+        return "Compiler data"; // sourceFile + ':' + name;
+    }
+
+    /**
+     * Mutable working state for building an immutable {@link CompilerData}. Mirrors the builder
+     * pattern used by {@link org.mozilla.javascript.InterpreterData.Builder}.
+     */
+    public static class Builder<T extends ScriptOrFn<T>> extends JSCode.Builder<T> {
+
+        final Builder<?> parentBuilder;
+
+        public CompilerData<org.mozilla.javascript.JSFunction>[] nestedFunctions;
+
+        public Instruction[] instructions;
+
+        public int[] exceptionTable;
+
+        public int maxVars;
+        public int maxLocals;
+        public int maxStack = 0;
+        public int maxFrameSize;
+
+        LineNumberTable builtLineNumberTable;
+
+        private CompilerData<T> built;
+
+        public Builder() {
+            this.parentBuilder = null;
+        }
+
+        public Builder(Builder<?> parent) {
+            this.parentBuilder = parent;
+        }
+
+        public void setLineNumberTable(LineNumberTable.Builder lineNumberTableBuilder) {
+            this.builtLineNumberTable = lineNumberTableBuilder.buildFinalTable();
+        }
+
+        @Override
+        public CompilerData<T> build() {
+            if (built == null) {
+                built = new CompilerData<>(this);
+            }
+            return built;
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/GeneratorState.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/GeneratorState.java
@@ -1,0 +1,12 @@
+package org.mozilla.javascript.interpreterv2;
+
+public class GeneratorState {
+    public GeneratorState(int operation, Object value) {
+        this.operation = operation;
+        this.value = value;
+    }
+
+    public int operation;
+    public Object value;
+    public RuntimeException returnedException;
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/InstructionSimplification.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/InstructionSimplification.java
@@ -1,0 +1,86 @@
+package org.mozilla.javascript.interpreterv2;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.mozilla.javascript.interpreterv2.instruction.Instruction;
+
+public class InstructionSimplification {
+    private final List<Instruction> instructions;
+    private final Set<Integer> jumpTargets;
+    private int currentStackOffset = 0;
+    private int currentPc = 0;
+
+    public InstructionSimplification(List<Instruction> instructions, Set<Integer> jumpTargets) {
+        this.instructions = instructions;
+        this.jumpTargets = jumpTargets;
+    }
+
+    public void simplify() {
+        for (int pc = 0; pc < instructions.size(); pc++) {
+            this.currentPc = pc;
+            resetForInstruction();
+
+            Instruction instruction = instructions.get(pc);
+            Instruction simplified = instruction.simplify(this);
+
+            if (instruction != simplified) {
+                instructions.set(pc, simplified);
+            }
+        }
+    }
+
+    public KnownType getStackValueType(int stackOffset) {
+        var producerPc = findStackProducer(stackOffset);
+        if (producerPc.isEmpty()) {
+            return KnownType.UNKNOWN;
+        }
+
+        int pc = producerPc.get();
+        int savedPc = this.currentPc;
+        this.currentPc = pc;
+        KnownType type = instructions.get(pc).getKnownType(this);
+        this.currentPc = savedPc;
+        return type;
+    }
+
+    public boolean isJumpTarget(int pc) {
+        return jumpTargets.contains(pc);
+    }
+
+    public void consumeStack(int count) {
+        currentStackOffset += count;
+    }
+
+    private Optional<Integer> findStackProducer(int stackOffset) {
+        int totalOffset = currentStackOffset + stackOffset;
+
+        if (isJumpTarget(currentPc)) {
+            return Optional.empty();
+        }
+
+        int remainingDepth = totalOffset;
+
+        for (int i = currentPc - 1; i >= 0; i--) {
+
+            Instruction inst = instructions.get(i);
+            int change = inst.stackChange();
+
+            remainingDepth -= change;
+
+            if (change > 0 && remainingDepth < 0) {
+                return Optional.of(i);
+            }
+
+            if (isJumpTarget(i)) {
+                return Optional.empty();
+            }
+        }
+
+        throw new IllegalStateException("We didn't find the producer of this stack value");
+    }
+
+    private void resetForInstruction() {
+        currentStackOffset = 0;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/KnownType.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/KnownType.java
@@ -1,0 +1,9 @@
+package org.mozilla.javascript.interpreterv2;
+
+public enum KnownType {
+    STRING,
+    NUMBER,
+    BOOLEAN,
+    OBJECT,
+    UNKNOWN
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/LineNumberTable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/LineNumberTable.java
@@ -1,0 +1,275 @@
+package org.mozilla.javascript.interpreterv2;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Logger;
+
+/**
+ * Packed array-based line number table implementation.
+ *
+ * <p>Uses four parallel arrays for memory efficiency:
+ *
+ * <ul>
+ *   <li>{@code pcs[]} - Program counter values (sorted)
+ *   <li>{@code lineOffsets[]} - Start index in {@code lines[]} for each PC
+ *   <li>{@code lineCounts[]} - Number of lines for each PC
+ *   <li>{@code lines[]} - All line numbers packed sequentially
+ * </ul>
+ *
+ * <p>Example: PC 10 has lines [5,6,7], PC 15 has line [8]
+ *
+ * <pre>
+ * pcs = [10, 15]
+ * lineOffsets = [0, 3]
+ * lineCounts = [3, 1]
+ * lines = [5, 6, 7, 8]
+ * </pre>
+ *
+ * <p>Lookup uses binary search on pcs[] with O(log n) performance. Memory usage is approximately 12
+ * bytes per PC + 4 bytes per line number (no object overhead).
+ */
+public class LineNumberTable {
+    private static final Logger LOG = Logger.getLogger(LineNumberTable.class.getName());
+
+    private final short[] pcs;
+    private final short[] lineOffsets;
+    private final short[] lineCounts;
+    private final short[] lines;
+
+    private LineNumberTable(short[] pcs, short[] lineOffsets, short[] lineCounts, short[] lines) {
+        this.pcs = pcs;
+        this.lineOffsets = lineOffsets;
+        this.lineCounts = lineCounts;
+        this.lines = lines;
+    }
+
+    /** Builder for LineNumberTable. */
+    public static class Builder {
+        private final List<Integer> pcsList = new ArrayList<>();
+        private final List<Set<Integer>> linesList = new ArrayList<>();
+        private int lastPc = -1;
+
+        public Builder() {}
+
+        public Builder(int initialSize) {
+            if (initialSize > 0) {
+                ((ArrayList<Integer>) pcsList).ensureCapacity(initialSize);
+                ((ArrayList<Set<Integer>>) linesList).ensureCapacity(initialSize);
+            }
+        }
+
+        /**
+         * Add line numbers to the set for a given PC.
+         *
+         * @param pc Program counter
+         * @param startLine Start line (inclusive)
+         * @param endLine End line (inclusive)
+         */
+        public void add(int pc, int startLine, int endLine) {
+            if (pc < lastPc) {
+                throw new IllegalArgumentException("Bytecode addresses must be increasing");
+            }
+
+            Set<Integer> lineSet;
+            if (pc == lastPc && !pcsList.isEmpty()) {
+                lineSet = linesList.get(linesList.size() - 1);
+            } else {
+                lineSet = new LinkedHashSet<>();
+                pcsList.add(pc);
+                linesList.add(lineSet);
+                lastPc = pc;
+            }
+            if (startLine == -1 && endLine == -1) {
+                lineSet.add(-1);
+            } else {
+                for (int line = startLine; line <= endLine; line++) {
+                    lineSet.add(line);
+                }
+            }
+        }
+
+        public LineNumberTable buildFinalTable() {
+            if (pcsList.isEmpty()) {
+                return null;
+            }
+
+            int numPcs = pcsList.size();
+
+            short[] pcs = new short[numPcs];
+            short[] lineOffsets = new short[numPcs];
+            short[] lineCounts = new short[numPcs];
+
+            int totalLines = 0;
+            for (Set<Integer> lineSet : linesList) {
+                totalLines += lineSet.size();
+            }
+            short[] lines = new short[totalLines];
+
+            int lineIdx = 0;
+            for (int i = 0; i < numPcs; i++) {
+                pcs[i] = (short) (pcsList.get(i) & 0xFFFF);
+                lineOffsets[i] = (short) (lineIdx & 0xFFFF);
+
+                Set<Integer> lineSet = linesList.get(i);
+                lineCounts[i] = (short) (lineSet.size() & 0xFFFF);
+
+                for (int line : lineSet) {
+                    lines[lineIdx++] = (short) (line & 0xFFFF);
+                }
+            }
+
+            return new LineNumberTable(pcs, lineOffsets, lineCounts, lines);
+        }
+    }
+
+    public static int getFirstLineNumber(LineNumberTable lineNumberTable) {
+        if (lineNumberTable == null
+                || lineNumberTable.lines == null
+                || lineNumberTable.lines.length == 0) {
+            return -1;
+        }
+        return lineNumberTable.lines[0];
+    }
+
+    public static short getPcFirstLineNumber(LineNumberTable lineNumberTable) {
+        if (isEmpty(lineNumberTable)) {
+            return -1;
+        }
+        return lineNumberTable.pcs[0];
+    }
+
+    /**
+     * Get the set of line numbers associated with a given PC.
+     *
+     * @param lineNumberTable The line number table
+     * @param pc The program counter
+     * @return List of line numbers, or null if PC not found or synthetic
+     */
+    public static List<Integer> getLineSetFromPc(LineNumberTable lineNumberTable, int pc) {
+        if (isEmpty(lineNumberTable)) {
+            return null;
+        }
+
+        // Binary search for PC
+        int idx = Arrays.binarySearch(lineNumberTable.pcs, (short) (pc & 0xFFFF));
+        if (idx < 0) return null;
+
+        int count = lineNumberTable.lineCounts[idx] & 0xFFFF;
+        if (count == 0) return null;
+
+        int offset = lineNumberTable.lineOffsets[idx] & 0xFFFF;
+
+        if (count == 1 && lineNumberTable.lines[offset] == -1) {
+            return null;
+        }
+
+        List<Integer> result = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            result.add((int) lineNumberTable.lines[offset + i]);
+        }
+        return result;
+    }
+
+    /**
+     * Get the last (most specific) line number associated with a given PC. If the PC is not found,
+     * returns the line number of the largest PC that is less than the given PC.
+     *
+     * <p>When multiple line numbers are recorded at the same PC (e.g., from nested structures like
+     * a BLOCK containing statements), this returns the last recorded line, which is typically the
+     * most specific one from the actual statement rather than the outer container.
+     *
+     * @param lineNumberTable The line number table
+     * @param pc The program counter
+     * @return The last line number, or -1 if not found or synthetic
+     */
+    public static int getLineNumberFromPc(LineNumberTable lineNumberTable, int pc) {
+        if (isEmpty(lineNumberTable)) {
+            return -1;
+        }
+
+        int idx = Arrays.binarySearch(lineNumberTable.pcs, (short) (pc & 0xFFFF));
+
+        if (idx < 0) {
+            idx = -idx - 2;
+            if (idx < 0) return -1;
+        }
+
+        int count = lineNumberTable.lineCounts[idx] & 0xFFFF;
+        if (count == 0) return -1;
+
+        int offset = lineNumberTable.lineOffsets[idx] & 0xFFFF;
+        // Return the last line number (most specific) instead of the first
+        int lastLine = lineNumberTable.lines[offset + count - 1];
+
+        return lastLine == -1 ? -1 : lastLine;
+    }
+
+    /**
+     * Get all unique line numbers in the table (excluding synthetic -1).
+     *
+     * @param lineNumberTable The line number table
+     * @return Array of unique line numbers
+     */
+    public static int[] getLineNumbers(LineNumberTable lineNumberTable) {
+        if (lineNumberTable == null
+                || lineNumberTable.lines == null
+                || lineNumberTable.lines.length == 0) {
+            return new int[0];
+        }
+
+        Set<Integer> uniqueLines = new LinkedHashSet<>();
+        for (short line : lineNumberTable.lines) {
+            if (line != -1) {
+                uniqueLines.add((int) line);
+            }
+        }
+        return uniqueLines.stream().mapToInt(n -> n).toArray();
+    }
+
+    /**
+     * Get a debug string representation of the line number table.
+     *
+     * @param lineNumberTable The line number table
+     * @return Debug string showing PC -> lines mapping
+     */
+    public static String getDebugString(LineNumberTable lineNumberTable) {
+        if (isEmpty(lineNumberTable)) {
+            return "[]";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append('[');
+        for (int i = 0; i < lineNumberTable.pcs.length; i++) {
+            if (i > 0) {
+                sb.append(",  ");
+            }
+            sb.append(lineNumberTable.pcs[i] & 0xFFFF);
+            sb.append(" -> [");
+
+            int offset = lineNumberTable.lineOffsets[i] & 0xFFFF;
+            int count = lineNumberTable.lineCounts[i] & 0xFFFF;
+            for (int j = 0; j < count; j++) {
+                if (j > 0) sb.append(", ");
+                sb.append((int) lineNumberTable.lines[offset + j]);
+            }
+            sb.append(']');
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+
+    /**
+     * Check if the line number table is empty.
+     *
+     * @param lineNumberTable The line number table
+     * @return true if empty
+     */
+    public static boolean isEmpty(LineNumberTable lineNumberTable) {
+        return lineNumberTable == null
+                || lineNumberTable.pcs == null
+                || lineNumberTable.pcs.length == 0;
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/LineNumberTable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/LineNumberTable.java
@@ -5,7 +5,6 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.logging.Logger;
 
 /**
  * Packed array-based line number table implementation.
@@ -31,19 +30,261 @@ import java.util.logging.Logger;
  * <p>Lookup uses binary search on pcs[] with O(log n) performance. Memory usage is approximately 12
  * bytes per PC + 4 bytes per line number (no object overhead).
  */
-public class LineNumberTable {
-    private static final Logger LOG = Logger.getLogger(LineNumberTable.class.getName());
+public abstract class LineNumberTable {
 
-    private final short[] pcs;
-    private final short[] lineOffsets;
-    private final short[] lineCounts;
-    private final short[] lines;
+    protected abstract int getFirstLineNo();
 
-    private LineNumberTable(short[] pcs, short[] lineOffsets, short[] lineCounts, short[] lines) {
-        this.pcs = pcs;
-        this.lineOffsets = lineOffsets;
-        this.lineCounts = lineCounts;
-        this.lines = lines;
+    protected abstract int getPcFirstLineNo();
+
+    protected abstract List<Integer> getLineSetFromPc(int pc);
+
+    protected abstract int getLineNoFromPc(int pc);
+
+    protected abstract int[] getLineNos();
+
+    protected abstract String debugString();
+
+    protected abstract boolean isEmptyTable();
+
+    private static class ShortLineNumberTable extends LineNumberTable {
+        private final short[] pcs;
+        private final short[] lineOffsets;
+        private final short[] lineCounts;
+        private final short[] lines;
+
+        private ShortLineNumberTable(
+                short[] pcs, short[] lineOffsets, short[] lineCounts, short[] lines) {
+            this.pcs = pcs;
+            this.lineOffsets = lineOffsets;
+            this.lineCounts = lineCounts;
+            this.lines = lines;
+        }
+
+        @Override
+        protected String debugString() {
+            if (isEmptyTable()) {
+                return "[]";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append('[');
+            for (int i = 0; i < pcs.length; i++) {
+                if (i > 0) {
+                    sb.append(",  ");
+                }
+                sb.append(pcs[i] & 0xFFFF);
+                sb.append(" -> [");
+
+                int offset = lineOffsets[i] & 0xFFFF;
+                int count = lineCounts[i] & 0xFFFF;
+                for (int j = 0; j < count; j++) {
+                    if (j > 0) sb.append(", ");
+                    sb.append((int) lines[offset + j]);
+                }
+                sb.append(']');
+            }
+            sb.append(']');
+            return sb.toString();
+        }
+
+        @Override
+        protected int getFirstLineNo() {
+            if (this.lines == null || this.lines.length == 0) {
+                return -1;
+            }
+            return lines[0];
+        }
+
+        @Override
+        protected int getPcFirstLineNo() {
+            if (isEmptyTable()) return -1;
+            return pcs[0];
+        }
+
+        @Override
+        protected int getLineNoFromPc(int pc) {
+            int idx = Arrays.binarySearch(pcs, (short) (pc & 0xFFFF));
+
+            if (idx < 0) {
+                idx = -idx - 2;
+                if (idx < 0) return -1;
+            }
+
+            int count = lineCounts[idx] & 0xFFFF;
+            if (count == 0) return -1;
+
+            int offset = lineOffsets[idx] & 0xFFFF;
+            // Return the last line number (most specific) instead of the first
+            int lastLine = lines[offset + count - 1];
+
+            return lastLine == -1 ? -1 : lastLine;
+        }
+
+        @Override
+        protected int[] getLineNos() {
+            if (lines == null || lines.length == 0) {
+                return new int[0];
+            }
+
+            Set<Integer> uniqueLines = new LinkedHashSet<>();
+            for (short line : lines) {
+                if (line != -1) {
+                    uniqueLines.add((int) line);
+                }
+            }
+            return uniqueLines.stream().mapToInt(n -> n).toArray();
+        }
+
+        @Override
+        protected List<Integer> getLineSetFromPc(int pc) {
+            if (isEmptyTable()) {
+                return null;
+            }
+
+            // Binary search for PC
+            int idx = Arrays.binarySearch(pcs, (short) (pc & 0xFFFF));
+            if (idx < 0) return null;
+
+            int count = lineCounts[idx] & 0xFFFF;
+            if (count == 0) return null;
+
+            int offset = lineOffsets[idx] & 0xFFFF;
+
+            if (count == 1 && lines[offset] == -1) {
+                return null;
+            }
+
+            List<Integer> result = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                result.add((int) lines[offset + i]);
+            }
+            return result;
+        }
+
+        @Override
+        protected boolean isEmptyTable() {
+            return pcs == null || pcs.length == 0;
+        }
+    }
+
+    private static class IntLineNumberTable extends LineNumberTable {
+        private final int[] pcs;
+        private final int[] lineOffsets;
+        private final int[] lineCounts;
+        private final int[] lines;
+
+        private IntLineNumberTable(int[] pcs, int[] lineOffsets, int[] lineCounts, int[] lines) {
+            this.pcs = pcs;
+            this.lineOffsets = lineOffsets;
+            this.lineCounts = lineCounts;
+            this.lines = lines;
+        }
+
+        @Override
+        protected String debugString() {
+            if (isEmptyTable()) {
+                return "[]";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.append('[');
+            for (int i = 0; i < pcs.length; i++) {
+                if (i > 0) {
+                    sb.append(",  ");
+                }
+                sb.append(pcs[i]);
+                sb.append(" -> [");
+
+                int offset = lineOffsets[i];
+                int count = lineCounts[i];
+                for (int j = 0; j < count; j++) {
+                    if (j > 0) sb.append(", ");
+                    sb.append((int) lines[offset + j]);
+                }
+                sb.append(']');
+            }
+            sb.append(']');
+            return sb.toString();
+        }
+
+        @Override
+        protected int getFirstLineNo() {
+            if (this.lines == null || this.lines.length == 0) {
+                return -1;
+            }
+            return lines[0];
+        }
+
+        @Override
+        protected int getPcFirstLineNo() {
+            if (isEmptyTable()) return -1;
+            return pcs[0];
+        }
+
+        @Override
+        protected int getLineNoFromPc(int pc) {
+            int idx = Arrays.binarySearch(pcs, pc);
+
+            if (idx < 0) {
+                idx = -idx - 2;
+                if (idx < 0) return -1;
+            }
+
+            int count = lineCounts[idx];
+            if (count == 0) return -1;
+
+            int offset = lineOffsets[idx];
+            // Return the last line number (most specific) instead of the first
+            int lastLine = lines[offset + count - 1];
+
+            return lastLine == -1 ? -1 : lastLine;
+        }
+
+        @Override
+        protected int[] getLineNos() {
+            if (lines == null || lines.length == 0) {
+                return new int[0];
+            }
+
+            Set<Integer> uniqueLines = new LinkedHashSet<>();
+            for (int line : lines) {
+                if (line != -1) {
+                    uniqueLines.add(line);
+                }
+            }
+            return uniqueLines.stream().mapToInt(n -> n).toArray();
+        }
+
+        @Override
+        protected List<Integer> getLineSetFromPc(int pc) {
+            if (isEmptyTable()) {
+                return null;
+            }
+
+            // Binary search for PC
+            int idx = Arrays.binarySearch(pcs, pc);
+            if (idx < 0) return null;
+
+            int count = lineCounts[idx];
+            if (count == 0) return null;
+
+            int offset = lineOffsets[idx];
+
+            if (count == 1 && lines[offset] == -1) {
+                return null;
+            }
+
+            List<Integer> result = new ArrayList<>(count);
+            for (int i = 0; i < count; i++) {
+                result.add((int) lines[offset + i]);
+            }
+            return result;
+        }
+
+        @Override
+        protected boolean isEmptyTable() {
+            return pcs == null || pcs.length == 0;
+        }
     }
 
     /** Builder for LineNumberTable. */
@@ -51,6 +292,7 @@ public class LineNumberTable {
         private final List<Integer> pcsList = new ArrayList<>();
         private final List<Set<Integer>> linesList = new ArrayList<>();
         private int lastPc = -1;
+        private boolean largeCaseSeen;
 
         public Builder() {}
 
@@ -69,6 +311,10 @@ public class LineNumberTable {
          * @param endLine End line (inclusive)
          */
         public void add(int pc, int startLine, int endLine) {
+            if (pc > 0xffff || startLine > 0xffff || endLine > 0xffff) {
+                largeCaseSeen = true;
+            }
+
             if (pc < lastPc) {
                 throw new IllegalArgumentException("Bytecode addresses must be increasing");
             }
@@ -96,6 +342,39 @@ public class LineNumberTable {
                 return null;
             }
 
+            return largeCaseSeen ? makeIntTable() : makeShortTable();
+        }
+
+        private LineNumberTable makeIntTable() {
+            int numPcs = pcsList.size();
+
+            int[] pcs = new int[numPcs];
+            int[] lineOffsets = new int[numPcs];
+            int[] lineCounts = new int[numPcs];
+
+            int totalLines = 0;
+            for (Set<Integer> lineSet : linesList) {
+                totalLines += lineSet.size();
+            }
+            int[] lines = new int[totalLines];
+
+            int lineIdx = 0;
+            for (int i = 0; i < numPcs; i++) {
+                pcs[i] = pcsList.get(i);
+                lineOffsets[i] = lineIdx;
+
+                Set<Integer> lineSet = linesList.get(i);
+                lineCounts[i] = lineSet.size();
+
+                for (int line : lineSet) {
+                    lines[lineIdx++] = line;
+                }
+            }
+
+            return new IntLineNumberTable(pcs, lineOffsets, lineCounts, lines);
+        }
+
+        private LineNumberTable makeShortTable() {
             int numPcs = pcsList.size();
 
             short[] pcs = new short[numPcs];
@@ -121,24 +400,22 @@ public class LineNumberTable {
                 }
             }
 
-            return new LineNumberTable(pcs, lineOffsets, lineCounts, lines);
+            return new ShortLineNumberTable(pcs, lineOffsets, lineCounts, lines);
         }
     }
 
     public static int getFirstLineNumber(LineNumberTable lineNumberTable) {
-        if (lineNumberTable == null
-                || lineNumberTable.lines == null
-                || lineNumberTable.lines.length == 0) {
+        if (lineNumberTable == null) {
             return -1;
         }
-        return lineNumberTable.lines[0];
+        return lineNumberTable.getFirstLineNo();
     }
 
-    public static short getPcFirstLineNumber(LineNumberTable lineNumberTable) {
-        if (isEmpty(lineNumberTable)) {
+    public static int getPcFirstLineNumber(LineNumberTable lineNumberTable) {
+        if (lineNumberTable == null) {
             return -1;
         }
-        return lineNumberTable.pcs[0];
+        return lineNumberTable.getPcFirstLineNo();
     }
 
     /**
@@ -149,28 +426,8 @@ public class LineNumberTable {
      * @return List of line numbers, or null if PC not found or synthetic
      */
     public static List<Integer> getLineSetFromPc(LineNumberTable lineNumberTable, int pc) {
-        if (isEmpty(lineNumberTable)) {
-            return null;
-        }
-
-        // Binary search for PC
-        int idx = Arrays.binarySearch(lineNumberTable.pcs, (short) (pc & 0xFFFF));
-        if (idx < 0) return null;
-
-        int count = lineNumberTable.lineCounts[idx] & 0xFFFF;
-        if (count == 0) return null;
-
-        int offset = lineNumberTable.lineOffsets[idx] & 0xFFFF;
-
-        if (count == 1 && lineNumberTable.lines[offset] == -1) {
-            return null;
-        }
-
-        List<Integer> result = new ArrayList<>(count);
-        for (int i = 0; i < count; i++) {
-            result.add((int) lineNumberTable.lines[offset + i]);
-        }
-        return result;
+        if (lineNumberTable == null) return null;
+        return lineNumberTable.getLineSetFromPc(pc);
     }
 
     /**
@@ -190,21 +447,7 @@ public class LineNumberTable {
             return -1;
         }
 
-        int idx = Arrays.binarySearch(lineNumberTable.pcs, (short) (pc & 0xFFFF));
-
-        if (idx < 0) {
-            idx = -idx - 2;
-            if (idx < 0) return -1;
-        }
-
-        int count = lineNumberTable.lineCounts[idx] & 0xFFFF;
-        if (count == 0) return -1;
-
-        int offset = lineNumberTable.lineOffsets[idx] & 0xFFFF;
-        // Return the last line number (most specific) instead of the first
-        int lastLine = lineNumberTable.lines[offset + count - 1];
-
-        return lastLine == -1 ? -1 : lastLine;
+        return lineNumberTable.getLineNoFromPc(pc);
     }
 
     /**
@@ -214,19 +457,11 @@ public class LineNumberTable {
      * @return Array of unique line numbers
      */
     public static int[] getLineNumbers(LineNumberTable lineNumberTable) {
-        if (lineNumberTable == null
-                || lineNumberTable.lines == null
-                || lineNumberTable.lines.length == 0) {
+        if (lineNumberTable == null) {
             return new int[0];
         }
 
-        Set<Integer> uniqueLines = new LinkedHashSet<>();
-        for (short line : lineNumberTable.lines) {
-            if (line != -1) {
-                uniqueLines.add((int) line);
-            }
-        }
-        return uniqueLines.stream().mapToInt(n -> n).toArray();
+        return lineNumberTable.getLineNos();
     }
 
     /**
@@ -236,29 +471,10 @@ public class LineNumberTable {
      * @return Debug string showing PC -> lines mapping
      */
     public static String getDebugString(LineNumberTable lineNumberTable) {
-        if (isEmpty(lineNumberTable)) {
+        if (lineNumberTable == null) {
             return "[]";
         }
-
-        StringBuilder sb = new StringBuilder();
-        sb.append('[');
-        for (int i = 0; i < lineNumberTable.pcs.length; i++) {
-            if (i > 0) {
-                sb.append(",  ");
-            }
-            sb.append(lineNumberTable.pcs[i] & 0xFFFF);
-            sb.append(" -> [");
-
-            int offset = lineNumberTable.lineOffsets[i] & 0xFFFF;
-            int count = lineNumberTable.lineCounts[i] & 0xFFFF;
-            for (int j = 0; j < count; j++) {
-                if (j > 0) sb.append(", ");
-                sb.append((int) lineNumberTable.lines[offset + j]);
-            }
-            sb.append(']');
-        }
-        sb.append(']');
-        return sb.toString();
+        return lineNumberTable.debugString();
     }
 
     /**
@@ -268,8 +484,6 @@ public class LineNumberTable {
      * @return true if empty
      */
     public static boolean isEmpty(LineNumberTable lineNumberTable) {
-        return lineNumberTable == null
-                || lineNumberTable.pcs == null
-                || lineNumberTable.pcs.length == 0;
+        return lineNumberTable == null || lineNumberTable.isEmptyTable();
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/instruction/Instruction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/instruction/Instruction.java
@@ -1,0 +1,24 @@
+package org.mozilla.javascript.interpreterv2.instruction;
+
+import org.mozilla.javascript.CallFrameV2;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.interpreterv2.InstructionSimplification;
+import org.mozilla.javascript.interpreterv2.KnownType;
+
+public abstract class Instruction {
+    public abstract void interpret(Context cx, CallFrameV2 frame);
+
+    public abstract int stackChange();
+
+    public Instruction simplify(InstructionSimplification simplifier) {
+        return this;
+    }
+
+    public KnownType getKnownType(InstructionSimplification simplifier) {
+        return KnownType.UNKNOWN;
+    }
+
+    public String toDebugString() {
+        return getClass().getSimpleName();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/interpreterv2/operand/Operand.java
+++ b/rhino/src/main/java/org/mozilla/javascript/interpreterv2/operand/Operand.java
@@ -1,0 +1,80 @@
+package org.mozilla.javascript.interpreterv2.operand;
+
+import org.mozilla.javascript.CallFrameV2;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.interpreterv2.InstructionSimplification;
+import org.mozilla.javascript.interpreterv2.KnownType;
+
+public abstract class Operand {
+    public static final Operand[] EMPTY_ARRAY = new Operand[0];
+
+    public abstract Object retrieve(Context cx, CallFrameV2 frame);
+
+    public abstract double retrieveDouble(CallFrameV2 frame);
+
+    public abstract boolean isDouble(CallFrameV2 frame);
+
+    public int stackChange() {
+        return 0;
+    }
+
+    public Operand convertToConsume() {
+        return this;
+    }
+
+    public void cleanup(CallFrameV2 frame) {}
+
+    public Object viewValue(Context cx, CallFrameV2 frame, int offset) {
+        return retrieve(cx, frame);
+    }
+
+    public boolean isValidJumpTableKey() {
+        return false;
+    }
+
+    public Object retrieveAndWrap(Context cx, CallFrameV2 frame) {
+        if (isDouble(frame)) {
+            return ScriptRuntime.wrapNumber(retrieveDouble(frame));
+        }
+        return retrieve(cx, frame);
+    }
+
+    public Number retrieveNumber(Context cx, CallFrameV2 frame) {
+        if (isDouble(frame)) {
+            return retrieveDouble(frame);
+        } else {
+            var obj = retrieve(cx, frame);
+            return ScriptRuntime.toNumeric(obj);
+        }
+    }
+
+    public boolean coerceToBoolean(Context cx, CallFrameV2 frame) {
+        if (isDouble(frame)) {
+            double x = retrieveDouble(frame);
+            return !Double.isNaN(x) && x != 0.0;
+        }
+        return ScriptRuntime.toBoolean(retrieve(cx, frame));
+    }
+
+    public double coerceToDouble(Context cx, CallFrameV2 frame) {
+        if (this.isDouble(frame)) {
+            return retrieveDouble(frame);
+        }
+        return ScriptRuntime.toNumber(retrieve(cx, frame));
+    }
+
+    public void setResult(Context cx, CallFrameV2 frame) {
+        if (isDouble(frame)) {
+            frame.setResult(retrieveDouble(frame));
+        } else {
+            frame.setResult(retrieve(cx, frame));
+        }
+    }
+
+    public KnownType getKnownType(InstructionSimplification simplifier) {
+        return KnownType.UNKNOWN;
+    }
+
+    public abstract void appendDebugString(StringBuilder sb);
+}

--- a/rhino/src/test/java/org/mozilla/javascript/interpreterv2/CompilerDataLineNumberTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/interpreterv2/CompilerDataLineNumberTest.java
@@ -1,0 +1,80 @@
+package org.mozilla.javascript.interpreterv2;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CompilerDataLineNumberTest {
+
+    private CompilerData<?> build(LineNumberTable.Builder lineNumberTable) {
+        CompilerData.Builder<?> b = new CompilerData.Builder<>();
+        b.setLineNumberTable(lineNumberTable);
+        return b.build();
+    }
+
+    @Test
+    public void emptyLineNumberTable() {
+        LineNumberTable.Builder lineNumberTable = new LineNumberTable.Builder();
+
+        CompilerData<?> cData = build(lineNumberTable);
+        assertArrayEquals(new int[0], cData.getLineNumbers());
+        assertEquals(-1, cData.getFirstLineNumber());
+        assertEquals(-1, cData.getPcFirstLineNumber());
+        assertEquals("[]", cData.getLineNumberTableForDebug());
+        assertEquals(-1, cData.getLineNumberFromPc(0, 0));
+        assertEquals(-1, cData.getLineNumberFromPc(99, 0));
+    }
+
+    @Test
+    public void lineNumberTableWithOneEntry() {
+        LineNumberTable.Builder lineNumberTable = new LineNumberTable.Builder();
+        lineNumberTable.add(1, 42, 42);
+
+        CompilerData<?> cData = build(lineNumberTable);
+        assertArrayEquals(new int[] {42}, cData.getLineNumbers());
+        assertEquals(42, cData.getFirstLineNumber());
+        assertEquals(1, cData.getPcFirstLineNumber());
+        assertEquals("[1 -> [42]]", cData.getLineNumberTableForDebug());
+        assertEquals(-1, cData.getLineNumberFromPc(0, 0));
+        assertEquals(42, cData.getLineNumberFromPc(99, 0));
+    }
+
+    @Test
+    public void lineNumberTableWithTwoEntries() {
+        LineNumberTable.Builder lineNumberTable = new LineNumberTable.Builder();
+        lineNumberTable.add(1, 1, 1);
+        lineNumberTable.add(7, 2, 2);
+
+        CompilerData<?> cData = build(lineNumberTable);
+        assertArrayEquals(new int[] {1, 2}, cData.getLineNumbers());
+        assertEquals(1, cData.getFirstLineNumber());
+        assertEquals(1, cData.getPcFirstLineNumber());
+        assertEquals("[1 -> [1],  7 -> [2]]", cData.getLineNumberTableForDebug());
+        assertEquals(-1, cData.getLineNumberFromPc(0, 0));
+        assertEquals(1, cData.getLineNumberFromPc(1, 0));
+        assertEquals(1, cData.getLineNumberFromPc(6, 0));
+        assertEquals(2, cData.getLineNumberFromPc(7, 0));
+        assertEquals(2, cData.getLineNumberFromPc(99, 0));
+    }
+
+    @Test
+    public void lineNumberTableLarge() {
+        LineNumberTable.Builder lineNumberTable = new LineNumberTable.Builder();
+        lineNumberTable.add(1, 2, 2);
+        lineNumberTable.add(6, 3, 4);
+        lineNumberTable.add(8, 5, 6);
+
+        CompilerData<?> cData = build(lineNumberTable);
+        assertArrayEquals(new int[] {2, 3, 4, 5, 6}, cData.getLineNumbers());
+        assertEquals(2, cData.getFirstLineNumber());
+        assertEquals(1, cData.getPcFirstLineNumber());
+        assertEquals("[1 -> [2],  6 -> [3, 4],  8 -> [5, 6]]", cData.getLineNumberTableForDebug());
+        assertEquals(-1, cData.getLineNumberFromPc(0, 0));
+        assertEquals(2, cData.getLineNumberFromPc(1, 0));
+        assertEquals(4, cData.getLineNumberFromPc(6, 0));
+        assertEquals(4, cData.getLineNumberFromPc(7, 0));
+        assertEquals(6, cData.getLineNumberFromPc(8, 0));
+        assertEquals(6, cData.getLineNumberFromPc(99, 0));
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/interpreterv2/CompilerDataLineNumberTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/interpreterv2/CompilerDataLineNumberTest.java
@@ -77,4 +77,32 @@ public class CompilerDataLineNumberTest {
         assertEquals(6, cData.getLineNumberFromPc(8, 0));
         assertEquals(6, cData.getLineNumberFromPc(99, 0));
     }
+
+    @Test
+    public void lineNumberTableReallyLarge() {
+        LineNumberTable.Builder lineNumberTable = new LineNumberTable.Builder();
+        for (int i = 1; i < 20; i = i + 4) {
+            var instruciton = 1 << i;
+            var start = 4 * i;
+            var end = 3 + (4 * i);
+            lineNumberTable.add(instruciton, start, end);
+        }
+        CompilerData<?> cData = build(lineNumberTable);
+        assertEquals(4, cData.getFirstLineNumber());
+        assertEquals(2, cData.getPcFirstLineNumber());
+        assertEquals(
+                "[2 -> [4, 5, 6, 7],  "
+                        + "32 -> [20, 21, 22, 23],  "
+                        + "512 -> [36, 37, 38, 39],  "
+                        + "8192 -> [52, 53, 54, 55],  "
+                        + "131072 -> [68, 69, 70, 71]]",
+                cData.getLineNumberTableForDebug());
+        assertEquals(-1, cData.getLineNumberFromPc(0, 0));
+        assertEquals(-1, cData.getLineNumberFromPc(1, 0));
+        assertEquals(7, cData.getLineNumberFromPc(2, 0));
+        assertEquals(23, cData.getLineNumberFromPc(32, 0));
+        assertEquals(39, cData.getLineNumberFromPc(512, 0));
+        assertEquals(55, cData.getLineNumberFromPc(8192, 0));
+        assertEquals(71, cData.getLineNumberFromPc(131072, 0));
+    }
 }

--- a/rhino/src/test/java/org/mozilla/javascript/interpreterv2/LineNumberTableTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/interpreterv2/LineNumberTableTest.java
@@ -1,0 +1,262 @@
+package org.mozilla.javascript.interpreterv2;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class LineNumberTableTest {
+    @Test
+    public void testGetFirstLineNumberFromNonEmptyMap() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(0, 2, 2);
+        LineNumberTable table = builder.buildFinalTable();
+        assertEquals(2, LineNumberTable.getFirstLineNumber(table));
+    }
+
+    @Test
+    public void testGetFirstLineNumberFromEmptyMap() {
+        assertEquals(-1, LineNumberTable.getFirstLineNumber(null));
+    }
+
+    @Test
+    public void testGetFirstLineNumberFromNullMap() {
+        assertEquals(-1, LineNumberTable.getFirstLineNumber(null));
+    }
+
+    @Test
+    public void testGetPcFirstLineNumberFromNullMap() {
+        assertEquals(-1, LineNumberTable.getPcFirstLineNumber(null));
+    }
+
+    @Test
+    public void testGetPcFirstLineNumberFromNonEmptyMap() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(0, 2, 2);
+        LineNumberTable table = builder.buildFinalTable();
+        assertEquals(0, LineNumberTable.getPcFirstLineNumber(table));
+    }
+
+    @Test
+    public void testGetPcFirstLineNumberFromEmptyMap() {
+        assertEquals(-1, LineNumberTable.getPcFirstLineNumber(null));
+    }
+
+    @Test
+    public void testGetLineNumberFromStandardMap() {
+        // bytecodes [1, 4) refer to line 1, [4, ...) to line 2
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(1, 1, 1);
+        builder.add(4, 2, 2);
+        LineNumberTable table = builder.buildFinalTable();
+        assertEquals(-1, LineNumberTable.getLineNumberFromPc(table, 0));
+        assertEquals(1, LineNumberTable.getLineNumberFromPc(table, 1));
+        assertEquals(1, LineNumberTable.getLineNumberFromPc(table, 2));
+        assertEquals(2, LineNumberTable.getLineNumberFromPc(table, 4));
+        assertEquals(2, LineNumberTable.getLineNumberFromPc(table, 6));
+    }
+
+    @Test
+    public void testGetLineNumberFromOnlyOneEntry() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(1, 1, 1);
+        LineNumberTable table = builder.buildFinalTable();
+        assertEquals(-1, LineNumberTable.getLineNumberFromPc(table, 0));
+        assertEquals(1, LineNumberTable.getLineNumberFromPc(table, 1));
+        assertEquals(1, LineNumberTable.getLineNumberFromPc(table, 2));
+    }
+
+    @Test
+    public void testGetLineNumberFromEmptyMap() {
+        assertEquals(-1, LineNumberTable.getLineNumberFromPc(null, 0));
+        assertEquals(-1, LineNumberTable.getLineNumberFromPc(null, 2));
+    }
+
+    @Test
+    public void testGetLineNumberFromNullMap() {
+        assertEquals(-1, LineNumberTable.getLineNumberFromPc(null, 0));
+    }
+
+    @Test
+    public void testGetLineNumbers() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(0, 1, 1);
+        builder.add(4, 2, 2);
+        LineNumberTable table = builder.buildFinalTable();
+        assertArrayEquals(new int[] {1, 2}, LineNumberTable.getLineNumbers(table));
+    }
+
+    @Test
+    public void testGetLineNumbersFromEmptyMap() {
+        assertArrayEquals(new int[0], LineNumberTable.getLineNumbers(null));
+    }
+
+    @Test
+    public void testGetLineNumbersFromNullMap() {
+        assertArrayEquals(new int[0], LineNumberTable.getLineNumbers(null));
+    }
+
+    @Test
+    public void testBuilder() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder(6);
+        builder.add(0, 4, 4);
+        builder.add(0, 5, 5);
+        builder.add(0, -1, -1);
+        builder.add(4, 12, 12);
+        builder.add(6, 13, 13);
+
+        LineNumberTable table = builder.buildFinalTable();
+        assertNotNull(table);
+
+        // PC 0 should have lines 4, 5, and -1 (synthetic)
+        // Note: getLineSetFromPc returns null for synthetic entries
+        String debugString = LineNumberTable.getDebugString(table);
+        assertTrue(debugString.contains("0 -> [4, 5, -1]"), "PC 0 should have lines 4, 5, -1");
+        assertTrue(debugString.contains("4 -> [12]"), "PC 4 should have line 12");
+        assertTrue(debugString.contains("6 -> [13]"), "PC 6 should have line 13");
+    }
+
+    @Test
+    public void testBuilderEnforcesPcOrder() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder(6);
+        builder.add(2, 4, 4);
+        assertThrows(IllegalArgumentException.class, () -> builder.add(0, 5, 5));
+    }
+
+    @Test
+    public void testBuilderWillReturnNullForEmptyMap() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        assertNull(builder.buildFinalTable());
+    }
+
+    @Test
+    public void testBuilderAccumulatesLines() {
+        // Test that multiple adds to the same PC accumulate lines
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(0, 1, 1);
+        builder.add(0, 2, 2);
+        builder.add(0, 3, 3);
+
+        LineNumberTable table = builder.buildFinalTable();
+        List<Integer> lines = LineNumberTable.getLineSetFromPc(table, 0);
+        assertEquals(3, lines.size());
+        assertTrue(lines.contains(1));
+        assertTrue(lines.contains(2));
+        assertTrue(lines.contains(3));
+    }
+
+    @Test
+    public void testBuilderDeduplicatesLines() {
+        // Test that duplicate lines are deduplicated
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        builder.add(0, 1, 1);
+        builder.add(0, 1, 1);
+        builder.add(0, 2, 2);
+
+        LineNumberTable table = builder.buildFinalTable();
+        List<Integer> lines = LineNumberTable.getLineSetFromPc(table, 0);
+        assertEquals(2, lines.size()); // Only 1 and 2, not 1, 1, 2
+    }
+
+    /**
+     * We want to check the lookup logic, so we'll build various sizes of maps and search for all
+     * possible entries, to ensure we don't have any weird edge cases with strange sizes of the map.
+     */
+    @Test
+    public void testGetLineNumberOnMultipleMapsNoGaps() {
+        // Map is [1,101,  2,102,  3,103, ...]
+        for (int size = 1; size <= 16; ++size) {
+            LineNumberTable.Builder builder = new LineNumberTable.Builder();
+            for (int pc = 1; pc <= size; ++pc) {
+                builder.add(pc, 100 + pc, 100 + pc);
+            }
+            LineNumberTable table = builder.buildFinalTable();
+
+            for (int pc = 1; pc <= size; ++pc) {
+                assertEquals(
+                        100 + pc,
+                        LineNumberTable.getLineNumberFromPc(table, pc),
+                        "Should find line for pc " + pc + " in table with no gaps of size " + size);
+            }
+
+            assertEquals(
+                    -1,
+                    LineNumberTable.getLineNumberFromPc(table, 0),
+                    "Should not find line number for pc before the first one in table with no gaps of size "
+                            + size);
+            assertEquals(
+                    100 + size,
+                    LineNumberTable.getLineNumberFromPc(table, size),
+                    "Should find line number for pc after the last one in table with no gaps of size "
+                            + size);
+        }
+    }
+
+    /**
+     * Similar to {@link #testGetLineNumberOnMultipleMapsNoGaps()} but we do have gaps in the PC.
+     */
+    @Test
+    public void testGetLineNumberOnMultipleMapsWithGaps() {
+        // Map is [1,0,  2,1,  4,2,  8,3,  16,4, ...]
+        for (int size = 1; size <= 10; ++size) {
+            LineNumberTable.Builder builder = new LineNumberTable.Builder();
+            for (int i = 0; i < size; ++i) {
+                builder.add((int) Math.pow(2, i), i, i);
+            }
+            LineNumberTable table = builder.buildFinalTable();
+
+            for (int pc = 1; pc < Math.pow(2, size); ++pc) {
+                int log2OfPc = (int) Math.floor(Math.log(pc) / Math.log(2));
+                assertEquals(
+                        log2OfPc,
+                        LineNumberTable.getLineNumberFromPc(table, pc),
+                        "Should find line for pc " + pc + " in table with gaps of size " + size);
+            }
+
+            assertEquals(
+                    -1,
+                    LineNumberTable.getLineNumberFromPc(table, 0),
+                    "Should not find line number for pc before the first one in table with gaps of size "
+                            + size);
+            assertEquals(
+                    size - 1,
+                    LineNumberTable.getLineNumberFromPc(table, (int) Math.pow(2, size)),
+                    "Should find line number for pc after the last one in table with gaps of size "
+                            + size);
+        }
+    }
+
+    @Test
+    public void testGetLineSetFromPc() {
+        LineNumberTable.Builder builder = new LineNumberTable.Builder();
+        // PC 0: single line 5
+        builder.add(0, 5, 5);
+        // PC 4: multiple lines 10, 11, 12
+        builder.add(4, 10, 12);
+
+        LineNumberTable table = builder.buildFinalTable();
+
+        // Test single-line set
+        List<Integer> lines = LineNumberTable.getLineSetFromPc(table, 0);
+        assertNotNull(lines);
+        assertEquals(1, lines.size());
+        assertEquals(5, lines.get(0));
+
+        // Test multi-line set
+        lines = LineNumberTable.getLineSetFromPc(table, 4);
+        assertNotNull(lines);
+        assertEquals(3, lines.size());
+        assertEquals(List.of(10, 11, 12), lines);
+
+        // Test synthetic line
+        LineNumberTable.Builder syntheticBuilder = new LineNumberTable.Builder();
+        syntheticBuilder.add(0, -1, -1);
+        LineNumberTable syntheticTable = syntheticBuilder.buildFinalTable();
+        lines = LineNumberTable.getLineSetFromPc(syntheticTable, 0);
+        assertNull(lines); // Synthetic lines return null
+
+        // Test null for PC before first entry
+        lines = LineNumberTable.getLineSetFromPc(table, -1);
+        assertNull(lines);
+    }
+}


### PR DESCRIPTION
This is the first chunk of Interpreter V2 work. It introduces the call frame, interpreter data, instructions, operand and other associated classes, but I cut the actual interpreter out of this PR to make it a more manageable size, that will come in the next chunk.

The `InstructionSimplification` and `KnownType` classes allow the compiler to replace general instructions such as `Add` with specialised versions when the typee are known.

I've extracted this from #2426 with some additional tidy up.