### PR TITLE
PoC: Replace `NativeJavaMethod` with descriptors that can be cached across contexts.

### DIFF
--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -149,7 +149,7 @@ decycle {
     // LiveConnect classes in root package
     // TODO: Move them to LiveConnect module
     ignoring(
-        from: "org.mozilla.javascript.(Native*|JavaMembers|FieldAndMethods|InterfaceAdapter|WrapFactory)",
+        from: "org.mozilla.javascript.(Native*|JavaMembers|FieldAndMethods|InterfaceAdapter|WrapFactory|ResolvedOverload|JavaAccessor)",
         to: "org.mozilla.javascript.lc.**"
     )
 

--- a/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaAdapter.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.javascript.lc.member.ExecutableBox;
 import org.mozilla.javascript.lc.type.TypeInfo;
 
 public final class JavaAdapter {
@@ -130,17 +131,19 @@ public final class JavaAdapter {
                 System.arraycopy(args, classCount + 1, ctorArgs, 2, argsCount);
                 // TODO: cache class wrapper?
                 NativeJavaClass classWrapper = new NativeJavaClass(scope, adapterClass, true);
-                NativeJavaMethod ctors = classWrapper.members.ctors;
-                int index = ctors.findCachedFunction(cx, ctorArgs);
+                ExecutableBox[] ctors = classWrapper.members.ctors;
+                int index =
+                        NativeJavaOverloadResolver.findCachedFunction(
+                                cx, ctors, ctorArgs, classWrapper.members.ctorOverloadCache);
                 if (index < 0) {
                     throw Context.reportRuntimeErrorById(
                             "msg.no.java.ctor",
                             adapterClass.getName(),
-                            NativeJavaMethod.scriptSignature(args));
+                            NativeJavaOverloadResolver.scriptSignature(args));
                 }
 
                 // Found the constructor, so try invoking it.
-                adapter = NativeJavaClass.constructInternal(ctorArgs, ctors.methods[index]);
+                adapter = NativeJavaClass.constructInternal(ctorArgs, ctors[index]);
             } else {
                 Class<?>[] ctorParms = {
                     ScriptRuntime.ScriptableClass, ScriptRuntime.ContextFactoryClass

--- a/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JavaMembers.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 import org.mozilla.javascript.lc.ReflectUtils;
 import org.mozilla.javascript.lc.member.ExecutableBox;
@@ -88,6 +89,37 @@ class JavaMembers {
         return findExplicitFunction(name, isStatic) != null;
     }
 
+    static JSDescriptor<JSFunction> buildNativeJavaMethodDescriptor(
+            ExecutableBox[] methods, String name) {
+        int arity = methods.length > 0 ? methods[0].getArgTypes().size() : 0;
+        JSDescriptor.Builder<JSFunction> builder = new JSDescriptor.Builder<>();
+        builder.code = new NativeJavaCode.Builder(methods);
+        builder.constructor = new JSCode.NullBuilder<>();
+        builder.name = name;
+        builder.arity = arity;
+        builder.isStrict = false;
+        builder.paramCount = arity;
+
+        var paramNames = new String[arity];
+        java.util.Arrays.fill(paramNames, "");
+        builder.paramAndVarNames = paramNames;
+        builder.paramIsConst = new boolean[arity];
+        builder.paramAndVarCount = arity;
+
+        builder.rawSource = "[native code]";
+        builder.rawSourceStart = 0;
+        builder.rawSourceEnd = builder.rawSource.length();
+        builder.hasPrototype = true;
+
+        return builder.build(desc -> {});
+    }
+
+    private static JSFunction buildNativeJavaMethodFunction(
+            Context cx, VarScope scope, ExecutableBox[] methods, String name) {
+        JSDescriptor<JSFunction> descriptor = buildNativeJavaMethodDescriptor(methods, name);
+        return JSFunction.createFunction(cx, scope, descriptor, null, null);
+    }
+
     Object get(Scriptable obj, VarScope scope, String name, Object javaObject, boolean isStatic) {
         Map<String, Object> ht = isStatic ? staticMembers : members;
         Object member = ht.get(name);
@@ -110,10 +142,11 @@ class JavaMembers {
                 return new FieldAndMethods(scope, withField);
             } else {
                 var method = (ExecutableOverload) member;
-                var built = new NativeJavaMethod(method.methods, method.name);
-                ScriptRuntime.setFunctionProtoAndParent(
-                        built, Context.getCurrentContext(), scope, false);
-                return built;
+                Context cx = Context.getCurrentContext();
+                JSFunction fn =
+                        buildNativeJavaMethodFunction(cx, scope, method.methods, method.name);
+                ScriptRuntime.setFunctionProtoAndParent(fn, cx, scope, false);
+                return fn;
             }
         }
 
@@ -254,7 +287,7 @@ class JavaMembers {
 
         if (isCtor) {
             // Explicit request for an overloaded constructor
-            methodsOrCtors = ctors.methods;
+            methodsOrCtors = ctors;
         } else {
             // Explicit request for an overloaded method
             String trueName = name.substring(0, sigStart);
@@ -301,8 +334,11 @@ class JavaMembers {
 
                 if (member instanceof ExecutableOverload
                         && ((ExecutableOverload) member).methods.length > 1) {
-                    NativeJavaMethod fun = new NativeJavaMethod(methodOrCtor, name);
-                    fun.setPrototype(prototype);
+                    Context cx = Context.getCurrentContext();
+                    JSFunction fun =
+                            buildNativeJavaMethodFunction(
+                                    cx, scope, new ExecutableBox[] {methodOrCtor}, name);
+                    ScriptRuntime.setFunctionProtoAndParent(fun, cx, scope, false);
                     ht.put(name, fun);
                     member = fun;
                 }
@@ -449,7 +485,7 @@ class JavaMembers {
         var accessibleFields = getAccessibleFields(includeProtected, includePrivate);
 
         // We reflect methods first, because we want overloaded field/method
-        // names to be allocated to the NativeJavaMethod before the field
+        // names to be allocated to the method function before the field
         // gets in the way.
         for (int cursor = 0; cursor < 2; cursor++) {
             var isStatic = (cursor == 0);
@@ -468,7 +504,7 @@ class JavaMembers {
         for (int i = 0; i != constructors.length; ++i) {
             ctorMembers[i] = new ExecutableBox(constructors[i], typeFactory);
         }
-        ctors = new NativeJavaMethod(ctorMembers, cl.getSimpleName());
+        ctors = ctorMembers;
     }
 
     /**
@@ -563,7 +599,7 @@ class JavaMembers {
             return !includePrivate
                     || !Modifier.isPrivate(((NativeJavaField) existed).raw().getModifiers());
         }
-        // member is NativeJavaMethod
+        // member is a method (ExecutableOverload)
         return true;
     }
 
@@ -623,18 +659,18 @@ class JavaMembers {
                     var bean = beans.computeIfAbsent(beanName, BeanProperty::new);
                     if (bean.getter == null
                             // prefer 'get' over 'is'
-                            || bean.getter.getFunctionName().startsWith("is")) {
+                            || bean.getter.name.startsWith("is")) {
                         if (method.methods.length == 1) {
-                            bean.getter = new NativeJavaMethod(method.methods, name);
+                            bean.getter = new JavaAccessor(method.methods, name);
                         } else {
-                            bean.getter = new NativeJavaMethod(candidate, name);
+                            bean.getter = new JavaAccessor(candidate, name);
                         }
                     }
                 }
             } else { // isSetBeaning
                 var bean = beans.computeIfAbsent(beanName, BeanProperty::new);
                 // capture all possible setters for now, actual setter will be searched later
-                bean.setter = new NativeJavaMethod(method.methods, name);
+                bean.setter = new JavaAccessor(method.methods, name);
             }
         }
 
@@ -652,7 +688,7 @@ class JavaMembers {
                 // We have a getter. Now, do we have a setter with matching type?
                 match = extractSetMethod(type, setterCandidates.methods, isStatic);
                 if (match != null) {
-                    bean.setter = new NativeJavaMethod(match, match.getName());
+                    bean.setter = new JavaAccessor(match, match.getName());
                     continue;
                 }
             }
@@ -664,8 +700,8 @@ class JavaMembers {
                 bean.setter = null;
             }
 
-            // at this stage we know there's at least one valid setter. We will let NativeJavaMethod
-            // itself to pick the best one.
+            // at this stage we know there's at least one valid setter. We will let overload
+            // resolution pick the best one at call time.
         }
 
         return beans;
@@ -740,7 +776,7 @@ class JavaMembers {
     private static ExecutableBox extractSetMethod(
             TypeInfo type, ExecutableBox[] methods, boolean isStatic) {
         //
-        // Note: it may be preferable to allow NativeJavaMethod.findFunction()
+        // Note: it may be preferable to allow NativeJavaOverloadResolver.findFunction()
         //       to find the appropriate setter; unfortunately, it requires an
         //       instance of the target arg to determine that.
         //
@@ -895,7 +931,12 @@ class JavaMembers {
     private final Map<String, Object> staticMembers;
 
     private final Map<String, ExecutableOverload.WithField> staticFieldAndMethods;
-    NativeJavaMethod ctors; // we use NativeJavaMethod for ctor overload resolution
+
+    /** Overloaded constructors, used for constructor overload resolution. */
+    ExecutableBox[] ctors;
+
+    /** Per-class cache of resolved constructor overloads, keyed by argument runtime types. */
+    final CopyOnWriteArrayList<ResolvedOverload> ctorOverloadCache = new CopyOnWriteArrayList<>();
 }
 
 final class BeanProperty {
@@ -904,18 +945,44 @@ final class BeanProperty {
     }
 
     final String name;
-    NativeJavaMethod getter;
-    NativeJavaMethod setter;
+    JavaAccessor getter;
+    JavaAccessor setter;
 }
 
-class FieldAndMethods extends NativeJavaMethod {
+/**
+ * A callable bean getter or setter, backed by one or more overloaded Java methods. Overload
+ * resolution and invocation are delegated to {@link NativeJavaOverloadResolver}.
+ */
+final class JavaAccessor {
+    final String name;
+    final ExecutableBox[] methods;
+    final CopyOnWriteArrayList<ResolvedOverload> overloadCache = new CopyOnWriteArrayList<>();
+
+    JavaAccessor(ExecutableBox[] methods, String name) {
+        this.methods = methods;
+        this.name = name;
+    }
+
+    JavaAccessor(ExecutableBox method, String name) {
+        this(new ExecutableBox[] {method}, name);
+    }
+
+    Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
+        return NativeJavaOverloadResolver.invoke(
+                cx, scope, thisObj, args, methods, overloadCache, name);
+    }
+}
+
+class FieldAndMethods extends JSFunction {
     @Serial private static final long serialVersionUID = -9222428244284796755L;
 
     FieldAndMethods(VarScope scope, ExecutableOverload.WithField withField) {
-        super(withField.methods, withField.name);
+        super(
+                scope,
+                JavaMembers.buildNativeJavaMethodDescriptor(withField.methods, withField.name),
+                null,
+                null);
         this.field = withField.field;
-        setParentScope(scope);
-        setPrototype(ScriptableObject.getFunctionPrototype(scope));
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaClass.java
@@ -140,16 +140,18 @@ public class NativeJavaClass extends NativeJavaObject implements Function {
         Class<?> classObject = getClassObject();
         int modifiers = classObject.getModifiers();
         if (!(Modifier.isInterface(modifiers) || Modifier.isAbstract(modifiers))) {
-            NativeJavaMethod ctors = members.ctors;
-            int index = ctors.findCachedFunction(cx, args);
+            ExecutableBox[] ctors = members.ctors;
+            int index =
+                    NativeJavaOverloadResolver.findCachedFunction(
+                            cx, ctors, args, members.ctorOverloadCache);
             if (index < 0) {
-                String sig = NativeJavaMethod.scriptSignature(args);
+                String sig = NativeJavaOverloadResolver.scriptSignature(args);
                 throw Context.reportRuntimeErrorById(
                         "msg.no.java.ctor", classObject.getName(), sig);
             }
 
             // Found the constructor, so try invoking it.
-            return constructSpecific(cx, scope, args, ctors.methods[index]);
+            return constructSpecific(cx, scope, args, ctors[index]);
         }
         if (args.length == 0) {
             throw Context.reportRuntimeErrorById("msg.adapter.zero.args");

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaCode.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaCode.java
@@ -1,0 +1,86 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.mozilla.javascript.lc.member.ExecutableBox;
+
+/**
+ * JSCode implementation for Java methods and constructors exposed to JavaScript.
+ *
+ * <p>Handles reflective method invocation with overload resolution and caching.
+ *
+ * @see NativeJavaOverloadResolver for overload resolution logic
+ */
+public class NativeJavaCode extends JSCode<JSFunction> {
+
+    private final ExecutableBox[] methods;
+    private final CopyOnWriteArrayList<ResolvedOverload> overloadCache =
+            new CopyOnWriteArrayList<>();
+
+    NativeJavaCode(ExecutableBox[] methods) {
+        this.methods = methods;
+    }
+
+    /** Access to the method array for overload resolution. */
+    public ExecutableBox[] getMethods() {
+        return methods;
+    }
+
+    @Override
+    public Object execute(
+            Context cx,
+            JSFunction executableObject,
+            Object newTarget,
+            VarScope scope,
+            Object thisObj,
+            Object[] args) {
+        return NativeJavaOverloadResolver.invoke(
+                cx,
+                scope,
+                thisObj,
+                args,
+                methods,
+                overloadCache,
+                executableObject.getFunctionName());
+    }
+
+    @Override
+    public Object resume(
+            Context cx,
+            JSFunction executableObject,
+            Object state,
+            VarScope scope,
+            int operation,
+            Object value) {
+        // Java methods are not resumable (not generators). If a method returns a generator,
+        // that's handled by wrapping the return value in execute().
+        throw Kit.codeBug("NativeJavaCode is not resumable");
+    }
+
+    /**
+     * Builder for NativeJavaCode. Creates immutable NativeJavaCode instances during descriptor
+     * compilation.
+     */
+    public static class Builder extends JSCode.Builder<JSFunction> {
+
+        private final ExecutableBox[] methods;
+        private NativeJavaCode built;
+
+        public Builder(ExecutableBox[] methods) {
+            this.methods = methods;
+        }
+
+        @Override
+        public JSCode<JSFunction> build() {
+            if (built == null) {
+                built = new NativeJavaCode(methods);
+            }
+            return built;
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaMember.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaMember.java
@@ -1,0 +1,12 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+interface NativeJavaMember extends Function {
+
+    MemberBox[] getMembers();
+}

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaObject.java
@@ -24,8 +24,8 @@ import org.mozilla.javascript.lc.type.TypeInfoFactory;
 
 /**
  * This class reflects non-Array Java objects into the JavaScript environment. It reflects fields
- * directly, and uses NativeJavaMethod objects to reflect (possibly overloaded) methods. It also
- * provides iterator support for all iterable objects.
+ * directly, and reflects (possibly overloaded) methods as {@link JSFunction} objects executed via
+ * {@link NativeJavaCode}. It also provides iterator support for all iterable objects.
  *
  * @author Mike Shaver
  * @see NativeJavaArray

--- a/rhino/src/main/java/org/mozilla/javascript/NativeJavaOverloadResolver.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeJavaOverloadResolver.java
@@ -6,10 +6,6 @@
 
 package org.mozilla.javascript;
 
-import java.io.Serial;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.mozilla.javascript.lc.ReflectUtils;
@@ -20,126 +16,42 @@ import org.mozilla.javascript.lc.type.TypeInfoFactory;
 import org.mozilla.javascript.lc.type.VariableTypeInfo;
 
 /**
- * This class reflects Java methods into the JavaScript environment and handles overloading of
- * methods.
+ * Overload resolution and caching logic for Java methods and constructors exposed to JavaScript.
  *
- * @author Mike Shaver
- * @see NativeJavaArray
- * @see NativeJavaPackage
- * @see NativeJavaClass
+ * @see NativeJavaMethod (deprecated in favor of JSFunction + NativeJavaCode)
  */
-public class NativeJavaMethod extends BaseFunction {
+public class NativeJavaOverloadResolver {
 
-    @Serial private static final long serialVersionUID = -3440381785576412928L;
+    private static final boolean DEBUG = false;
 
-    // TODO: serialization support by read/write class and method name
-    final ExecutableBox[] methods;
-    private final String functionName;
-    private final transient CopyOnWriteArrayList<ResolvedOverload> overloadCache =
-            new CopyOnWriteArrayList<>();
+    private NativeJavaOverloadResolver() {}
 
-    NativeJavaMethod(ExecutableBox[] methods, String name) {
-        this.functionName = name;
-        this.methods = methods;
-    }
-
-    NativeJavaMethod(ExecutableBox method, String name) {
-        this.functionName = name;
-        this.methods = new ExecutableBox[] {method};
-    }
-
-    @Deprecated
-    public NativeJavaMethod(VarScope scope, Method method, String name) {
-        this(new ExecutableBox(method, TypeInfoFactory.GLOBAL, method.getDeclaringClass()), name);
-    }
-
-    @Override
-    public String getFunctionName() {
-        return functionName;
-    }
-
-    static String scriptSignature(Object[] values) {
-        StringBuilder sig = new StringBuilder();
-        for (int i = 0; i != values.length; ++i) {
-            Object value = values[i];
-
-            String s;
-            if (value == null) {
-                s = "null";
-            } else if (value instanceof Boolean) {
-                s = "boolean";
-            } else if (value instanceof String) {
-                s = "string";
-            } else if (value instanceof Number) {
-                s = "number";
-            } else if (value instanceof Scriptable) {
-                if (value instanceof Undefined) {
-                    s = "undefined";
-                } else if (value instanceof Wrapper) {
-                    Object wrapped = ((Wrapper) value).unwrap();
-                    s = wrapped.getClass().getName();
-                } else if (value instanceof Function) {
-                    s = "function";
-                } else {
-                    s = "object";
-                }
-            } else {
-                s = JavaMembers.javaSignature(value.getClass());
-            }
-
-            if (i != 0) {
-                sig.append(',');
-            }
-            sig.append(s);
-        }
-        return sig.toString();
-    }
-
-    @Override
-    String decompile(int indent, EnumSet<DecompilerFlag> flags) {
-        StringBuilder sb = new StringBuilder();
-        boolean justbody = flags.contains(DecompilerFlag.ONLY_BODY);
-        if (!justbody) {
-            sb.append("function ");
-            sb.append(getFunctionName());
-            sb.append("() {");
-        }
-        sb.append("/*\n");
-        sb.append(toString());
-        sb.append(justbody ? "*/\n" : "*/}\n");
-        return sb.toString();
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0, N = methods.length; i != N; ++i) {
-            // Check member type, we also use this for overloaded constructors
-            if (methods[i].isMethod()) {
-                Method method = methods[i].asMethod();
-                sb.append(JavaMembers.javaSignature(method.getReturnType()));
-                sb.append(' ');
-                sb.append(method.getName());
-            } else {
-                sb.append(methods[i].getName());
-            }
-            sb.append(ReflectUtils.liveConnectSignature(methods[i].getArgTypes()));
-            sb.append('\n');
-        }
-        return sb.toString();
-    }
-
-    @Override
-    public Object call(Context cx, VarScope scope, Scriptable thisObj, Object[] args) {
-        // Find a method that matches the types given.
+    /**
+     * Resolve the best matching method from {@code methods} for {@code args}, invoke it against the
+     * appropriate Java object, and wrap the result for JavaScript. This is the shared invocation
+     * path used by {@link NativeJavaCode} and the deprecated {@link NativeJavaMethod}.
+     *
+     * @param thisObj the JavaScript {@code this}; used both to locate the receiver Java object and,
+     *     when it is a {@link NativeJavaObject} with a parameterized static type, to consolidate
+     *     type variables
+     * @param functionName used only for error messages
+     */
+    static Object invoke(
+            Context cx,
+            VarScope scope,
+            Object thisObj,
+            Object[] args,
+            ExecutableBox[] methods,
+            CopyOnWriteArrayList<ResolvedOverload> overloadCache,
+            String functionName) {
         if (methods.length == 0) {
             throw new RuntimeException("No methods defined for call");
         }
 
-        int index = findCachedFunction(cx, args);
+        int index = findCachedFunction(cx, methods, args, overloadCache);
         if (index < 0) {
             Class<?> c = methods[0].asMethod().getDeclaringClass();
-            String sig = c.getName() + '.' + getFunctionName() + '(' + scriptSignature(args) + ')';
+            String sig = c.getName() + '.' + functionName + '(' + scriptSignature(args) + ')';
             throw Context.reportRuntimeErrorById("msg.java.no_such_method", sig);
         }
 
@@ -160,13 +72,13 @@ public class NativeJavaMethod extends BaseFunction {
         if (meth.isStatic()) {
             javaObject = null; // don't need an object
         } else {
-            Scriptable o = thisObj;
+            Scriptable o = (Scriptable) thisObj;
             Class<?> c = meth.getDeclaringClass();
             for (; ; ) {
                 if (o == null) {
                     throw Context.reportRuntimeErrorById(
                             "msg.nonjava.method",
-                            getFunctionName(),
+                            functionName,
                             ScriptRuntime.toString(thisObj),
                             c.getName());
                 }
@@ -179,66 +91,23 @@ public class NativeJavaMethod extends BaseFunction {
                 o = o.getPrototype();
             }
         }
-        if (debug) {
-            printDebug("Calling ", meth, args);
-        }
 
         var returnValue = meth.invoke(javaObject, args);
         var returnType = meth.getReturnType();
-
-        if (debug) {
-            Class<?> actualType = (returnValue == null) ? null : returnValue.getClass();
-            System.err.println(
-                    " ----- Returned "
-                            + returnValue
-                            + " actual = "
-                            + actualType
-                            + " expect = "
-                            + returnType.asClass());
-        }
 
         if (returnType == TypeInfo.PRIMITIVE_VOID) {
             // skip result wrapping if we don't need result at all
             return Undefined.instance;
         }
 
-        Object wrapped =
-                cx.getWrapFactory()
-                        .wrap(
-                                cx, scope,
-                                returnValue, returnType);
-        if (debug) {
-            Class<?> actualType = (wrapped == null) ? null : wrapped.getClass();
-            System.err.println(" ----- Wrapped as " + wrapped + " class = " + actualType);
-        }
-
-        return wrapped;
-    }
-
-    int findCachedFunction(Context cx, Object[] args) {
-        if (methods.length > 1) {
-            for (ResolvedOverload ovl : overloadCache) {
-                if (ovl.matches(args)) {
-                    return ovl.index;
-                }
-            }
-            int index = findFunction(cx, methods, args);
-            // As a sanity measure, don't let the lookup cache grow longer
-            // than twice the number of overloaded methods
-            if (overloadCache.size() < methods.length * 2) {
-                ResolvedOverload ovl = new ResolvedOverload(args, index);
-                overloadCache.addIfAbsent(ovl);
-            }
-            return index;
-        }
-        return findFunction(cx, methods, args);
+        return cx.getWrapFactory().wrap(cx, scope, returnValue, returnType);
     }
 
     /**
      * Find the index of the correct function to call given the set of methods or constructors and
      * the arguments. If no function can be found to call, return -1.
      */
-    static int findFunction(Context cx, ExecutableBox[] methodsOrCtors, Object[] args) {
+    public static int findFunction(Context cx, ExecutableBox[] methodsOrCtors, Object[] args) {
         if (methodsOrCtors.length == 0) {
             return -1;
         }
@@ -246,7 +115,7 @@ public class NativeJavaMethod extends BaseFunction {
             if (failFastConversionWeights(args, methodsOrCtors[0]) == null) {
                 return -1;
             }
-            if (debug) printDebug("Found ", methodsOrCtors[0], args);
+            if (DEBUG) printDebug("Found ", methodsOrCtors[0], args);
             return 0;
         }
 
@@ -267,7 +136,7 @@ public class NativeJavaMethod extends BaseFunction {
             }
 
             if (firstBestFit < 0) {
-                if (debug) printDebug("Found first applicable ", member, args);
+                if (DEBUG) printDebug("Found first applicable ", member, args);
                 firstBestFit = i;
                 firstBestFitWeights = weights;
                 continue search;
@@ -277,10 +146,8 @@ public class NativeJavaMethod extends BaseFunction {
             // The loop starts from -1 denoting firstBestFit and proceed
             // until extraBestFitsCount to avoid extraBestFits allocation
             // in the most common case of no ambiguity
-            int betterCount = 0; // number of times member was preferred over
-            // best fits
-            int worseCount = 0; // number of times best fits were preferred
-            // over member
+            int betterCount = 0; // number of times member was preferred over best fits
+            int worseCount = 0; // number of times best fits were preferred over member
             for (int j = -1; j != extraBestFitsCount; ++j) {
                 int bestFitIndex = j < 0 ? firstBestFit : extraBestFits[j];
                 ExecutableBox bestFit = methodsOrCtors[bestFitIndex];
@@ -288,8 +155,7 @@ public class NativeJavaMethod extends BaseFunction {
                 if (cx.hasFeature(Context.FEATURE_ENHANCED_JAVA_ACCESS)
                         && bestFit.isPublic() != member.isPublic()) {
                     // When FEATURE_ENHANCED_JAVA_ACCESS gives us access
-                    // to non-public members, continue to prefer public
-                    // methods in overloading
+                    // to non-public members, continue to prefer public methods in overloading
                     if (!bestFit.isPublic()) ++betterCount;
                     else ++worseCount;
                 } else {
@@ -303,19 +169,14 @@ public class NativeJavaMethod extends BaseFunction {
                         ++worseCount;
                     } else {
                         if (preference != PREFERENCE_EQUAL) Kit.codeBug();
-                        // This should not happen in theory
-                        // but on some JVMs, Class.getMethods will return all
-                        // static methods of the class hierarchy, even if
-                        // a derived class's parameters match exactly.
-                        // We want to call the derived class's method.
+                        // This should not happen in theory but on some JVMs, Class.getMethods will
+                        // return all static methods of the class hierarchy, even if a derived
+                        // class's parameters match exactly. We want to call the derived class's
+                        // method.
                         if (bestFit.isStatic()
                                 && bestFit.getDeclaringClass()
                                         .isAssignableFrom(member.getDeclaringClass())) {
-                            // On some JVMs, Class.getMethods will return all
-                            // static methods of the class hierarchy, even if
-                            // a derived class's parameters match exactly.
-                            // We want to call the derived class's method.
-                            if (debug) printDebug("Substituting (overridden static)", member, args);
+                            if (DEBUG) printDebug("Substituting (overridden static)", member, args);
                             if (j == -1) {
                                 firstBestFit = i;
                                 firstBestFitWeights = weights;
@@ -324,7 +185,7 @@ public class NativeJavaMethod extends BaseFunction {
                                 extraBestFitWeights[j] = weights;
                             }
                         } else {
-                            if (debug) printDebug("Ignoring same signature member ", member, args);
+                            if (DEBUG) printDebug("Ignoring same signature member ", member, args);
                         }
                         continue search;
                     }
@@ -332,16 +193,16 @@ public class NativeJavaMethod extends BaseFunction {
             }
             if (betterCount == 1 + extraBestFitsCount) {
                 // member was preferred over all best fits
-                if (debug) printDebug("New first applicable ", member, args);
+                if (DEBUG) printDebug("New first applicable ", member, args);
                 firstBestFit = i;
                 firstBestFitWeights = weights;
                 extraBestFitsCount = 0;
             } else if (worseCount == 1 + extraBestFitsCount) {
                 // all best fits were preferred over member, ignore it
-                if (debug) printDebug("Rejecting (all current bests better) ", member, args);
+                if (DEBUG) printDebug("Rejecting (all current bests better) ", member, args);
             } else {
                 // some ambiguity was present, add member to best fit set
-                if (debug) printDebug("Added to best fit set ", member, args);
+                if (DEBUG) printDebug("Added to best fit set ", member, args);
                 if (extraBestFits == null) {
                     // Allocate maximum possible array
                     extraBestFits = new int[methodsOrCtors.length - 1];
@@ -380,30 +241,81 @@ public class NativeJavaMethod extends BaseFunction {
 
         if (methodsOrCtors[0].isConstructor()) {
             throw Context.reportRuntimeErrorById(
-                    "msg.constructor.ambiguous", memberName, scriptSignature(args), buf.toString());
+                    "msg.constructor.ambiguous", memberName, "", buf.toString());
         }
         throw Context.reportRuntimeErrorById(
-                "msg.method.ambiguous",
-                memberClass,
-                memberName,
-                scriptSignature(args),
-                buf.toString());
+                "msg.method.ambiguous", memberClass, memberName, "", buf.toString());
     }
 
-    /** Types are equal */
-    private static final int PREFERENCE_EQUAL = 0;
+    /**
+     * Find and cache the index of the correct function to call. Uses per-call-site caching via
+     * ResolvedOverload to avoid repeated overload resolution for the same arg types.
+     */
+    public static int findCachedFunction(
+            Context cx,
+            ExecutableBox[] methods,
+            Object[] args,
+            CopyOnWriteArrayList<ResolvedOverload> overloadCache) {
+        if (methods.length > 1) {
+            for (ResolvedOverload ovl : overloadCache) {
+                if (ovl.matches(args)) {
+                    return ovl.index;
+                }
+            }
+            int index = findFunction(cx, methods, args);
+            // As a sanity measure, don't let the lookup cache grow longer
+            // than twice the number of overloaded methods
+            if (overloadCache.size() < methods.length * 2) {
+                ResolvedOverload ovl = new ResolvedOverload(args, index);
+                overloadCache.addIfAbsent(ovl);
+            }
+            return index;
+        }
+        return findFunction(cx, methods, args);
+    }
 
+    public static String scriptSignature(Object[] values) {
+        StringBuilder sig = new StringBuilder();
+        for (int i = 0; i != values.length; ++i) {
+            Object value = values[i];
+
+            String s;
+            if (value == null) {
+                s = "null";
+            } else if (value instanceof Boolean) {
+                s = "boolean";
+            } else if (value instanceof String) {
+                s = "string";
+            } else if (value instanceof Number) {
+                s = "number";
+            } else if (value instanceof Scriptable) {
+                if (value instanceof Undefined) {
+                    s = "undefined";
+                } else if (value instanceof Wrapper) {
+                    Object wrapped = ((Wrapper) value).unwrap();
+                    s = wrapped.getClass().getName();
+                } else if (value instanceof Function) {
+                    s = "function";
+                } else {
+                    s = "object";
+                }
+            } else {
+                s = JavaMembers.javaSignature(value.getClass());
+            }
+
+            if (i != 0) {
+                sig.append(',');
+            }
+            sig.append(s);
+        }
+        return sig.toString();
+    }
+
+    private static final int PREFERENCE_EQUAL = 0;
     private static final int PREFERENCE_FIRST_ARG = 1;
     private static final int PREFERENCE_SECOND_ARG = 2;
-
-    /** No clear "easy" conversion */
     private static final int PREFERENCE_AMBIGUOUS = 3;
 
-    /**
-     * Determine which of two signatures is the closer fit. Returns one of {@link
-     * #PREFERENCE_EQUAL}, {@link #PREFERENCE_FIRST_ARG}, {@link #PREFERENCE_SECOND_ARG}, or {@link
-     * #PREFERENCE_AMBIGUOUS}.
-     */
     private static int preferSignature(
             Object[] args,
             ExecutableBox member1,
@@ -429,7 +341,6 @@ public class NativeJavaMethod extends BaseFunction {
             final var arg = args[j];
 
             // Determine which of type1, type2 is easier to convert from arg.
-
             final var rank1 =
                     j < computedWeights1.length
                             ? computedWeights1[j]
@@ -468,17 +379,6 @@ public class NativeJavaMethod extends BaseFunction {
         return totalPreference;
     }
 
-    /**
-     * 1. {@code args} is too short for {@code member} calling -> return {@code null}
-     *
-     * <p>2. at least one arg cannot be converted -> return {@code null}
-     *
-     * <p>3. otherwise -> return an int array holding all computed conversion weights, whose length
-     * will be {@code args.length} for non-vararg member or {@code args.length-1} for vararg member
-     *
-     * @see NativeJavaObject#getConversionWeight(Object, org.mozilla.javascript.lc.type.TypeInfo)
-     * @see NativeJavaObject#canConvert(Object, org.mozilla.javascript.lc.type.TypeInfo)
-     */
     static int[] failFastConversionWeights(Object[] args, ExecutableBox member) {
         final var argTypes = member.getArgTypes();
         var typeLen = argTypes.size();
@@ -496,7 +396,7 @@ public class NativeJavaMethod extends BaseFunction {
         for (int i = 0; i < typeLen; i++) {
             final var weight = NativeJavaObject.getConversionWeight(args[i], argTypes.get(i));
             if (weight >= NativeJavaObject.CONVERSION_NONE) {
-                if (debug) {
+                if (DEBUG) {
                     printDebug("Rejecting (args can't convert) ", member, args);
                 }
                 return null;
@@ -506,10 +406,8 @@ public class NativeJavaMethod extends BaseFunction {
         return weights;
     }
 
-    private static final boolean debug = false;
-
     private static void printDebug(String msg, ExecutableBox member, Object[] args) {
-        if (debug) {
+        if (DEBUG) {
             StringBuilder sb = new StringBuilder();
             sb.append(" ----- ");
             sb.append(msg);
@@ -524,50 +422,5 @@ public class NativeJavaMethod extends BaseFunction {
             sb.append(')');
             System.out.println(sb);
         }
-    }
-}
-
-class ResolvedOverload {
-    final Class<?>[] types;
-    final int index;
-
-    ResolvedOverload(Object[] args, int index) {
-        this.index = index;
-        types = new Class<?>[args.length];
-        for (int i = 0, l = args.length; i < l; i++) {
-            Object arg = args[i];
-            if (arg instanceof Wrapper) arg = ((Wrapper) arg).unwrap();
-            types[i] = arg == null ? null : arg.getClass();
-        }
-    }
-
-    boolean matches(Object[] args) {
-        if (args.length != types.length) {
-            return false;
-        }
-        for (int i = 0, l = args.length; i < l; i++) {
-            Object arg = args[i];
-            if (arg instanceof Wrapper) arg = ((Wrapper) arg).unwrap();
-            if (arg == null) {
-                if (types[i] != null) return false;
-            } else if (arg.getClass() != types[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof ResolvedOverload)) {
-            return false;
-        }
-        ResolvedOverload ovl = (ResolvedOverload) other;
-        return Arrays.equals(types, ovl.types) && index == ovl.index;
-    }
-
-    @Override
-    public int hashCode() {
-        return Arrays.hashCode(types);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/ResolvedOverload.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ResolvedOverload.java
@@ -1,0 +1,59 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+import java.util.Arrays;
+
+/**
+ * Caches the result of overload resolution for a specific set of argument runtime types, so that
+ * {@link NativeJavaOverloadResolver} can skip the resolution work when the same shape of arguments
+ * is seen again.
+ */
+class ResolvedOverload {
+    final Class<?>[] types;
+    final int index;
+
+    ResolvedOverload(Object[] args, int index) {
+        this.index = index;
+        types = new Class<?>[args.length];
+        for (int i = 0, l = args.length; i < l; i++) {
+            Object arg = args[i];
+            if (arg instanceof Wrapper) arg = ((Wrapper) arg).unwrap();
+            types[i] = arg == null ? null : arg.getClass();
+        }
+    }
+
+    boolean matches(Object[] args) {
+        if (args.length != types.length) {
+            return false;
+        }
+        for (int i = 0, l = args.length; i < l; i++) {
+            Object arg = args[i];
+            if (arg instanceof Wrapper) arg = ((Wrapper) arg).unwrap();
+            if (arg == null) {
+                if (types[i] != null) return false;
+            } else if (arg.getClass() != types[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof ResolvedOverload)) {
+            return false;
+        }
+        ResolvedOverload ovl = (ResolvedOverload) other;
+        return Arrays.equals(types, ovl.types) && index == ovl.index;
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(types);
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaCodeTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaCodeTest.java
@@ -1,0 +1,133 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeJavaObject;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Tests for NativeJavaCode — the JSCode<JSFunction> implementation for Java methods exposed to
+ * JavaScript.
+ */
+public class NativeJavaCodeTest {
+
+    /** Helper class for testing Java method invocation from JavaScript. */
+    public static class JavaMethodDummy {
+        public final List<String> captured = new ArrayList<>();
+
+        public String greet(String name) {
+            captured.add("greet");
+            return "Hello, " + name;
+        }
+
+        public int add(int a, int b) {
+            captured.add("add");
+            return a + b;
+        }
+
+        public void doNothing() {
+            captured.add("doNothing");
+        }
+
+        public static int staticAdd(int a, int b) {
+            return a + b;
+        }
+    }
+
+    @Test
+    public void testSimpleMethodCall() {
+        Utils.runWithAllModes(
+                cx -> {
+                    final var dummy = new JavaMethodDummy();
+                    final var scope = cx.initStandardObjects();
+                    ScriptableObject.putProperty(scope, "obj", Context.javaToJS(dummy, scope));
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "var x = obj.greet('World'); x;",
+                                    "NativeJavaCodeTest.js",
+                                    0,
+                                    null);
+                    assertEquals(NativeJavaObject.class, result.getClass());
+                    assertEquals("Hello, World", ((NativeJavaObject) result).unwrap());
+                    assertEquals("greet", dummy.captured.get(0));
+                    return null;
+                });
+    }
+
+    @Test
+    public void testIntegerReturn() {
+        Utils.runWithAllModes(
+                cx -> {
+                    final var dummy = new JavaMethodDummy();
+                    final var scope = cx.initStandardObjects();
+                    ScriptableObject.putProperty(scope, "obj", Context.javaToJS(dummy, scope));
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope, "obj.add(2, 3);", "NativeJavaCodeTest.js", 0, null);
+
+                    assertEquals(5, ((Number) result).intValue());
+                    assertEquals("add", dummy.captured.get(0));
+                    return null;
+                });
+    }
+
+    @Test
+    public void testVoidReturn() {
+        Utils.runWithAllModes(
+                cx -> {
+                    final var dummy = new JavaMethodDummy();
+                    final var scope = cx.initStandardObjects();
+                    ScriptableObject.putProperty(scope, "obj", Context.javaToJS(dummy, scope));
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "obj.doNothing(); 'done';",
+                                    "NativeJavaCodeTest.js",
+                                    0,
+                                    null);
+
+                    assertEquals("done", result);
+                    assertEquals("doNothing", dummy.captured.get(0));
+                    return null;
+                });
+    }
+
+    @Test
+    public void testStaticMethod() {
+        Utils.runWithAllModes(
+                cx -> {
+                    final var scope = cx.initStandardObjects();
+                    ScriptableObject.putProperty(
+                            scope,
+                            "JavaMethodDummy",
+                            new org.mozilla.javascript.NativeJavaClass(
+                                    scope, JavaMethodDummy.class));
+
+                    Object result =
+                            cx.evaluateString(
+                                    scope,
+                                    "JavaMethodDummy.staticAdd(5, 7);",
+                                    "NativeJavaCodeTest.js",
+                                    0,
+                                    null);
+
+                    assertEquals(12, ((Number) result).intValue());
+                    return null;
+                });
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMapTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/NativeJavaMapTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
 import org.mozilla.javascript.EvaluatorException;
+import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.NativeArray;
-import org.mozilla.javascript.NativeJavaMethod;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.testutils.Utils;
 import org.mozilla.javascript.tools.shell.Global;
@@ -156,7 +156,7 @@ public class NativeJavaMapTest {
         map.put("a", "abc");
 
         assertThrows(EvaluatorException.class, () -> runScript("value[0]", map, false));
-        assertTrue(runScript("value.put", map, false) instanceof NativeJavaMethod);
+        assertTrue(runScript("value.put", map, false) instanceof JSFunction);
         assertThrows(EvaluatorException.class, () -> runScript("value['a'] = 0", map, false));
         assertEquals(false, runScript("'a' in value", map, false));
         assertEquals(true, runScript("Object.keys(value).includes('getClass')", map, false));


### PR DESCRIPTION
We cache a large number of `NativeJavaMethod`s between contexts in production instances to avoid repeatedly reflecting on the same things, but this is tricky as they must be detached from their original prototypes and if anything is wrong we end up leaking resources. This change tries to refactor things to fit native java methods into the same descriptor framework we use elsewhere, giving us something we can more easily cache and reuse.

Making a draft for PR for now to gather feedback, I feel like this area should be possible to simplify further with a bit more work.