### PR TITLE
Simplify modular java related checks

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -42,8 +42,6 @@ import org.mozilla.javascript.lc.type.TypeInfoFactory;
  */
 class JavaMembers {
 
-    private static final boolean STRICT_REFLECTIVE_ACCESS = isModularJava();
-
     private static final Permission allPermission = new AllPermission();
 
     JavaMembers(VarScope scope, Class<?> cl) {
@@ -63,19 +61,6 @@ class JavaMembers {
             this.cl = cl;
             boolean includePrivate = cx.hasFeature(Context.FEATURE_ENHANCED_JAVA_ACCESS);
             reflect(cx, scope, includeProtected, includePrivate);
-        }
-    }
-
-    /**
-     * This method returns true if we are on a "modular" version of Java (Java 11 or up). It does
-     * not use the SourceVersion class because this is not present on Android.
-     */
-    private static boolean isModularJava() {
-        try {
-            Class.class.getMethod("getModule");
-            return true;
-        } catch (NoSuchMethodException e) {
-            return false;
         }
     }
 
@@ -851,7 +836,7 @@ class JavaMembers {
 
     private static JavaMembers createJavaMembers(
             VarScope associatedScope, Class<?> cl, boolean includeProtected) {
-        if (STRICT_REFLECTIVE_ACCESS) {
+        if (ReflectUtils.IS_MODULAR_JAVA) {
             return new JavaMembers_jdk11(associatedScope, cl, includeProtected);
         } else {
             return new JavaMembers(associatedScope, cl, includeProtected);

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
@@ -6,10 +6,9 @@
 
 package org.mozilla.javascript;
 
-import org.mozilla.javascript.lc.ReflectUtils;
-
 import java.lang.reflect.Method;
 import java.util.Map;
+import org.mozilla.javascript.lc.ReflectUtils;
 
 /** Version of {@link JavaMembers} for modular JDKs. */
 class JavaMembers_jdk11 extends JavaMembers {
@@ -36,7 +35,8 @@ class JavaMembers_jdk11 extends JavaMembers {
             return true;
         }
 
-        // `.getModule()` not present on Android, `.getPackageName()` not after API 31. Compatibility is ensured by gating it after IS_MODULAR_JAVA
+        // `.getModule()` not present on Android, `.getPackageName()` not after API 31.
+        // Android compatibility is ensured by gating it after IS_MODULAR_JAVA
         return clazz.getModule().isExported(clazz.getPackageName());
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers_jdk11.java
@@ -6,9 +6,9 @@
 
 package org.mozilla.javascript;
 
-import java.lang.reflect.InvocationTargetException;
+import org.mozilla.javascript.lc.ReflectUtils;
+
 import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
 import java.util.Map;
 
 /** Version of {@link JavaMembers} for modular JDKs. */
@@ -32,61 +32,12 @@ class JavaMembers_jdk11 extends JavaMembers {
     }
 
     private static boolean isExportedClass(Class<?> clazz) {
-        /*
-         * We are going to invoke, using reflection, the approximate equivalent
-         * to the following Java 9 code:
-         *
-         * return clazz.getModule().isExported(clazz.getPackageName());
-         */
-
-        // First, determine the package name
-        String pname;
-        Package pkg = clazz.getPackage();
-        if (pkg == null) {
-            // Primitive types, arrays, proxy classes
-            if (!Proxy.isProxyClass(clazz)) {
-                // Should be a primitive type or array
-                return true;
-            }
-            String clName = clazz.getName();
-            pname = clName.substring(0, clName.lastIndexOf('.'));
-        } else {
-            pname = pkg.getName();
-        }
-
-        // Obtain the module
-        Method getmodule;
-        @SuppressWarnings("GetClassOnClass")
-        Class<?> cl = clazz.getClass();
-        try {
-            getmodule = cl.getMethod("getModule");
-        } catch (NoSuchMethodException e) {
-            // We are on non-modular Java
+        if (!ReflectUtils.IS_MODULAR_JAVA) {
             return true;
         }
 
-        Object module;
-        try {
-            module = getmodule.invoke(clazz);
-        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-            return false;
-        }
-
-        Class<?> moduleClass = module.getClass();
-
-        // Execute isExported()
-        boolean exported;
-        try {
-            Method isexported = moduleClass.getMethod("isExported", String.class);
-            exported = (boolean) isexported.invoke(module, pname);
-        } catch (NoSuchMethodException
-                | IllegalAccessException
-                | IllegalArgumentException
-                | InvocationTargetException e) {
-            // If we reached this part of the code, this cannot happen
-            exported = false;
-        }
-        return exported;
+        // `.getModule()` not present on Android, `.getPackageName()` not after API 31. Compatibility is ensured by gating it after IS_MODULAR_JAVA
+        return clazz.getModule().isExported(clazz.getPackageName());
     }
 
     private static Method findAccessibleMethod(Method method) {

--- a/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
@@ -1,7 +1,6 @@
 package org.mozilla.javascript.lc;
 
 import java.util.List;
-
 import org.mozilla.javascript.lc.type.TypeInfo;
 
 /**
@@ -10,7 +9,8 @@ import org.mozilla.javascript.lc.type.TypeInfo;
 public abstract class ReflectUtils {
 
     /**
-     * {@code true} if we are on a "modular" version of Java (Java 11 or up, excluding Android). It does not use the SourceVersion class because this is not present on Android.
+     * {@code true} if we are on a "modular" version of Java (Java 11 or up, excluding Android). It
+     * does not use the SourceVersion class because this is not present on Android.
      */
     public static final boolean IS_MODULAR_JAVA;
 

--- a/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
@@ -9,6 +9,22 @@ import org.mozilla.javascript.lc.type.TypeInfo;
  */
 public abstract class ReflectUtils {
 
+    /**
+     * {@code true} if we are on a "modular" version of Java (Java 11 or up, excluding Android). It does not use the SourceVersion class because this is not present on Android.
+     */
+    public static final boolean IS_MODULAR_JAVA;
+
+    static {
+        boolean isModularJava;
+        try {
+            Class.class.getMethod("getModule");
+            isModularJava = true;
+        } catch (NoSuchMethodException e) {
+            isModularJava = false;
+        }
+        IS_MODULAR_JAVA = isModularJava;
+    }
+
     public static String javaSignature(Class<?> type) {
         int arrayDimension = 0;
         while (type.isArray()) {

--- a/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
+++ b/rhino/src/main/java/org/mozilla/javascript/lc/ReflectUtils.java
@@ -1,36 +1,13 @@
 package org.mozilla.javascript.lc;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
+
 import org.mozilla.javascript.lc.type.TypeInfo;
 
 /**
  * @author ZZZank
  */
 public abstract class ReflectUtils {
-
-    public static Iterator<Class<?>> walkSuperClasses(Class<?> start, boolean includeSelf) {
-        var c = includeSelf ? start : start.getSuperclass();
-        return new Iterator<>() {
-            private Class<?> current = c;
-
-            @Override
-            public boolean hasNext() {
-                return current != null;
-            }
-
-            @Override
-            public Class<?> next() {
-                var result = current;
-                if (result == null) {
-                    throw new NoSuchElementException();
-                }
-                current = current.getSuperclass();
-                return result;
-            }
-        };
-    }
 
     public static String javaSignature(Class<?> type) {
         int arrayDimension = 0;


### PR DESCRIPTION
- The "isModularJava" bool field moved to `ReflectUtils`
- `.isExportedClass(Class)` rewritten to call methods directly instead of via reflection. Main logic is gated after `ReflectUtils.IS_MODULAR_JAVA`, for Android compatibility