### PR TITLE
Actually disable background compilation for benchmarks

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -32,7 +32,7 @@ jmh {
             }
         }
     }
-    jvmArgs = ['-XX:+BackgroundCompilation']
+    jvmArgs = ['-XX:-BackgroundCompilation']
     benchmarkMode = ['avgt']
     fork = 1
     iterations = 5


### PR DESCRIPTION
The flag should be a `-` since [the intention](https://github.com/mozilla/rhino/commit/efe57ab63deb4a60993c4b914db1da8cf29132a4#diff-77ab8968a72299a5fe665cc05d74e3f4c8d3059b243f8fc52d94462a898909fbR35) is to disable background compilation, but it was accidentally a `+`.