### PR TITLE
Handle strict mode better in direct eval.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeGlobal.java
@@ -459,7 +459,7 @@ public class NativeGlobal implements Serializable {
     private static Object js_eval(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         TopLevel top = ScriptableObject.getTopLevelScope(f.getDeclarationScope());
-        return ScriptRuntime.evalSpecial(cx, top, top.getGlobalThis(), args, "eval code", 1);
+        return ScriptRuntime.evalSpecial(cx, top, top.getGlobalThis(), args, "eval code", 1, false);
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -3471,7 +3471,8 @@ public class ScriptRuntime {
 
         if (callType == Node.SPECIALCALL_EVAL) {
             if (thisObj.getParentScope() == null && NativeGlobal.isEvalFunction(fun)) {
-                return evalSpecial(cx, scope, callerThis, args, filename, lineNumber);
+                return evalSpecial(
+                        cx, scope, callerThis, args, filename, lineNumber, cx.isStrictMode());
             }
         } else {
             throw Kit.codeBug();
@@ -3602,7 +3603,8 @@ public class ScriptRuntime {
             Object thisArg,
             Object[] args,
             String filename,
-            int lineNumber) {
+            int lineNumber,
+            boolean isStrict) {
         if (args.length < 1) return Undefined.instance;
         Object x = args[0];
         if (!(x instanceof CharSequence)) {
@@ -3666,7 +3668,14 @@ public class ScriptRuntime {
                 thisArg == Undefined.instance
                         ? Undefined.SCRIPTABLE_UNDEFINED
                         : (Scriptable) thisArg;
-        return script.exec(cx, scope, thisObject);
+        VarScope evalScope;
+        if (isStrict
+                || (script instanceof JSScript && ((JSScript) script).getDescriptor().isStrict())) {
+            evalScope = new ScopeObject(scope);
+        } else {
+            evalScope = scope;
+        }
+        return script.exec(cx, evalScope, thisObject);
     }
 
     /** The typeof operator */

--- a/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/ScriptRuntimeEvalSpecialTest.java
@@ -27,7 +27,7 @@ public class ScriptRuntimeEvalSpecialTest {
                     TopLevel scope = cx.initStandardObjects();
                     Object o =
                             ScriptRuntime.evalSpecial(
-                                    cx, scope, thisArg, new Object[] {"true"}, "", 0);
+                                    cx, scope, thisArg, new Object[] {"true"}, "", 0, false);
                     assertEquals(true, o);
                     return null;
                 });

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -3509,7 +3509,7 @@ language/directive-prologue 2/62 (3.23%)
     14.1-4-s.js non-strict
     14.1-5-s.js non-strict
 
-language/eval-code 239/347 (68.88%)
+language/eval-code 227/347 (65.42%)
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
     direct/arrow-fn-a-following-parameter-is-named-arguments-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js non-strict
     direct/arrow-fn-a-preceding-parameter-is-named-arguments-arrow-func-declare-arguments-assign.js non-strict
@@ -3614,9 +3614,6 @@ language/eval-code 239/347 (68.88%)
     direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js {unsupported: [async]}
     direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js {unsupported: [async]}
     direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js {unsupported: [async]}
-    direct/block-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/block-decl-eval-source-is-strict-onlystrict.js strict
-    direct/block-decl-onlystrict.js strict
     direct/export.js {unsupported: [module]}
     direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments.js non-strict
     direct/func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js non-strict
@@ -3692,8 +3689,8 @@ language/eval-code 239/347 (68.88%)
     direct/gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js non-strict
     direct/import.js {unsupported: [module]}
     direct/lex-env-distinct-cls.js {unsupported: [class]}
-    direct/lex-env-distinct-const.js
-    direct/lex-env-distinct-let.js
+    direct/lex-env-distinct-const.js non-strict
+    direct/lex-env-distinct-let.js non-strict
     direct/lex-env-no-init-cls.js {unsupported: [class]}
     direct/lex-env-no-init-const.js
     direct/lex-env-no-init-let.js
@@ -3713,42 +3710,33 @@ language/eval-code 239/347 (68.88%)
     direct/new.target-arrow.js {unsupported: [new.target]}
     direct/new.target-fn.js {unsupported: [new.target]}
     direct/non-definable-global-var.js non-strict
-    direct/switch-case-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/switch-case-decl-eval-source-is-strict-onlystrict.js strict
-    direct/switch-case-decl-onlystrict.js strict
-    direct/switch-dflt-decl-eval-source-is-strict-nostrict.js non-strict
-    direct/switch-dflt-decl-eval-source-is-strict-onlystrict.js strict
-    direct/switch-dflt-decl-onlystrict.js strict
     direct/var-env-func-init-global-update-configurable.js non-strict
-    direct/var-env-func-strict-caller.js strict
-    direct/var-env-func-strict-caller-2.js strict
-    direct/var-env-func-strict-source.js
     direct/var-env-global-lex-non-strict.js non-strict
     direct/var-env-lower-lex-non-strict.js non-strict
-    direct/var-env-var-strict-caller.js strict
-    direct/var-env-var-strict-caller-2.js strict
-    direct/var-env-var-strict-caller-3.js strict
-    direct/var-env-var-strict-source.js
     indirect/always-non-strict.js strict
-    indirect/block-decl-strict.js
     indirect/export.js {unsupported: [module]}
     indirect/import.js {unsupported: [module]}
     indirect/lex-env-distinct-cls.js {unsupported: [class]}
-    indirect/lex-env-distinct-const.js
-    indirect/lex-env-distinct-let.js
+    indirect/lex-env-distinct-const.js non-strict
+    indirect/lex-env-distinct-let.js non-strict
     indirect/lex-env-no-init-cls.js {unsupported: [class]}
     indirect/lex-env-no-init-const.js
     indirect/lex-env-no-init-let.js
     indirect/new.target.js {unsupported: [new.target]}
-    indirect/non-definable-function-with-function.js
-    indirect/non-definable-function-with-variable.js
-    indirect/non-definable-global-var.js non-strict
-    indirect/switch-case-decl-strict.js
-    indirect/switch-dflt-decl-strict.js
+    indirect/non-definable-function-with-function.js non-strict
+    indirect/non-definable-function-with-variable.js non-strict
+    indirect/non-definable-global-function.js strict
+    indirect/non-definable-global-generator.js strict
+    indirect/non-definable-global-var.js
+    indirect/realm.js strict
+    indirect/var-env-func-init-global-new.js strict
     indirect/var-env-func-init-global-update-configurable.js
-    indirect/var-env-func-strict.js
+    indirect/var-env-func-init-multi.js strict
+    indirect/var-env-func-non-strict.js strict
     indirect/var-env-global-lex-non-strict.js
-    indirect/var-env-var-strict.js
+    indirect/var-env-var-init-global-exstng.js strict
+    indirect/var-env-var-init-global-new.js strict
+    indirect/var-env-var-non-strict.js strict
 
 ~language/export 3/3 (100.0%)
 
@@ -5390,7 +5378,7 @@ language/global-code 26/42 (61.9%)
     script-decl-lex-lex.js
     script-decl-lex-restricted-global.js
     script-decl-lex-var.js
-    script-decl-lex-var-declared-via-eval.js
+    script-decl-lex-var-declared-via-eval.js non-strict
     script-decl-var.js
     script-decl-var-collision.js
     script-decl-var-err.js non-strict


### PR DESCRIPTION
I'm trying to reduce the differences between our fork and here to make merging down easier. This one came up because it was originally implemented as a special case in the interpreter, but seemed better suited to being in `evalSpecial` itself.