### PR TITLE
Remove `fieldsAndMethods` map from JavaMembers

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -57,9 +57,7 @@ class JavaMembers {
                 throw Context.reportRuntimeErrorById("msg.access.prohibited", cl.getName());
             }
             this.members = new HashMap<>();
-            this.fieldAndMethods = new HashMap<>();
             this.staticMembers = new HashMap<>();
-            this.staticFieldAndMethods = new HashMap<>();
             this.cl = cl;
             boolean includePrivate = cx.hasFeature(Context.FEATURE_ENHANCED_JAVA_ACCESS);
             reflect(cx, scope, includeProtected, includePrivate);
@@ -779,21 +777,6 @@ class JavaMembers {
         return null;
     }
 
-    Map<String, FieldAndMethods> getFieldAndMethodsObjects(
-            VarScope scope, Object javaObject, boolean isStatic) {
-        var ht = isStatic ? staticFieldAndMethods : fieldAndMethods;
-
-        var expectedCapacity = (int) Math.ceil(ht.size() / 0.75);
-        var result = new HashMap<String, FieldAndMethods>(expectedCapacity);
-        for (var entry : ht.entrySet()) {
-            var fieldAndMethods = new FieldAndMethods(scope, entry.getValue());
-            fieldAndMethods.javaObject = javaObject;
-
-            result.put(entry.getKey(), fieldAndMethods);
-        }
-        return result;
-    }
-
     static JavaMembers lookupClass(
             VarScope scope, Class<?> dynamicType, Class<?> staticType, boolean includeProtected) {
         JavaMembers members;
@@ -889,12 +872,9 @@ class JavaMembers {
      */
     private final Map<String, Object> members;
 
-    private final Map<String, ExecutableOverload.WithField> fieldAndMethods;
-
     /** All possible types of values in this map: same as {@link #members} */
     private final Map<String, Object> staticMembers;
 
-    private final Map<String, ExecutableOverload.WithField> staticFieldAndMethods;
     NativeJavaMethod ctors; // we use NativeJavaMethod for ctor overload resolution
 }
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -89,6 +89,11 @@ class JavaMembers {
     Object get(Scriptable obj, VarScope scope, String name, Object javaObject, boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = ht.get(name);
+        if (member instanceof FieldAndMethods fieldAndMethods) {
+            var fam = new FieldAndMethods(scope, fieldAndMethods.withField);
+            fam.javaObject = javaObject;
+            return fam;
+        }
         if (!isStatic && member == null) {
             // Try to get static member from instance (LC3)
             member = staticMembers.get(name);
@@ -893,7 +898,7 @@ class FieldAndMethods extends NativeJavaMethod {
 
     FieldAndMethods(VarScope scope, ExecutableOverload.WithField withField) {
         super(withField.methods, withField.name);
-        this.field = withField.field;
+        this.withField = withField;
         setParentScope(scope);
         setPrototype(ScriptableObject.getFunctionPrototype(scope));
     }
@@ -901,6 +906,7 @@ class FieldAndMethods extends NativeJavaMethod {
     @Override
     public Object getDefaultValue(Class<?> hint) {
         if (hint == ScriptRuntime.FunctionClass) return this;
+        NativeJavaField field = this.withField.field;
         Object rval;
         try {
             rval = field.get(javaObject);
@@ -916,6 +922,6 @@ class FieldAndMethods extends NativeJavaMethod {
         return rval;
     }
 
-    NativeJavaField field;
+    ExecutableOverload.WithField withField;
     Object javaObject;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -89,11 +89,6 @@ class JavaMembers {
     Object get(Scriptable obj, VarScope scope, String name, Object javaObject, boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = ht.get(name);
-        if (member instanceof FieldAndMethods fieldAndMethods) {
-            var fam = new FieldAndMethods(scope, fieldAndMethods.withField);
-            fam.javaObject = javaObject;
-            return fam;
-        }
         if (!isStatic && member == null) {
             // Try to get static member from instance (LC3)
             member = staticMembers.get(name);
@@ -107,12 +102,12 @@ class JavaMembers {
         }
 
         // TODO: cache instance in caller NativeJavaObject
-        if (member instanceof ExecutableOverload) {
-            if (member instanceof ExecutableOverload.WithField) {
-                var withField = (ExecutableOverload.WithField) member;
-                return new FieldAndMethods(scope, withField);
+        if (member instanceof ExecutableOverload method) {
+            if (member instanceof ExecutableOverload.WithField withField) {
+                var fam = new FieldAndMethods(scope, withField);
+                fam.javaObject = javaObject;
+                return fam;
             } else {
-                var method = (ExecutableOverload) member;
                 var built = new NativeJavaMethod(method.methods, method.name);
                 ScriptRuntime.setFunctionProtoAndParent(
                         built, Context.getCurrentContext(), scope, false);

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -893,7 +893,7 @@ class FieldAndMethods extends NativeJavaMethod {
 
     FieldAndMethods(VarScope scope, ExecutableOverload.WithField withField) {
         super(withField.methods, withField.name);
-        this.withField = withField;
+        this.field = withField.field;
         setParentScope(scope);
         setPrototype(ScriptableObject.getFunctionPrototype(scope));
     }
@@ -901,7 +901,6 @@ class FieldAndMethods extends NativeJavaMethod {
     @Override
     public Object getDefaultValue(Class<?> hint) {
         if (hint == ScriptRuntime.FunctionClass) return this;
-        NativeJavaField field = this.withField.field;
         Object rval;
         try {
             rval = field.get(javaObject);
@@ -917,6 +916,6 @@ class FieldAndMethods extends NativeJavaMethod {
         return rval;
     }
 
-    ExecutableOverload.WithField withField;
+    NativeJavaField field;
     Object javaObject;
 }

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -44,7 +44,6 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
     protected void initMembers() {
         Class<?> cl = (Class<?>) javaObject;
         members = JavaMembers.lookupClass(parent, cl, cl, isAdapter);
-        staticFieldAndMethods = members.getFieldAndMethodsObjects(parent, cl, true);
     }
 
     @Override
@@ -64,11 +63,6 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         // We don't really care what the object is, since we're returning
         // one constructed out of whole cloth, so we return null.
         if ("prototype".equals(name)) return null;
-
-        var staticFieldAndMethod = staticFieldAndMethods.get(name);
-        if (staticFieldAndMethod != null) {
-            return staticFieldAndMethod;
-        }
 
         if (members.has(name, true)) {
             return members.get(this, parent, name, javaObject, true);
@@ -232,8 +226,6 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         }
         return Kit.classOrNull(loader, nestedClassName);
     }
-
-    private Map<String, FieldAndMethods> staticFieldAndMethods;
 
     @Override
     public boolean equals(Object obj) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -17,7 +17,6 @@ import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Objects;
 import org.mozilla.javascript.lc.type.TypeInfo;
 import org.mozilla.javascript.lc.type.TypeInfoFactory;
@@ -63,7 +62,6 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
             dynamicType = staticType.asClass();
         }
         members = JavaMembers.lookupClass(parent, dynamicType, staticType.asClass(), isAdapter);
-        fieldAndMethods = members.getFieldAndMethodsObjects(parent, javaObject, false);
     }
 
     @Override
@@ -86,10 +84,6 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     @Override
     public Object get(String name, Scriptable start) {
-        var fieldAndMethod = fieldAndMethods.get(name);
-        if (fieldAndMethod != null) {
-            return fieldAndMethod;
-        }
         return members.get(this, parent, name, javaObject, false);
     }
 
@@ -977,7 +971,6 @@ public class NativeJavaObject implements Scriptable, SymbolScriptable, Wrapper, 
 
     protected transient TypeInfo staticType;
     protected transient JavaMembers members;
-    private transient Map<String, FieldAndMethods> fieldAndMethods;
     protected transient boolean isAdapter;
 
     private static final Object COERCED_INTERFACE_KEY = "Coerced Interface";

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/FieldAndMethodsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/FieldAndMethodsTest.java
@@ -1,0 +1,79 @@
+package org.mozilla.javascript.tests.lc;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.testutils.Utils;
+
+public class FieldAndMethodsTest {
+
+    @Test
+    public void test() {
+        Utils.runWithAllModes(cx -> {
+            this.fieldAndMethods = "init";
+            this.methodCallResult = -1;
+
+            var topLevel = cx.initStandardObjects();
+
+            topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
+
+            return cx.evaluateString(topLevel, """
+                let assert = test.asser
+
+                assert(test.fieldAndMethods(42) == -1, "method call");
+                assert(test.fieldAndMethods(0) == 42, "method call");
+
+                assert('' + test.fieldAndMethods == 'init', "field get should grab value from field");
+                test.fieldAndMethods = 'altered';
+                assert('' + test.fieldAndMethods == 'altered', "field set should take effect");
+
+                """, "FieldsAndMethodTest", 1, null);
+        });
+    }
+
+    /**
+     * see <a href="https://rhino.github.io/tutorials/scripting_java/#limitations">rhino.github.io</a>
+     */
+    @Test
+    public void lazyField() {
+        Utils.runWithAllModes(cx -> {
+            var topLevel = cx.initStandardObjects();
+
+            topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
+
+            return cx.evaluateString(topLevel, """
+                let assert = test.asser
+
+                test.fieldAndMethods = 'init';
+
+                let fam = test.fieldAndMethods
+                let forceConverted = '' + fam
+                assert('' + fam == 'init', "field get, obviously");
+                assert(forceConverted == 'init', "force conversion now");
+
+                test.fieldAndMethods = 'altered';
+                assert('' + fam == 'altered', "value of field is resolved lazily");
+                assert(forceConverted == 'init', "but forcefully converted value is not affected");
+
+                """, "FieldsAndMethodTest", 1, null);
+        });
+    }
+
+    public String fieldAndMethods;
+    private int methodCallResult;
+
+    public int fieldAndMethods(int i) {
+        var last = methodCallResult;
+        methodCallResult = i;
+        return last;
+    }
+
+    public void aMethodThatWillAffectFieldAndMethods(String value) {
+        this.fieldAndMethods = value;
+    }
+
+    public static void asser(boolean t, String errMessage) {
+        if (!t) {
+            throw new AssertionError(errMessage);
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/lc/FieldAndMethodsTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/lc/FieldAndMethodsTest.java
@@ -8,15 +8,18 @@ public class FieldAndMethodsTest {
 
     @Test
     public void test() {
-        Utils.runWithAllModes(cx -> {
-            this.fieldAndMethods = "init";
-            this.methodCallResult = -1;
+        Utils.runWithAllModes(
+                cx -> {
+                    this.fieldAndMethods = "init";
+                    this.methodCallResult = -1;
 
-            var topLevel = cx.initStandardObjects();
+                    var topLevel = cx.initStandardObjects();
 
-            topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
+                    topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
 
-            return cx.evaluateString(topLevel, """
+                    return cx.evaluateString(
+                            topLevel,
+                            """
                 let assert = test.asser
 
                 assert(test.fieldAndMethods(42) == -1, "method call");
@@ -26,21 +29,28 @@ public class FieldAndMethodsTest {
                 test.fieldAndMethods = 'altered';
                 assert('' + test.fieldAndMethods == 'altered', "field set should take effect");
 
-                """, "FieldsAndMethodTest", 1, null);
-        });
+                """,
+                            "FieldsAndMethodTest",
+                            1,
+                            null);
+                });
     }
 
     /**
-     * see <a href="https://rhino.github.io/tutorials/scripting_java/#limitations">rhino.github.io</a>
+     * see <a
+     * href="https://rhino.github.io/tutorials/scripting_java/#limitations">rhino.github.io</a>
      */
     @Test
     public void lazyField() {
-        Utils.runWithAllModes(cx -> {
-            var topLevel = cx.initStandardObjects();
+        Utils.runWithAllModes(
+                cx -> {
+                    var topLevel = cx.initStandardObjects();
 
-            topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
+                    topLevel.put("test", topLevel, Context.javaToJS(this, topLevel));
 
-            return cx.evaluateString(topLevel, """
+                    return cx.evaluateString(
+                            topLevel,
+                            """
                 let assert = test.asser
 
                 test.fieldAndMethods = 'init';
@@ -54,8 +64,11 @@ public class FieldAndMethodsTest {
                 assert('' + fam == 'altered', "value of field is resolved lazily");
                 assert(forceConverted == 'init', "but forcefully converted value is not affected");
 
-                """, "FieldsAndMethodTest", 1, null);
-        });
+                """,
+                            "FieldsAndMethodTest",
+                            1,
+                            null);
+                });
     }
 
     public String fieldAndMethods;


### PR DESCRIPTION
since `fieldsAndMethods` and `staticFieldsAndMethods` is never mutated now, they will always be an empty map, basically invalidating related code logic. This PR removed these two now unused map, and restored FieldAndMethods handling by rebinding `javaObject` in `JavaMembers#get(...)`