### PR TITLE
Add lazy source code provision.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
@@ -1,0 +1,16 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+
+/** Can provide source code for a built in Function */
+public class BuiltInSourceCodeProvider implements SourceCodeProvider, Serializable {
+    private static final long serialVersionUID = 1L;
+    public static final BuiltInSourceCodeProvider INSTANCE = new BuiltInSourceCodeProvider();
+
+    private BuiltInSourceCodeProvider() {}
+
+    @Override
+    public String getSource(String functionName, int start, int end) {
+        return String.format("function %s() {\n\t[native code]\n}", functionName);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
@@ -10,7 +10,7 @@ public class BuiltInSourceCodeProvider implements SourceCodeProvider, Serializab
     private BuiltInSourceCodeProvider() {}
 
     @Override
-    public String getSource(String functionName, int start, int end) {
-        return String.format("function %s() {\n\t[native code]\n}", functionName);
+    public String getSource(JSDescriptor<?> desc, int start, int end) {
+        return String.format("function %s() {\n\t[native code]\n}", desc.getFunctionName());
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSourceCodeProvider.java
@@ -13,4 +13,9 @@ public class BuiltInSourceCodeProvider implements SourceCodeProvider, Serializab
     public String getSource(JSDescriptor<?> desc, int start, int end) {
         return String.format("function %s() {\n\t[native code]\n}", desc.getFunctionName());
     }
+
+    @Override
+    public String getRawSource() {
+        return String.format("/*[native code]*/\n}");
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -762,9 +762,9 @@ public class ClassDescriptor {
             builder.paramAndVarNames = paramNames;
             builder.paramIsConst = new boolean[length];
             builder.paramAndVarCount = length;
-            builder.rawSource = String.format("function %s() {\n\t[native code]\n}", name);
-            builder.rawSourceStart = 0;
-            builder.rawSourceEnd = builder.rawSource.length();
+            builder.sourceCodeProvider = BuiltInSourceCodeProvider.INSTANCE;
+            builder.sourceStart = 0;
+            builder.sourceEnd = 0;
 
             builder.hasPrototype = true;
             return builder.build(desc -> {});

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenUtils.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenUtils.java
@@ -92,7 +92,7 @@ public class CodeGenUtils {
             String rawSource,
             CompilerEnvirons compilerEnv) {
         builder.sourceFile = scriptOrFn.getSourceName();
-        builder.rawSource = rawSource;
+        builder.sourceCodeProvider = compilerEnv.getSourceCodeProvider();
         builder.isTopLevel = true;
         builder.isScript = true;
         builder.isEvalFunction = compilerEnv.isInEval();
@@ -114,8 +114,8 @@ public class CodeGenUtils {
         // Calculate arity (function.length) - count params before first default
         builder.arity = FunctionNode.calculateFunctionArity(scriptOrFn);
 
-        builder.rawSourceStart = scriptOrFn.getRawSourceStart();
-        builder.rawSourceEnd = scriptOrFn.getRawSourceEnd();
+        builder.sourceStart = scriptOrFn.getRawSourceStart();
+        builder.sourceEnd = scriptOrFn.getRawSourceEnd();
     }
 
     /** Configure the constructor appropriately based on a function's type. */

--- a/rhino/src/main/java/org/mozilla/javascript/CompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompileSpec.java
@@ -1,0 +1,154 @@
+package org.mozilla.javascript;
+
+import java.io.Reader;
+import java.util.function.Consumer;
+import org.mozilla.javascript.ast.ScriptNode;
+import org.mozilla.javascript.sourcemap.SourceMapper;
+
+/**
+ * Parameters for compiling a JavaScript script (i.e. top-level program source). Build instances via
+ * {@link #fromSource(String)} or {@link #fromReader(Reader)} and pass them to {@link
+ * Context#compileScript(ScriptCompileSpec)} or {@link Context#evaluateScript(ScriptCompileSpec,
+ * VarScope)}.
+ *
+ * @see FunctionCompileSpec
+ */
+public abstract class CompileSpec<T extends ScriptOrFn<T>> {
+    private final String source;
+    private final String sourceName;
+    private final int lineno;
+    private final Object securityDomain;
+    private final Evaluator compiler;
+    private final ErrorReporter compilationErrorReporter;
+    private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+    private final SourceMapper sourceMapper;
+    private final SourceCodeSupplier sourceCodeSupplier;
+
+    public CompileSpec(Builder<T, ?> builder) {
+        this.source = builder.source;
+        this.sourceName = builder.sourceName;
+        this.lineno = Math.max(builder.lineno, 0);
+        this.securityDomain = builder.securityDomain;
+        this.compiler = builder.compiler;
+        this.compilationErrorReporter = builder.compilationErrorReporter;
+        this.compilerEnvironsProcessor = builder.compilerEnvironsProcessor;
+        this.sourceMapper = builder.sourceMapper;
+        this.sourceCodeSupplier = builder.sourceCodeSupplier;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public VarScope getScope() {
+        return null;
+    }
+
+    public String getSourceName() {
+        return sourceName;
+    }
+
+    public int getLineno() {
+        return lineno;
+    }
+
+    public Object getSecurityDomain() {
+        return securityDomain;
+    }
+
+    public Evaluator getCompiler() {
+        return compiler;
+    }
+
+    public ErrorReporter getCompilationErrorReporter() {
+        return compilationErrorReporter;
+    }
+
+    public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
+        return compilerEnvironsProcessor;
+    }
+
+    public SourceMapper getSourceMapper() {
+        return sourceMapper;
+    }
+
+    public SourceCodeSupplier getSourceCodeSupplier() {
+        return sourceCodeSupplier;
+    }
+
+    abstract boolean returnFunction();
+
+    abstract CompileFn<T> compilationFunction();
+
+    @FunctionalInterface
+    interface CompileFn<T extends ScriptOrFn<T>> {
+        CompilationResult<T> compile(
+                Evaluator evaluator, CompilerEnvirons env, ScriptNode tree, String rawSource);
+    }
+
+    public abstract static class Builder<T extends ScriptOrFn<T>, U extends Builder<T, U>> {
+        protected final String source;
+        protected String sourceName;
+        protected int lineno = 0;
+        protected Object securityDomain;
+        protected Evaluator compiler;
+        protected ErrorReporter compilationErrorReporter;
+        protected Consumer<CompilerEnvirons> compilerEnvironsProcessor;
+        protected SourceMapper sourceMapper;
+        protected SourceCodeSupplier sourceCodeSupplier;
+
+        protected Builder(String source) {
+            this.source = source;
+        }
+
+        public U sourceName(String sourceName) {
+            this.sourceName = sourceName;
+            return getThis();
+        }
+
+        public U lineno(int lineno) {
+            this.lineno = lineno;
+            return getThis();
+        }
+
+        public U securityDomain(Object securityDomain) {
+            this.securityDomain = securityDomain;
+            return getThis();
+        }
+
+        public U compiler(Evaluator compiler) {
+            this.compiler = compiler;
+            return getThis();
+        }
+
+        public U compilationErrorReporter(ErrorReporter compilationErrorReporter) {
+            this.compilationErrorReporter = compilationErrorReporter;
+            return getThis();
+        }
+
+        public U compilerEnvironsProcessor(Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
+            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
+            return getThis();
+        }
+
+        public U sourceMapper(SourceMapper sourceMapper) {
+            this.sourceMapper = sourceMapper;
+            return getThis();
+        }
+
+        /**
+         * Can be used to set a lazy source code provider for the script being compiled - for
+         * example, something that will lookup the script from a database. If set, Rhino will avoid
+         * storing the encoded source code and thus save memory. The trade-off is, of course, that
+         * whenever someone does `Function.toString()` we will need to do a database lookup.
+         */
+        public U sourceCodeSupplier(SourceCodeSupplier sourceCodeSupplier) {
+            this.sourceCodeSupplier = sourceCodeSupplier;
+            return getThis();
+        }
+
+        protected abstract U getThis();
+
+        public abstract CompileSpec<T> build();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/CompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompileSpec.java
@@ -6,12 +6,15 @@ import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
- * Parameters for compiling a JavaScript script (i.e. top-level program source). Build instances via
- * {@link #fromSource(String)} or {@link #fromReader(Reader)} and pass them to {@link
+ * Parameters for compiling a JavaScript script (i.e. top-level program source) or function. Build
+ * instances via {@link ScriptCompileSpec#fromSource(String)} or {@link
+ * ScriptCompileSpec#fromReader(Reader)} or {@link FunctionCompileSpec#fromSource(String)} or {@link
+ * FunctionCompileSpec#fromReader(Reader)} to create a {@link Builder}, set the other properties you
+ * need on that, and then pass the built compile spec to {@link
  * Context#compileScript(ScriptCompileSpec)} or {@link Context#evaluateScript(ScriptCompileSpec,
- * VarScope)}.
+ * VarScope)}, or the equivalent methods for compiling functions.
  *
- * @see FunctionCompileSpec
+ * @see FunctionCompileSpec ScriptCompileSpec
  */
 public abstract class CompileSpec<T extends ScriptOrFn<T>> {
     private final String source;

--- a/rhino/src/main/java/org/mozilla/javascript/CompilerEnvirons.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompilerEnvirons.java
@@ -56,6 +56,22 @@ public class CompilerEnvirons {
         this.errorReporter = errorReporter;
     }
 
+    public void setSourceMapper(SourceMapper sourceMapper) {
+        this.sourceMapper = sourceMapper;
+    }
+
+    public SourceMapper getSourceMapper() {
+        return sourceMapper;
+    }
+
+    public SourceCodeProvider getSourceCodeProvider() {
+        return sourceCodeProvider;
+    }
+
+    public void setSourceCodeProvider(SourceCodeProvider sourceCodeProvider) {
+        this.sourceCodeProvider = sourceCodeProvider;
+    }
+
     public final int getLanguageVersion() {
         return languageVersion;
     }
@@ -282,14 +298,6 @@ public class CompilerEnvirons {
         return securityDomain;
     }
 
-    public void setSourceMapper(SourceMapper sourceMapper) {
-        this.sourceMapper = sourceMapper;
-    }
-
-    public SourceMapper getSourceMapper() {
-        return sourceMapper;
-    }
-
     /**
      * Returns a {@code CompilerEnvirons} suitable for using Rhino in an IDE environment. Most
      * features are enabled by default. The {@link ErrorReporter} is set to an {@link
@@ -309,6 +317,8 @@ public class CompilerEnvirons {
     }
 
     private ErrorReporter errorReporter;
+    private SourceMapper sourceMapper;
+    private SourceCodeProvider sourceCodeProvider;
 
     private int languageVersion;
     private boolean generateDebugInfo;
@@ -332,5 +342,4 @@ public class CompilerEnvirons {
     private Scriptable homeObjecgt;
     private SecurityController securityController;
     private Object securityDomain;
-    private SourceMapper sourceMapper;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2651,44 +2651,14 @@ public class Context implements Closeable {
     }
 
     protected Script compileScriptImpl(ScriptCompileSpec spec) {
-        Compiled<JSScript> compiled =
-                compileImpl(
-                        spec.getSource(),
-                        spec.getSourceName(),
-                        spec.getLineno(),
-                        spec.getSecurityDomain(),
-                        spec.getCompiler(),
-                        spec.getCompilationErrorReporter(),
-                        spec.getCompilerEnvironsProcessor(),
-                        spec.getSourceMapper(),
-                        spec.getSourceCodeSupplier(),
-                        false,
-                        Evaluator::compileScript);
+        Compiled<JSScript> compiled = compileImpl(spec);
         return compiled.evaluator.createScriptObject(compiled.result, spec.getSecurityDomain());
     }
 
     protected Function compileFunctionImpl(FunctionCompileSpec spec) {
-        Compiled<JSFunction> compiled =
-                compileImpl(
-                        spec.getSource(),
-                        spec.getSourceName(),
-                        spec.getLineno(),
-                        spec.getSecurityDomain(),
-                        spec.getCompiler(),
-                        spec.getCompilationErrorReporter(),
-                        spec.getCompilerEnvironsProcessor(),
-                        spec.getSourceMapper(),
-                        spec.getSourceCodeSupplier(),
-                        true,
-                        Evaluator::compileFunction);
+        Compiled<JSFunction> compiled = compileImpl(spec);
         return compiled.evaluator.createFunctionObject(
                 this, spec.getScope(), compiled.result, spec.getSecurityDomain());
-    }
-
-    @FunctionalInterface
-    private interface CompileFn<T extends ScriptOrFn<T>> {
-        CompilationResult<T> compile(
-                Evaluator evaluator, CompilerEnvirons env, ScriptNode tree, String rawSource);
     }
 
     private static final class Compiled<T extends ScriptOrFn<T>> {
@@ -2701,44 +2671,45 @@ public class Context implements Closeable {
         }
     }
 
-    private <T extends ScriptOrFn<T>> Compiled<T> compileImpl(
-            String sourceString,
-            String sourceName,
-            int lineno,
-            Object securityDomain,
-            Evaluator compiler,
-            ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironProcessor,
-            SourceMapper sourceMapper,
-            SourceCodeSupplier sourceCodeSupplier,
-            boolean returnFunction,
-            CompileFn<T> compileFn) {
+    private <T extends ScriptOrFn<T>> Compiled<T> compileImpl(CompileSpec<T> spec) {
+        String sourceString = spec.getSource();
+
+        String sourceName = spec.getSourceName();
         if (sourceName == null) {
             sourceName = "unnamed script";
         }
 
+        var securityDomain = spec.getSecurityDomain();
         if (securityDomain != null && getSecurityController() == null) {
             throw new IllegalArgumentException(
                     "securityDomain should be null if setSecurityController() was never called");
         }
 
         SourceCodeProvider sourceCodeProvider =
-                SourceCodeProvider.make(generatingSource, sourceCodeSupplier, sourceString);
+                SourceCodeProvider.make(
+                        generatingSource, spec.getSourceCodeSupplier(), sourceString);
+
+        VarScope scope = spec.getScope();
+        boolean returnFunction = spec.returnFunction();
 
         CompilerEnvirons compilerEnv = new CompilerEnvirons();
         compilerEnv.initFromContext(this);
         compilerEnv.setSecurityDomain(securityDomain);
-        if (sourceMapper != null) {
-            compilerEnv.setSourceMapper(sourceMapper);
-        }
+        compilerEnv.setSourceMapper(spec.getSourceMapper());
+        compilerEnv.setSourceCodeProvider(sourceCodeProvider);
 
+        ErrorReporter compilationErrorReporter = spec.getCompilationErrorReporter();
         if (compilationErrorReporter == null) {
             compilationErrorReporter = compilerEnv.getErrorReporter();
         }
 
+        Consumer<CompilerEnvirons> compilerEnvironProcessor = spec.getCompilerEnvironsProcessor();
         if (compilerEnvironProcessor != null) {
             compilerEnvironProcessor.accept(compilerEnv);
         }
+
+        int lineno = spec.getLineno();
+        SourceMapper sourceMapper = spec.getSourceMapper();
 
         ScriptNode tree =
                 parse(
@@ -2749,13 +2720,14 @@ public class Context implements Closeable {
                         compilationErrorReporter,
                         returnFunction);
 
+        Evaluator compiler = spec.getCompiler();
         CompilationResult<T> result;
         try {
             if (compiler == null) {
                 compiler = createCompiler();
             }
 
-            result = compileFn.compile(compiler, compilerEnv, tree, sourceString);
+            result = spec.compilationFunction().compile(compiler, compilerEnv, tree, sourceString);
         } catch (ClassSizeException e) {
             // we hit some class file limit, fall back to interpreter or report
 
@@ -2771,7 +2743,7 @@ public class Context implements Closeable {
                             returnFunction);
 
             compiler = createInterpreter();
-            result = compileFn.compile(compiler, compilerEnv, tree, sourceString);
+            result = spec.compilationFunction().compile(compiler, compilerEnv, tree, sourceString);
         }
 
         if (debugger != null) {

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -2661,6 +2661,7 @@ public class Context implements Closeable {
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
                         spec.getSourceMapper(),
+                        spec.getSourceCodeSupplier(),
                         false,
                         Evaluator::compileScript);
         return compiled.evaluator.createScriptObject(compiled.result, spec.getSecurityDomain());
@@ -2677,6 +2678,7 @@ public class Context implements Closeable {
                         spec.getCompilationErrorReporter(),
                         spec.getCompilerEnvironsProcessor(),
                         spec.getSourceMapper(),
+                        spec.getSourceCodeSupplier(),
                         true,
                         Evaluator::compileFunction);
         return compiled.evaluator.createFunctionObject(
@@ -2708,6 +2710,7 @@ public class Context implements Closeable {
             ErrorReporter compilationErrorReporter,
             Consumer<CompilerEnvirons> compilerEnvironProcessor,
             SourceMapper sourceMapper,
+            SourceCodeSupplier sourceCodeSupplier,
             boolean returnFunction,
             CompileFn<T> compileFn) {
         if (sourceName == null) {
@@ -2718,6 +2721,9 @@ public class Context implements Closeable {
             throw new IllegalArgumentException(
                     "securityDomain should be null if setSecurityController() was never called");
         }
+
+        SourceCodeProvider sourceCodeProvider =
+                SourceCodeProvider.make(generatingSource, sourceCodeSupplier, sourceString);
 
         CompilerEnvirons compilerEnv = new CompilerEnvirons();
         compilerEnv.initFromContext(this);

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -1590,7 +1590,7 @@ public class Context implements Closeable {
      * @return a string representing the script source
      */
     public final String decompileScript(Script script, int indent) {
-        return ((JSScript) script).getDescriptor().getRawSource();
+        return ((JSScript) script).getDescriptor().getSource();
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
@@ -14,7 +14,7 @@ public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable
     }
 
     @Override
-    public String getSource(String functionName, int start, int end) {
+    public String getSource(JSDescriptor<?> desc, int start, int end) {
         return rawSource.substring(start, end);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
@@ -1,0 +1,20 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Stores a reference to the original source code and returns it as necessary. */
+public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable {
+    private static final long serialVersionUID = 1L;
+    private final String rawSource;
+
+    public EagerSourceCodeProvider(String rawSource) {
+        Objects.requireNonNull(rawSource);
+        this.rawSource = rawSource;
+    }
+
+    @Override
+    public String getSource(String functionName, int start, int end) {
+        return rawSource.substring(start, end);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
@@ -17,4 +17,9 @@ public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable
     public String getSource(JSDescriptor<?> desc, int start, int end) {
         return rawSource.substring(start, end);
     }
+
+    // Escape hatch for class compilation.
+    public String getRawSource() {
+        return rawSource;
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
@@ -18,7 +18,7 @@ public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable
         return rawSource.substring(start, end);
     }
 
-    // Escape hatch for class compilation.
+    @Override
     public String getRawSource() {
         return rawSource;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EqualObjectGraphs.java
@@ -302,7 +302,7 @@ final class EqualObjectGraphs {
     }
 
     private static boolean equalJSFunctions(final ScriptOrFn<?> f1, final ScriptOrFn<?> f2) {
-        return Objects.equals(f1.getDescriptor().getRawSource(), f2.getDescriptor().getRawSource());
+        return Objects.equals(f1.getDescriptor().getSource(), f2.getDescriptor().getSource());
     }
 
     // Sort IDs deterministically

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -23,6 +23,7 @@ public final class FunctionCompileSpec {
     private final ErrorReporter compilationErrorReporter;
     private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
     private final SourceMapper sourceMapper;
+    private final SourceCodeSupplier sourceCodeSupplier;
 
     public FunctionCompileSpec(
             String source,
@@ -33,7 +34,8 @@ public final class FunctionCompileSpec {
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
             Consumer<CompilerEnvirons> compilerEnvironsProcessor,
-            SourceMapper sourceMapper) {
+            SourceMapper sourceMapper,
+            SourceCodeSupplier sourceCodeSupplier) {
         if (scope == null) {
             throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
         }
@@ -46,6 +48,7 @@ public final class FunctionCompileSpec {
         this.compilationErrorReporter = compilationErrorReporter;
         this.compilerEnvironsProcessor = compilerEnvironsProcessor;
         this.sourceMapper = sourceMapper;
+        this.sourceCodeSupplier = sourceCodeSupplier;
     }
 
     public static Builder fromSource(String source, VarScope scope) {
@@ -92,6 +95,10 @@ public final class FunctionCompileSpec {
         return sourceMapper;
     }
 
+    public SourceCodeSupplier getSourceCodeSupplier() {
+        return sourceCodeSupplier;
+    }
+
     public static final class Builder {
         private final String source;
         private final VarScope scope;
@@ -102,6 +109,7 @@ public final class FunctionCompileSpec {
         private ErrorReporter compilationErrorReporter;
         private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
         private SourceMapper sourceMapper;
+        private SourceCodeSupplier sourceCodeSupplier;
 
         private Builder(String source, VarScope scope) {
             if (scope == null) {
@@ -147,6 +155,17 @@ public final class FunctionCompileSpec {
             return this;
         }
 
+        /**
+         * Can be used to set a lazy source code provider for the script being compiled - for
+         * example, something that will lookup the script from a database. If set, Rhino will avoid
+         * storing the encoded source code and thus save memory. The trade-off is, of course, that
+         * whenever someone does `Function.toString()` we will need to do a database lookup.
+         */
+        public Builder sourceCodeSupplier(SourceCodeSupplier sourceCodeSupplier) {
+            this.sourceCodeSupplier = sourceCodeSupplier;
+            return this;
+        }
+
         public FunctionCompileSpec build() {
             int normalizedLineno = Math.max(lineno, 0);
             return new FunctionCompileSpec(
@@ -158,7 +177,8 @@ public final class FunctionCompileSpec {
                     compiler,
                     compilationErrorReporter,
                     compilerEnvironsProcessor,
-                    sourceMapper);
+                    sourceMapper,
+                    sourceCodeSupplier);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -2,8 +2,6 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.function.Consumer;
-import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
  * Parameters for compiling a JavaScript function (a single function definition). The parent scope
@@ -13,42 +11,15 @@ import org.mozilla.javascript.sourcemap.SourceMapper;
  *
  * @see ScriptCompileSpec
  */
-public final class FunctionCompileSpec {
-    private final String source;
+public final class FunctionCompileSpec extends CompileSpec<JSFunction> {
     private final VarScope scope;
-    private final String sourceName;
-    private final int lineno;
-    private final Object securityDomain;
-    private final Evaluator compiler;
-    private final ErrorReporter compilationErrorReporter;
-    private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
-    private final SourceMapper sourceMapper;
-    private final SourceCodeSupplier sourceCodeSupplier;
 
-    public FunctionCompileSpec(
-            String source,
-            VarScope scope,
-            String sourceName,
-            int lineno,
-            Object securityDomain,
-            Evaluator compiler,
-            ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironsProcessor,
-            SourceMapper sourceMapper,
-            SourceCodeSupplier sourceCodeSupplier) {
-        if (scope == null) {
+    public FunctionCompileSpec(Builder builder) {
+        super(builder);
+        if (builder.scope == null) {
             throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
         }
-        this.source = source;
-        this.scope = scope;
-        this.sourceName = sourceName;
-        this.lineno = lineno;
-        this.securityDomain = securityDomain;
-        this.compiler = compiler;
-        this.compilationErrorReporter = compilationErrorReporter;
-        this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-        this.sourceMapper = sourceMapper;
-        this.sourceCodeSupplier = sourceCodeSupplier;
+        this.scope = builder.scope;
     }
 
     public static Builder fromSource(String source, VarScope scope) {
@@ -59,126 +30,39 @@ public final class FunctionCompileSpec {
         return new Builder(Kit.readReader(reader), scope);
     }
 
-    public String getSource() {
-        return source;
-    }
-
+    @Override
     public VarScope getScope() {
         return scope;
     }
 
-    public String getSourceName() {
-        return sourceName;
+    @Override
+    boolean returnFunction() {
+        return true;
     }
 
-    public int getLineno() {
-        return lineno;
+    @Override
+    CompileFn<JSFunction> compilationFunction() {
+        return Evaluator::compileFunction;
     }
 
-    public Object getSecurityDomain() {
-        return securityDomain;
-    }
-
-    public Evaluator getCompiler() {
-        return compiler;
-    }
-
-    public ErrorReporter getCompilationErrorReporter() {
-        return compilationErrorReporter;
-    }
-
-    public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
-        return compilerEnvironsProcessor;
-    }
-
-    public SourceMapper getSourceMapper() {
-        return sourceMapper;
-    }
-
-    public SourceCodeSupplier getSourceCodeSupplier() {
-        return sourceCodeSupplier;
-    }
-
-    public static final class Builder {
-        private final String source;
+    public static final class Builder extends CompileSpec.Builder<JSFunction, Builder> {
         private final VarScope scope;
-        private String sourceName;
-        private int lineno = 0;
-        private Object securityDomain;
-        private Evaluator compiler;
-        private ErrorReporter compilationErrorReporter;
-        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
-        private SourceMapper sourceMapper;
-        private SourceCodeSupplier sourceCodeSupplier;
 
         private Builder(String source, VarScope scope) {
+            super(source);
             if (scope == null) {
                 throw new IllegalArgumentException("scope is required for FunctionCompileSpec");
             }
-            this.source = source;
             this.scope = scope;
         }
 
-        public Builder sourceName(String sourceName) {
-            this.sourceName = sourceName;
-            return this;
-        }
-
-        public Builder lineno(int lineno) {
-            this.lineno = lineno;
-            return this;
-        }
-
-        public Builder securityDomain(Object securityDomain) {
-            this.securityDomain = securityDomain;
-            return this;
-        }
-
-        public Builder compiler(Evaluator compiler) {
-            this.compiler = compiler;
-            return this;
-        }
-
-        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-            this.compilationErrorReporter = compilationErrorReporter;
-            return this;
-        }
-
-        public Builder compilerEnvironsProcessor(
-                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-            return this;
-        }
-
-        public Builder sourceMapper(SourceMapper sourceMapper) {
-            this.sourceMapper = sourceMapper;
-            return this;
-        }
-
-        /**
-         * Can be used to set a lazy source code provider for the script being compiled - for
-         * example, something that will lookup the script from a database. If set, Rhino will avoid
-         * storing the encoded source code and thus save memory. The trade-off is, of course, that
-         * whenever someone does `Function.toString()` we will need to do a database lookup.
-         */
-        public Builder sourceCodeSupplier(SourceCodeSupplier sourceCodeSupplier) {
-            this.sourceCodeSupplier = sourceCodeSupplier;
+        @Override
+        protected Builder getThis() {
             return this;
         }
 
         public FunctionCompileSpec build() {
-            int normalizedLineno = Math.max(lineno, 0);
-            return new FunctionCompileSpec(
-                    source,
-                    scope,
-                    sourceName,
-                    normalizedLineno,
-                    securityDomain,
-                    compiler,
-                    compilationErrorReporter,
-                    compilerEnvironsProcessor,
-                    sourceMapper,
-                    sourceCodeSupplier);
+            return new FunctionCompileSpec(this);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/FunctionCompileSpec.java
@@ -61,6 +61,7 @@ public final class FunctionCompileSpec extends CompileSpec<JSFunction> {
             return this;
         }
 
+        @Override
         public FunctionCompileSpec build() {
             return new FunctionCompileSpec(this);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Interpreter.java
@@ -31,7 +31,7 @@ public final class Interpreter extends AInterpreter<CallFrame, InterpreterData<?
     static final int EXCEPTION_SLOT_SIZE = 6;
 
     static boolean compareDescs(JSDescriptor i1, JSDescriptor i2) {
-        return i1 == i2 || Objects.equals(getRawSource(i1), getRawSource(i2));
+        return i1 == i2 || Objects.equals(getSource(i1), getSource(i2));
     }
 
     private static CallFrame captureFrameForGenerator(CallFrame frame) {
@@ -373,11 +373,11 @@ public final class Interpreter extends AInterpreter<CallFrame, InterpreterData<?
         return ret;
     }
 
-    static String getRawSource(JSDescriptor<?> desc) {
-        if (desc.getRawSource() == null) {
+    static String getSource(JSDescriptor<?> desc) {
+        if (desc.getSource() == null) {
             return null;
         }
-        return desc.getRawSource();
+        return desc.getSource();
     }
 
     static void initFunction(Context cx, VarScope scope, JSDescriptor<?> parent, int index) {

--- a/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
@@ -15,7 +15,7 @@ import org.mozilla.javascript.debug.DebuggableScript;
  * function objects represented by {@link JSFunction}s become more lightweight in their creation.
  */
 public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable, DebuggableScript {
-    private static final long seria_ersio_ID = 5067677351589230234L;
+    private static final long serialVersionUID = 5067677351589230234L;
 
     private static final int IS_STRICT_FLAG = 1;
     private static final int IS_SCRIPT_FLAG = 1 << 1;
@@ -39,9 +39,9 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
     private final boolean[] paramIsConst;
     private final int flags;
     private final String sourceFile;
-    private final String rawSource;
-    private final int rawSourceStart;
-    private final int rawSourceEnd;
+    private final SourceCodeProvider sourceCodeProvider;
+    private final int sourceStart;
+    private final int sourceEnd;
     private final String name;
     private final int languageVersion;
     private final int paramAndVarCount;
@@ -67,9 +67,9 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
             boolean isEvalFunction,
             boolean hasRestArg,
             String sourceFile,
-            String rawSource,
-            int rawSourceStart,
-            int rawSourceEnd,
+            SourceCodeProvider sourceCodeProvider,
+            int sourceStart,
+            int sourceEnd,
             String name,
             int languageVersion,
             int paramAndVarCount,
@@ -105,9 +105,9 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
         this.flags = flags;
 
         this.sourceFile = sourceFile;
-        this.rawSource = rawSource;
-        this.rawSourceStart = rawSourceStart;
-        this.rawSourceEnd = rawSourceEnd;
+        this.sourceCodeProvider = sourceCodeProvider;
+        this.sourceStart = sourceStart;
+        this.sourceEnd = sourceEnd;
         this.name = name == null ? "" : name;
         this.languageVersion = languageVersion;
         this.paramAndVarCount = paramAndVarCount;
@@ -178,7 +178,7 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
     }
 
     public String getRawSource() {
-        return rawSource.substring(rawSourceStart, rawSourceEnd);
+        return sourceCodeProvider.getSource(name, sourceStart, sourceEnd);
     }
 
     public String getName() {
@@ -303,9 +303,9 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
         public boolean isEvalFunction;
         public boolean hasRestArg;
         public String sourceFile;
-        public String rawSource;
-        public int rawSourceStart;
-        public int rawSourceEnd;
+        public SourceCodeProvider sourceCodeProvider;
+        public int sourceStart;
+        public int sourceEnd;
         public String name;
         public int languageVersion;
         public int paramAndVarCount;
@@ -324,7 +324,7 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
         private Builder(Builder<?> parent) {
             this.parent = parent;
             this.languageVersion = parent.languageVersion;
-            this.rawSource = parent.rawSource;
+            this.sourceCodeProvider = parent.sourceCodeProvider;
             this.sourceFile = parent.sourceFile;
             this.isStrict = parent.isStrict;
             this.securityController = parent.securityController;
@@ -373,9 +373,9 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
                             isEvalFunction,
                             hasRestArg,
                             sourceFile,
-                            rawSource,
-                            rawSourceStart,
-                            rawSourceEnd,
+                            sourceCodeProvider,
+                            sourceStart,
+                            sourceEnd,
                             name == null ? null : name.intern(),
                             languageVersion,
                             paramAndVarCount,

--- a/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
@@ -177,7 +177,7 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
         return sourceFile;
     }
 
-    public String getRawSource() {
+    public String getSource() {
         return sourceCodeProvider.getSource(name, sourceStart, sourceEnd);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSDescriptor.java
@@ -39,7 +39,7 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
     private final boolean[] paramIsConst;
     private final int flags;
     private final String sourceFile;
-    private final SourceCodeProvider sourceCodeProvider;
+    private volatile SourceCodeProvider sourceCodeProvider;
     private final int sourceStart;
     private final int sourceEnd;
     private final String name;
@@ -105,7 +105,10 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
         this.flags = flags;
 
         this.sourceFile = sourceFile;
-        this.sourceCodeProvider = sourceCodeProvider;
+        this.sourceCodeProvider =
+                sourceCodeProvider != null
+                        ? sourceCodeProvider
+                        : NullSourceCodeProvider.NULL_PROVIDER;
         this.sourceStart = sourceStart;
         this.sourceEnd = sourceEnd;
         this.name = name == null ? "" : name;
@@ -178,7 +181,16 @@ public final class JSDescriptor<T extends ScriptOrFn<T>> implements Serializable
     }
 
     public String getSource() {
-        return sourceCodeProvider.getSource(name, sourceStart, sourceEnd);
+        return sourceCodeProvider.getSource(this, sourceStart, sourceEnd);
+    }
+
+    // For testing purposes.
+    SourceCodeProvider getSourceProvider() {
+        return sourceCodeProvider;
+    }
+
+    void replaceSourceProvider(SourceCodeProvider newProvider) {
+        sourceCodeProvider = newProvider;
     }
 
     public String getName() {

--- a/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSFunction.java
@@ -57,7 +57,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
 
     @Override
     final String decompile(int indent, EnumSet<DecompilerFlag> flags) {
-        return descriptor.getRawSource();
+        return descriptor.getSource();
     }
 
     public boolean isShorthand() {
@@ -117,7 +117,7 @@ public class JSFunction extends BaseFunction implements ScriptOrFn<JSFunction> {
     }
 
     public String getRawSource() {
-        return descriptor.getRawSource();
+        return descriptor.getSource();
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
@@ -1,0 +1,36 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+import java.lang.ref.WeakReference;
+import java.util.Objects;
+
+/**
+ * Can provide source code from a lazy {@link SourceCodeSupplier}, that for example can retrieve it
+ * from the database.
+ */
+public class LazySourceCodeProvider implements SourceCodeProvider, Serializable {
+    private static final long serialVersionUID = 1L;
+    private final SourceCodeSupplier sourceSupplier;
+    private WeakReference<String> sourceCodeRef;
+
+    public LazySourceCodeProvider(SourceCodeSupplier sourceSupplier) {
+        Objects.requireNonNull(sourceSupplier);
+        this.sourceSupplier = sourceSupplier;
+    }
+
+    @Override
+    public String getSource(String functionName, int start, int end) {
+        if (sourceCodeRef != null && sourceCodeRef.get() != null) {
+            String source = sourceCodeRef.get();
+            return source.substring(start, end);
+        } else {
+            String source = sourceSupplier.get();
+            sourceCodeRef = new WeakReference<>(source);
+            if (source != null) {
+                return source.substring(start, end);
+            } else {
+                return null;
+            }
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
@@ -20,11 +20,12 @@ public class LazySourceCodeProvider implements SourceCodeProvider, Serializable 
 
     @Override
     public String getSource(String functionName, int start, int end) {
-        if (sourceCodeRef != null && sourceCodeRef.get() != null) {
-            String source = sourceCodeRef.get();
+        String source;
+        if (sourceCodeRef != null && (source = sourceCodeRef.get()) != null) {
+            source = sourceCodeRef.get();
             return source.substring(start, end);
         } else {
-            String source = sourceSupplier.get();
+            source = sourceSupplier.get();
             sourceCodeRef = new WeakReference<>(source);
             if (source != null) {
                 return source.substring(start, end);

--- a/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
@@ -39,6 +39,11 @@ public class LazySourceCodeProvider implements SourceCodeProvider, Serializable 
         }
     }
 
+    @Override
+    public String getRawSource() {
+        return sourceSupplier.get();
+    }
+
     static class ResolvedSourceProvider implements SourceCodeProvider {
 
         private String source;
@@ -49,6 +54,11 @@ public class LazySourceCodeProvider implements SourceCodeProvider, Serializable 
 
         @Override
         public String getSource(JSDescriptor<?> functionName, int start, int end) {
+            return source;
+        }
+
+        @Override
+        public String getRawSource() {
             return source;
         }
     }

--- a/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
@@ -19,19 +19,37 @@ public class LazySourceCodeProvider implements SourceCodeProvider, Serializable 
     }
 
     @Override
-    public String getSource(String functionName, int start, int end) {
+    public String getSource(JSDescriptor<?> descriptor, int start, int end) {
         String source;
         if (sourceCodeRef != null && (source = sourceCodeRef.get()) != null) {
-            source = sourceCodeRef.get();
-            return source.substring(start, end);
+            var functionSrc = source.substring(start, end);
+            descriptor.replaceSourceProvider(new ResolvedSourceProvider(functionSrc));
+            return functionSrc;
         } else {
             source = sourceSupplier.get();
-            sourceCodeRef = new WeakReference<>(source);
             if (source != null) {
-                return source.substring(start, end);
+                sourceCodeRef = new WeakReference<>(source);
+                var funcionSrc = source.substring(start, end);
+                descriptor.replaceSourceProvider(new ResolvedSourceProvider(funcionSrc));
+                return funcionSrc;
             } else {
-                return null;
+                descriptor.replaceSourceProvider(new ResolvedSourceProvider(""));
+                return "";
             }
+        }
+    }
+
+    static class ResolvedSourceProvider implements SourceCodeProvider {
+
+        private String source;
+
+        private ResolvedSourceProvider(String source) {
+            this.source = source;
+        }
+
+        @Override
+        public String getSource(JSDescriptor<?> functionName, int start, int end) {
+            return source;
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LazySourceCodeProvider.java
@@ -29,9 +29,9 @@ public class LazySourceCodeProvider implements SourceCodeProvider, Serializable 
             source = sourceSupplier.get();
             if (source != null) {
                 sourceCodeRef = new WeakReference<>(source);
-                var funcionSrc = source.substring(start, end);
-                descriptor.replaceSourceProvider(new ResolvedSourceProvider(funcionSrc));
-                return funcionSrc;
+                var functionSrc = source.substring(start, end);
+                descriptor.replaceSourceProvider(new ResolvedSourceProvider(functionSrc));
+                return functionSrc;
             } else {
                 descriptor.replaceSourceProvider(new ResolvedSourceProvider(""));
                 return "";

--- a/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvider.java
@@ -5,6 +5,7 @@ class NullSourceCodeProvider implements SourceCodeProvider {
 
     private NullSourceCodeProvider() {}
 
+    @Override
     public String getSource(JSDescriptor<?> desc, int start, int end) {
         return String.format(
                 "function %s() {\n\t/* Source unavailable */\n}", desc.getFunctionName());
@@ -12,7 +13,6 @@ class NullSourceCodeProvider implements SourceCodeProvider {
 
     @Override
     public String getRawSource() {
-        return String.format(
-                "/* Source unavailable */\n");
+        return String.format("/* Source unavailable */\n");
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
@@ -1,0 +1,11 @@
+package org.mozilla.javascript;
+
+class NullSourceCodeProvider implements SourceCodeProvider {
+    static final SourceCodeProvider NULL_PROVIDER = new NullSourceCodeProvider();
+
+    private NullSourceCodeProvider() {}
+
+    public String getSource(String functionName, int start, int end) {
+        return String.format("function %s() {\n\t/* Source unavailable */\n}", functionName);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
@@ -5,7 +5,8 @@ class NullSourceCodeProvider implements SourceCodeProvider {
 
     private NullSourceCodeProvider() {}
 
-    public String getSource(String functionName, int start, int end) {
-        return String.format("function %s() {\n\t/* Source unavailable */\n}", functionName);
+    public String getSource(JSDescriptor<?> desc, int start, int end) {
+        return String.format(
+                "function %s() {\n\t/* Source unavailable */\n}", desc.getFunctionName());
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NullSourceCodeProvier.java
@@ -9,4 +9,10 @@ class NullSourceCodeProvider implements SourceCodeProvider {
         return String.format(
                 "function %s() {\n\t/* Source unavailable */\n}", desc.getFunctionName());
     }
+
+    @Override
+    public String getRawSource() {
+        return String.format(
+                "/* Source unavailable */\n");
+    }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -2,8 +2,6 @@ package org.mozilla.javascript;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.function.Consumer;
-import org.mozilla.javascript.sourcemap.SourceMapper;
 
 /**
  * Parameters for compiling a JavaScript script (i.e. top-level program source). Build instances via
@@ -13,36 +11,10 @@ import org.mozilla.javascript.sourcemap.SourceMapper;
  *
  * @see FunctionCompileSpec
  */
-public final class ScriptCompileSpec {
-    private final String source;
-    private final String sourceName;
-    private final int lineno;
-    private final Object securityDomain;
-    private final Evaluator compiler;
-    private final ErrorReporter compilationErrorReporter;
-    private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
-    private final SourceMapper sourceMapper;
-    private final SourceCodeSupplier sourceCodeSupplier;
+public final class ScriptCompileSpec extends CompileSpec<JSScript> {
 
-    public ScriptCompileSpec(
-            String source,
-            String sourceName,
-            int lineno,
-            Object securityDomain,
-            Evaluator compiler,
-            ErrorReporter compilationErrorReporter,
-            Consumer<CompilerEnvirons> compilerEnvironsProcessor,
-            SourceMapper sourceMapper,
-            SourceCodeSupplier sourceCodeSupplier) {
-        this.source = source;
-        this.sourceName = sourceName;
-        this.lineno = lineno;
-        this.securityDomain = securityDomain;
-        this.compiler = compiler;
-        this.compilationErrorReporter = compilationErrorReporter;
-        this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-        this.sourceMapper = sourceMapper;
-        this.sourceCodeSupplier = sourceCodeSupplier;
+    public ScriptCompileSpec(Builder builder) {
+        super(builder);
     }
 
     public static Builder fromSource(String source) {
@@ -53,116 +25,29 @@ public final class ScriptCompileSpec {
         return new Builder(Kit.readReader(reader));
     }
 
-    public String getSource() {
-        return source;
+    @Override
+    boolean returnFunction() {
+        return false;
     }
 
-    public String getSourceName() {
-        return sourceName;
+    @Override
+    CompileFn<JSScript> compilationFunction() {
+        return Evaluator::compileScript;
     }
 
-    public int getLineno() {
-        return lineno;
-    }
-
-    public Object getSecurityDomain() {
-        return securityDomain;
-    }
-
-    public Evaluator getCompiler() {
-        return compiler;
-    }
-
-    public ErrorReporter getCompilationErrorReporter() {
-        return compilationErrorReporter;
-    }
-
-    public Consumer<CompilerEnvirons> getCompilerEnvironsProcessor() {
-        return compilerEnvironsProcessor;
-    }
-
-    public SourceMapper getSourceMapper() {
-        return sourceMapper;
-    }
-
-    public SourceCodeSupplier getSourceCodeSupplier() {
-        return sourceCodeSupplier;
-    }
-
-    public static final class Builder {
-        private final String source;
-        private String sourceName;
-        private int lineno = 0;
-        private Object securityDomain;
-        private Evaluator compiler;
-        private ErrorReporter compilationErrorReporter;
-        private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
-        private SourceMapper sourceMapper;
-        private SourceCodeSupplier sourceCodeSupplier;
-
+    public static final class Builder extends CompileSpec.Builder<JSScript, Builder> {
         private Builder(String source) {
-            this.source = source;
+            super(source);
         }
 
-        public Builder sourceName(String sourceName) {
-            this.sourceName = sourceName;
+        @Override
+        protected Builder getThis() {
             return this;
         }
 
-        public Builder lineno(int lineno) {
-            this.lineno = lineno;
-            return this;
-        }
-
-        public Builder securityDomain(Object securityDomain) {
-            this.securityDomain = securityDomain;
-            return this;
-        }
-
-        public Builder compiler(Evaluator compiler) {
-            this.compiler = compiler;
-            return this;
-        }
-
-        public Builder compilationErrorReporter(ErrorReporter compilationErrorReporter) {
-            this.compilationErrorReporter = compilationErrorReporter;
-            return this;
-        }
-
-        public Builder compilerEnvironsProcessor(
-                Consumer<CompilerEnvirons> compilerEnvironsProcessor) {
-            this.compilerEnvironsProcessor = compilerEnvironsProcessor;
-            return this;
-        }
-
-        public Builder sourceMapper(SourceMapper sourceMapper) {
-            this.sourceMapper = sourceMapper;
-            return this;
-        }
-
-        /**
-         * Can be used to set a lazy source code provider for the script being compiled - for
-         * example, something that will lookup the script from a database. If set, Rhino will avoid
-         * storing the encoded source code and thus save memory. The trade-off is, of course, that
-         * whenever someone does `Function.toString()` we will need to do a database lookup.
-         */
-        public Builder sourceCodeSupplier(SourceCodeSupplier sourceCodeSupplier) {
-            this.sourceCodeSupplier = sourceCodeSupplier;
-            return this;
-        }
-
+        @Override
         public ScriptCompileSpec build() {
-            int normalizedLineno = Math.max(lineno, 0);
-            return new ScriptCompileSpec(
-                    source,
-                    sourceName,
-                    normalizedLineno,
-                    securityDomain,
-                    compiler,
-                    compilationErrorReporter,
-                    compilerEnvironsProcessor,
-                    sourceMapper,
-                    sourceCodeSupplier);
+            return new ScriptCompileSpec(this);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptCompileSpec.java
@@ -22,6 +22,7 @@ public final class ScriptCompileSpec {
     private final ErrorReporter compilationErrorReporter;
     private final Consumer<CompilerEnvirons> compilerEnvironsProcessor;
     private final SourceMapper sourceMapper;
+    private final SourceCodeSupplier sourceCodeSupplier;
 
     public ScriptCompileSpec(
             String source,
@@ -31,7 +32,8 @@ public final class ScriptCompileSpec {
             Evaluator compiler,
             ErrorReporter compilationErrorReporter,
             Consumer<CompilerEnvirons> compilerEnvironsProcessor,
-            SourceMapper sourceMapper) {
+            SourceMapper sourceMapper,
+            SourceCodeSupplier sourceCodeSupplier) {
         this.source = source;
         this.sourceName = sourceName;
         this.lineno = lineno;
@@ -40,6 +42,7 @@ public final class ScriptCompileSpec {
         this.compilationErrorReporter = compilationErrorReporter;
         this.compilerEnvironsProcessor = compilerEnvironsProcessor;
         this.sourceMapper = sourceMapper;
+        this.sourceCodeSupplier = sourceCodeSupplier;
     }
 
     public static Builder fromSource(String source) {
@@ -82,6 +85,10 @@ public final class ScriptCompileSpec {
         return sourceMapper;
     }
 
+    public SourceCodeSupplier getSourceCodeSupplier() {
+        return sourceCodeSupplier;
+    }
+
     public static final class Builder {
         private final String source;
         private String sourceName;
@@ -91,6 +98,7 @@ public final class ScriptCompileSpec {
         private ErrorReporter compilationErrorReporter;
         private Consumer<CompilerEnvirons> compilerEnvironsProcessor;
         private SourceMapper sourceMapper;
+        private SourceCodeSupplier sourceCodeSupplier;
 
         private Builder(String source) {
             this.source = source;
@@ -132,6 +140,17 @@ public final class ScriptCompileSpec {
             return this;
         }
 
+        /**
+         * Can be used to set a lazy source code provider for the script being compiled - for
+         * example, something that will lookup the script from a database. If set, Rhino will avoid
+         * storing the encoded source code and thus save memory. The trade-off is, of course, that
+         * whenever someone does `Function.toString()` we will need to do a database lookup.
+         */
+        public Builder sourceCodeSupplier(SourceCodeSupplier sourceCodeSupplier) {
+            this.sourceCodeSupplier = sourceCodeSupplier;
+            return this;
+        }
+
         public ScriptCompileSpec build() {
             int normalizedLineno = Math.max(lineno, 0);
             return new ScriptCompileSpec(
@@ -142,7 +161,8 @@ public final class ScriptCompileSpec {
                     compiler,
                     compilationErrorReporter,
                     compilerEnvironsProcessor,
-                    sourceMapper);
+                    sourceMapper,
+                    sourceCodeSupplier);
         }
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
@@ -7,7 +7,7 @@ public interface SourceCodeProvider {
     static SourceCodeProvider make(
             boolean generatingSource, SourceCodeSupplier sourceCodeSupplier, String rawSource) {
         if (!generatingSource) {
-            return null;
+            return NullSourceCodeProvider.NULL_PROVIDER;
         } else if (sourceCodeSupplier != null) {
             return new LazySourceCodeProvider(sourceCodeSupplier);
         } else {

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
@@ -1,0 +1,17 @@
+package org.mozilla.javascript;
+
+/** An object that can provide the source code for the given function. Internal usage only. */
+public interface SourceCodeProvider {
+    String getSource(String functionName, int start, int end);
+
+    static SourceCodeProvider make(
+            boolean generatingSource, SourceCodeSupplier sourceCodeSupplier, String rawSource) {
+        if (!generatingSource) {
+            return null;
+        } else if (sourceCodeSupplier != null) {
+            return new LazySourceCodeProvider(sourceCodeSupplier);
+        } else {
+            return new EagerSourceCodeProvider(rawSource);
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
@@ -2,7 +2,7 @@ package org.mozilla.javascript;
 
 /** An object that can provide the source code for the given function. Internal usage only. */
 public interface SourceCodeProvider {
-    String getSource(String functionName, int start, int end);
+    String getSource(JSDescriptor<?> functionName, int start, int end);
 
     static SourceCodeProvider make(
             boolean generatingSource, SourceCodeSupplier sourceCodeSupplier, String rawSource) {

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
@@ -2,7 +2,12 @@ package org.mozilla.javascript;
 
 /** An object that can provide the source code for the given function. Internal usage only. */
 public interface SourceCodeProvider {
-    String getSource(JSDescriptor<?> functionName, int start, int end);
+    /** Return the source for this descriptor, betweeen the start and end offsets */
+    String getSource(JSDescriptor<?> descriptor, int start, int end);
+
+    /** Return the raw source for this descriptor usually the entire
+        source file if availab le. */
+    String getRawSource();
 
     static SourceCodeProvider make(
             boolean generatingSource, SourceCodeSupplier sourceCodeSupplier, String rawSource) {

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeProvider.java
@@ -5,8 +5,7 @@ public interface SourceCodeProvider {
     /** Return the source for this descriptor, betweeen the start and end offsets */
     String getSource(JSDescriptor<?> descriptor, int start, int end);
 
-    /** Return the raw source for this descriptor usually the entire
-        source file if availab le. */
+    /** Return the raw source for this descriptor usually the entire source file if availab le. */
     String getRawSource();
 
     static SourceCodeProvider make(

--- a/rhino/src/main/java/org/mozilla/javascript/SourceCodeSupplier.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SourceCodeSupplier.java
@@ -1,0 +1,14 @@
+package org.mozilla.javascript;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/**
+ * A lambda that can provide the source code for a given script.
+ *
+ * <p>It is expected that this is implemented externally, from Rhino users.
+ *
+ * @see CompileRequest.Builder#sourceSupplier(ISourceCodeSupplier)
+ */
+@FunctionalInterface
+public interface SourceCodeSupplier extends Supplier<String>, Serializable {}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -23,6 +23,7 @@ import org.mozilla.javascript.JSDescriptor;
 import org.mozilla.javascript.JavaAdapter;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ScriptRuntime;
+import org.mozilla.javascript.SourceCodeProvider;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -128,6 +129,7 @@ public class ClassCompiler {
         if (compilerEnv.isGeneratingSource()) {
             tree.setRawSource(source);
             tree.setRawSourceBounds(0, source.length());
+            compilerEnv.setSourceCodeProvider(SourceCodeProvider.make(true, null, source));
         }
 
         // release reference to original parse tree & parser
@@ -147,7 +149,7 @@ public class ClassCompiler {
 
         Codegen codegen = new Codegen();
         codegen.setMainMethodClass(mainMethodClassName);
-        JSDescriptor.Builder builder = new JSDescriptor.Builder();
+        JSDescriptor.Builder<?> builder = new JSDescriptor.Builder<>();
         MHJSCode.BuilderEnv builderEnv = new MHJSCode.BuilderEnv(scriptClassName);
         byte[] scriptClassBytes =
                 codegen.compileToClassFile(
@@ -190,13 +192,13 @@ public class ClassCompiler {
      * class descriptors, and the main method will create a {@link JSDescriptor} object based on the
      * first descriptor and pass that to the main method in the runtime.
      */
-    private Object[] buildDescriptorsAndMain(String mainClassName, JSDescriptor.Builder builder) {
+    private Object[] buildDescriptorsAndMain(String mainClassName, JSDescriptor.Builder<?> builder) {
         var classes = new HashMap<String, byte[]>();
         var mainName = mainClassName + "Main";
 
         var cfw = new ClassFileWriter(mainName, "java.lang.Object", "");
         var builders = new ArrayList<JSDescriptor.Builder<?>>();
-        buildDescriptor(cfw, builder, classes, builders, mainClassName);
+        buildDescriptor(cfw, builder, builder, classes, builders, mainClassName);
         cfw.startMethod("<clinit>", "()V", ACC_STATIC);
         cfw.addLoadConstant(builders.size());
         cfw.add(ByteCode.ANEWARRAY, "org/mozilla/javascript/JSDescriptor");
@@ -257,7 +259,8 @@ public class ClassCompiler {
      */
     private void buildDescriptor(
             ClassFileWriter cfw,
-            JSDescriptor.Builder builder,
+            JSDescriptor.Builder<?> builder,
+            JSDescriptor.Builder<?> root,
             Map<String, byte[]> classes,
             List<JSDescriptor.Builder<?>> builders,
             String mainClassName) {
@@ -308,9 +311,21 @@ public class ClassCompiler {
         cfw.add(builder.isEvalFunction ? ByteCode.ICONST_1 : ByteCode.ICONST_0);
         cfw.add(builder.hasRestArg ? ByteCode.ICONST_1 : ByteCode.ICONST_0);
         cfw.addLoadConstant(builder.sourceFile);
-        cfw.addLoadConstant(builder.rawSource);
-        cfw.addLoadConstant(builder.rawSourceStart);
-        cfw.addLoadConstant(builder.rawSourceEnd);
+        if (compilerEnv.isGeneratingSource()) {
+            cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
+            cfw.add(ByteCode.DUP);
+            cfw.addLoadConstant(
+                    root.sourceCodeProvider.getSource(root.name, root.sourceStart, root.sourceEnd));
+            cfw.addInvoke(
+                    ByteCode.INVOKESPECIAL,
+                    "org.mozilla.javascript.EagerSourceCodeProvider",
+                    "<init>",
+                    "(Ljava/lang/String;)V");
+        } else {
+            cfw.add(ByteCode.ACONST_NULL);
+        }
+        cfw.addLoadConstant(builder.sourceStart);
+        cfw.addLoadConstant(builder.sourceEnd);
         if (builder.name == null) {
             cfw.add(ByteCode.ACONST_NULL);
         } else {
@@ -351,7 +366,7 @@ public class ClassCompiler {
                 cfw.addInvoke(
                         ByteCode.INVOKESTATIC,
                         cfw.getClassName(),
-                        "init" + functionId((JSDescriptor.Builder) child),
+                        "init" + functionId((JSDescriptor.Builder<?>) child),
                         "(Lorg/mozilla/javascript/JSDescriptor;)Lorg/mozilla/javascript/JSDescriptor;");
                 cfw.add(ByteCode.AASTORE);
                 cfw.add(ByteCode.IINC, 2, 1);
@@ -371,7 +386,7 @@ public class ClassCompiler {
         cfw.add(ByteCode.ARETURN);
         cfw.stopMethod(3);
         for (var child : builder.nestedFunctions) {
-            buildDescriptor(cfw, (JSDescriptor.Builder) child, classes, builders, mainClassName);
+            buildDescriptor(cfw, (JSDescriptor.Builder<?>) child, root, classes, builders, mainClassName);
         }
     }
 
@@ -381,7 +396,7 @@ public class ClassCompiler {
      */
     private void buildCode(
             ClassFileWriter cfw,
-            JSCode.Builder builder,
+            JSCode.Builder<?> builder,
             Map<String, byte[]> classes,
             String mainClassName) {
         if (builder instanceof JSCode.NullBuilder<?>) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.EagerSourceCodeProvider;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSCode;
 import org.mozilla.javascript.JSDescriptor;
@@ -312,17 +313,14 @@ public class ClassCompiler {
         cfw.add(builder.hasRestArg ? ByteCode.ICONST_1 : ByteCode.ICONST_0);
         cfw.addLoadConstant(builder.sourceFile);
         if (compilerEnv.isGeneratingSource()) {
-            // cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
-            // cfw.add(ByteCode.DUP);
-            // cfw.addLoadConstant(
-            //         root.sourceCodeProvider.getSource(root.name, root.sourceStart,
-            // root.sourceEnd));
-            // cfw.addInvoke(
-            //         ByteCode.INVOKESPECIAL,
-            //         "org.mozilla.javascript.EagerSourceCodeProvider",
-            //         "<init>",
-            //         "(Ljava/lang/String;)V");
-            cfw.add(ByteCode.ACONST_NULL);
+            cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
+            cfw.add(ByteCode.DUP);
+            cfw.addLoadConstant(root.sourceCodeProvider.getRawSource());
+            cfw.addInvoke(
+                    ByteCode.INVOKESPECIAL,
+                    "org.mozilla.javascript.EagerSourceCodeProvider",
+                    "<init>",
+                    "(Ljava/lang/String;)V");
         } else {
             cfw.add(ByteCode.ACONST_NULL);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -17,7 +17,6 @@ import java.util.Map;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CompilerEnvirons;
-import org.mozilla.javascript.EagerSourceCodeProvider;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSCode;
 import org.mozilla.javascript.JSDescriptor;
@@ -193,7 +192,8 @@ public class ClassCompiler {
      * class descriptors, and the main method will create a {@link JSDescriptor} object based on the
      * first descriptor and pass that to the main method in the runtime.
      */
-    private Object[] buildDescriptorsAndMain(String mainClassName, JSDescriptor.Builder<?> builder) {
+    private Object[] buildDescriptorsAndMain(
+            String mainClassName, JSDescriptor.Builder<?> builder) {
         var classes = new HashMap<String, byte[]>();
         var mainName = mainClassName + "Main";
 
@@ -386,7 +386,8 @@ public class ClassCompiler {
         cfw.add(ByteCode.ARETURN);
         cfw.stopMethod(3);
         for (var child : builder.nestedFunctions) {
-            buildDescriptor(cfw, (JSDescriptor.Builder<?>) child, root, classes, builders, mainClassName);
+            buildDescriptor(
+                    cfw, (JSDescriptor.Builder<?>) child, root, classes, builders, mainClassName);
         }
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -312,15 +312,17 @@ public class ClassCompiler {
         cfw.add(builder.hasRestArg ? ByteCode.ICONST_1 : ByteCode.ICONST_0);
         cfw.addLoadConstant(builder.sourceFile);
         if (compilerEnv.isGeneratingSource()) {
-            cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
-            cfw.add(ByteCode.DUP);
-            cfw.addLoadConstant(
-                    root.sourceCodeProvider.getSource(root.name, root.sourceStart, root.sourceEnd));
-            cfw.addInvoke(
-                    ByteCode.INVOKESPECIAL,
-                    "org.mozilla.javascript.EagerSourceCodeProvider",
-                    "<init>",
-                    "(Ljava/lang/String;)V");
+            // cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
+            // cfw.add(ByteCode.DUP);
+            // cfw.addLoadConstant(
+            //         root.sourceCodeProvider.getSource(root.name, root.sourceStart,
+            // root.sourceEnd));
+            // cfw.addInvoke(
+            //         ByteCode.INVOKESPECIAL,
+            //         "org.mozilla.javascript.EagerSourceCodeProvider",
+            //         "<init>",
+            //         "(Ljava/lang/String;)V");
+            cfw.add(ByteCode.ACONST_NULL);
         } else {
             cfw.add(ByteCode.ACONST_NULL);
         }

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
@@ -125,6 +125,7 @@ public class FunctionCompileSpecTest {
                                         null,
                                         null,
                                         null,
+                                        null,
                                         null));
         assertTrue(ex.getMessage().contains("scope is required"));
     }

--- a/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/FunctionCompileSpecTest.java
@@ -115,18 +115,7 @@ public class FunctionCompileSpecTest {
         var ex =
                 assertThrows(
                         IllegalArgumentException.class,
-                        () ->
-                                new FunctionCompileSpec(
-                                        "function f() {}",
-                                        null,
-                                        null,
-                                        0,
-                                        null,
-                                        null,
-                                        null,
-                                        null,
-                                        null,
-                                        null));
+                        () -> FunctionCompileSpec.fromSource("function f() {}", null).build());
         assertTrue(ex.getMessage().contains("scope is required"));
     }
 

--- a/rhino/src/test/java/org/mozilla/javascript/JSDescriptorSourceCodeProviderTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/JSDescriptorSourceCodeProviderTest.java
@@ -1,0 +1,81 @@
+package org.mozilla.javascript;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class JSDescriptorSourceCodeProviderTest {
+    private Context cx;
+
+    @BeforeEach
+    public void setUp() {
+        cx = Context.enter();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Context.exit();
+    }
+
+    private static SourceCodeProvider sourceCodeProviderOf(JSDescriptor<?> descriptor)
+            throws ReflectiveOperationException {
+        return descriptor.getSourceProvider();
+    }
+
+    @Test
+    public void compilingWithSourceCodeSupplierUsesLazyProvider()
+            throws ReflectiveOperationException {
+        String source = "var x = 1;";
+
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource(source)
+                                .sourceName("test.js")
+                                .sourceCodeSupplier(() -> source)
+                                .build());
+
+        JSDescriptor<JSScript> descriptor = script.getDescriptor();
+        assertNotNull(descriptor);
+        assertInstanceOf(LazySourceCodeProvider.class, sourceCodeProviderOf(descriptor));
+    }
+
+    @Test
+    public void lazyProviderReplacesItselfOnAccess() throws ReflectiveOperationException {
+        String source = "var x = 1;";
+
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource(source)
+                                .sourceName("test.js")
+                                .sourceCodeSupplier(() -> source)
+                                .build());
+
+        JSDescriptor<JSScript> descriptor = script.getDescriptor();
+        assertNotNull(descriptor);
+        assertInstanceOf(LazySourceCodeProvider.class, sourceCodeProviderOf(descriptor));
+        String src1 = descriptor.getSource();
+        assertInstanceOf(
+                LazySourceCodeProvider.ResolvedSourceProvider.class,
+                sourceCodeProviderOf(descriptor));
+        String src2 = descriptor.getSource();
+        assertEquals(src1, src2);
+    }
+
+    @Test
+    public void compilingWithoutSourceCodeSupplierUsesEagerProvider()
+            throws ReflectiveOperationException {
+        String source = "var x = 1;";
+
+        Script script =
+                cx.compileScript(
+                        ScriptCompileSpec.fromSource(source).sourceName("test.js").build());
+
+        JSDescriptor<JSScript> descriptor = script.getDescriptor();
+        assertNotNull(descriptor);
+        assertInstanceOf(EagerSourceCodeProvider.class, sourceCodeProviderOf(descriptor));
+    }
+}

--- a/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/CodegenTest.java
@@ -75,8 +75,8 @@ public class CodegenTest {
                                         .startsWith("org.mozilla.javascript.JSScript"),
                                 script.getClass().getName());
                         Assertions.assertTrue(
-                                script.getDescriptor().getRawSource().length() > 1000,
-                                "" + script.getDescriptor().getRawSource().length());
+                                script.getDescriptor().getSource().length() > 1000,
+                                "" + script.getDescriptor().getSource().length());
                         return null;
                     } catch (IOException e) {
                         Assertions.fail(e.getMessage());
@@ -144,8 +144,8 @@ public class CodegenTest {
                                     .startsWith("org.mozilla.javascript.JSScript"),
                             script.getClass().getName());
                     Assertions.assertTrue(
-                            script.getDescriptor().getRawSource().length() > 1000,
-                            "" + script.getDescriptor().getRawSource().length());
+                            script.getDescriptor().getSource().length() > 1000,
+                            "" + script.getDescriptor().getSource().length());
                     return null;
                 });
 
@@ -164,8 +164,8 @@ public class CodegenTest {
                                         .startsWith("org.mozilla.javascript.JSScript"),
                                 script.getClass().getName());
                         Assertions.assertTrue(
-                                script.getDescriptor().getRawSource().length() > 1000,
-                                "" + script.getDescriptor().getRawSource().length());
+                                script.getDescriptor().getSource().length() > 1000,
+                                "" + script.getDescriptor().getSource().length());
                         return null;
                     } catch (IOException e) {
                         Assertions.fail(e.getMessage());
@@ -215,8 +215,8 @@ public class CodegenTest {
                                     .startsWith("org.mozilla.javascript.JSScript"),
                             script.getClass().getName());
                     Assertions.assertTrue(
-                            script.getDescriptor().getRawSource().length() > 1000,
-                            "" + script.getDescriptor().getRawSource().length());
+                            script.getDescriptor().getSource().length() > 1000,
+                            "" + script.getDescriptor().getSource().length());
                     return null;
                 });
 
@@ -235,8 +235,8 @@ public class CodegenTest {
                                         .startsWith("org.mozilla.javascript.JSScript"),
                                 script.getClass().getName());
                         Assertions.assertTrue(
-                                script.getDescriptor().getRawSource().length() > 1000,
-                                "" + script.getDescriptor().getRawSource().length());
+                                script.getDescriptor().getSource().length() > 1000,
+                                "" + script.getDescriptor().getSource().length());
                         return null;
                     } catch (IOException e) {
                         Assertions.fail(e.getMessage());
@@ -282,8 +282,8 @@ public class CodegenTest {
                                     .startsWith("org.mozilla.javascript.JSScript"),
                             script.getClass().getName());
                     Assertions.assertTrue(
-                            script.getDescriptor().getRawSource().length() > 1000,
-                            "" + script.getDescriptor().getRawSource().length());
+                            script.getDescriptor().getSource().length() > 1000,
+                            "" + script.getDescriptor().getSource().length());
                     return null;
                 });
 
@@ -302,8 +302,8 @@ public class CodegenTest {
                                         .startsWith("org.mozilla.javascript.JSScript"),
                                 script.getClass().getName());
                         Assertions.assertTrue(
-                                script.getDescriptor().getRawSource().length() > 1000,
-                                "" + script.getDescriptor().getRawSource().length());
+                                script.getDescriptor().getSource().length() > 1000,
+                                "" + script.getDescriptor().getSource().length());
                         return null;
                     } catch (IOException e) {
                         Assertions.fail(e.getMessage());


### PR DESCRIPTION
In many cases where we are loading large quantities of JavaScript we would like to have source code available, but do not want to pay the resource cost of having those strings on the heap all the time if they can be retrieved from a database, files, or other sources. This PR introduces a pluggable system that can lazily resolve source code requests only when required. If the feature is not used then we pay a cost of 16 bytes per source for the `EagerSourceCodeProvider`.