### PR TITLE
Add support for constant_dynamic with `SymbolKey` as an example.

### DIFF
--- a/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
+++ b/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
@@ -10,9 +10,16 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.StackWalker.Option;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.config.RhinoConfig;
 
@@ -917,17 +924,7 @@ public class ClassFileWriter {
         int newStack = itsStackTop + stackDiff;
         if (newStack < 0 || Short.MAX_VALUE < newStack) badStack(newStack);
 
-        BootstrapEntry bsmEntry = new BootstrapEntry(bsm, bsmArgs);
-
-        if (itsBootstrapMethods == null) {
-            itsBootstrapMethods = new ArrayList<>();
-        }
-        int bootstrapIndex = itsBootstrapMethods.indexOf(bsmEntry);
-        if (bootstrapIndex == -1) {
-            bootstrapIndex = itsBootstrapMethods.size();
-            itsBootstrapMethods.add(bsmEntry);
-            itsBootstrapMethodsLength += bsmEntry.code.length;
-        }
+        int bootstrapIndex = getBootstrapMethodIndex(bsm, bsmArgs);
 
         short invokedynamicIndex =
                 itsConstantPool.addInvokeDynamic(methodName, methodType, bootstrapIndex);
@@ -941,6 +938,108 @@ public class ClassFileWriter {
         if (DEBUGSTACK) {
             System.err.println("After invokedynamic stack = " + itsStackTop);
         }
+    }
+
+    /**
+     * Register a describer that this writer will use to turn values of {@link
+     * DynamicConstantDescriber#describedType} into dynamic constants.
+     *
+     * <p>A value is matched to a describer by walking up its superclasses, so a describer also
+     * covers the subclasses of its type. Describers must therefore be keyed on a class rather than
+     * on an interface.
+     */
+    public <T extends DynamicConstant> void registerDynamicConstantDescriber(
+            DynamicConstantDescriber<T> describer) {
+        itsConstantDescribers.put(describer.describedType(), describer);
+    }
+
+    /**
+     * Generate the load constant bytecode for the given value, using the describer registered for
+     * its type. Both the constant and its bootstrap method are added to the constant pool, and the
+     * bootstrap method is shared with any invokedynamic instruction using the same one.
+     *
+     * @param constant the constant
+     */
+    public void addLoadDynamicConstant(DynamicConstant constant) {
+        // Class file version 55 is required for CONSTANT_Dynamic
+        if (MajorVersion < 55) {
+            throw new RuntimeException("Please build and run with JDK 11 for dynamic constants");
+        }
+
+        Class<?> type = constant.getClass();
+        DynamicConstantDescriber<?> describer = findConstantDescriber(type);
+        if (describer == null) {
+            throw new IllegalArgumentException("no dynamic constant describer for " + type);
+        }
+        DynamicConstantDesc<?> desc =
+                describe(describer, constant)
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "value cannot be described as a dynamic constant: "
+                                                        + constant));
+        addLoadConstant(desc);
+    }
+
+    /** Generate the load constant bytecode for an already described constant. */
+    void addLoadConstant(ConstantDesc desc) {
+        int index = itsConstantPool.addConstantDesc(desc);
+        add(isTwoWordConstant(desc) ? ByteCode.LDC2_W : ByteCode.LDC, index);
+    }
+
+    /**
+     * Whether an "ldc" of the given constant pushes two words, and so must use "ldc2_w". Only
+     * dynamic constants can vary here; every other kind of description we can write is either
+     * always one word or has its own dedicated addLoadConstant overload.
+     */
+    private static boolean isTwoWordConstant(ConstantDesc desc) {
+        if (desc instanceof DynamicConstantDesc) {
+            ClassDesc type = ((DynamicConstantDesc<?>) desc).constantType();
+            return ConstantDescs.CD_long.equals(type) || ConstantDescs.CD_double.equals(type);
+        }
+        return desc instanceof Long || desc instanceof Double;
+    }
+
+    /** Find the describer registered for a type, or for its nearest described supertype. */
+    private DynamicConstantDescriber<?> findConstantDescriber(Class<?> type) {
+        return itsConstantDescribers.get(type);
+    }
+
+    /**
+     * The describer registry is a heterogeneous container: the registration API guarantees that
+     * each describer is keyed by the type it accepts, and lookup only ever reaches a describer
+     * whose key the value is assignable to, so the cast here is safe even though it cannot be
+     * expressed in the type system.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends DynamicConstant> Optional<DynamicConstantDesc<T>> describe(
+            DynamicConstantDescriber<T> describer, DynamicConstant value) {
+        return describer.describe((T) value);
+    }
+
+    /**
+     * The index in the BootstrapMethods attribute of the given bootstrap method, adding it if it is
+     * not already present. The attribute is shared between invokedynamic instructions and dynamic
+     * constants.
+     */
+    int getBootstrapMethodIndex(MHandle bsm, Object... bsmArgs) {
+        BootstrapEntry bsmEntry = new BootstrapEntry(bsm, bsmArgs);
+
+        if (itsBootstrapMethods == null) {
+            itsBootstrapMethods = new ArrayList<>();
+        }
+        int bootstrapIndex = itsBootstrapMethods.indexOf(bsmEntry);
+        if (bootstrapIndex == -1) {
+            bootstrapIndex = itsBootstrapMethods.size();
+            itsBootstrapMethods.add(bsmEntry);
+            itsBootstrapMethodsLength += bsmEntry.code.length;
+        }
+        return bootstrapIndex;
+    }
+
+    int getBootstrapMethodIndex(DynamicConstantDesc<?> desc) {
+        DirectMethodHandleDesc bsm = desc.bootstrapMethod();
+        return getBootstrapMethodIndex(MHandle.of(bsm), (Object[]) desc.bootstrapArgs());
     }
 
     /**
@@ -2196,6 +2295,14 @@ public class ClassFileWriter {
                         case ConstantPool.CONSTANT_Class:
                             push(TypeInfo.OBJECT("java/lang/Class", itsConstantPool));
                             break;
+                        case ConstantPool.CONSTANT_Dynamic:
+                            String constDescriptor =
+                                    (String) itsConstantPool.getConstantData(index);
+                            push(
+                                    TypeInfo.fromType(
+                                            descriptorToInternalName(constDescriptor),
+                                            itsConstantPool));
+                            break;
                         default:
                             throw new IllegalArgumentException("bad const type " + constType);
                     }
@@ -2677,7 +2784,7 @@ public class ClassFileWriter {
      *
      * <p>For example, descriptor Ljava/lang/Object; becomes java/lang/Object.
      */
-    private static String classDescriptorToInternalName(String descriptor) {
+    static String classDescriptorToInternalName(String descriptor) {
         return descriptor.substring(1, descriptor.length() - 1);
     }
 
@@ -4520,12 +4627,35 @@ public class ClassFileWriter {
         final String owner;
         final String name;
         final String desc;
+        final boolean isInterface;
 
         public MHandle(byte tag, String owner, String name, String desc) {
+            this(tag, owner, name, desc, false);
+        }
+
+        /**
+         * @param isInterface whether the owner is an interface. This must be set for the static and
+         *     special reference kinds, whose tags do not otherwise distinguish an interface owner,
+         *     so that the handle refers to a CONSTANT_InterfaceMethodref.
+         */
+        public MHandle(byte tag, String owner, String name, String desc, boolean isInterface) {
             this.tag = tag;
             this.owner = owner;
             this.name = name;
             this.desc = desc;
+            this.isInterface = isInterface;
+        }
+
+        /** Convert a {@code java.lang.constant} method handle description into a handle. */
+        static MHandle of(DirectMethodHandleDesc desc) {
+            // Kind.refKind is the JVMS reference kind, which is exactly what ByteCode.MH_*
+            // holds, so the tag needs no translation.
+            return new MHandle(
+                    (byte) desc.kind().refKind,
+                    classDescriptorToInternalName(desc.owner().descriptorString()),
+                    desc.methodName(),
+                    desc.lookupDescriptor(),
+                    desc.isOwnerInterface());
         }
 
         @Override
@@ -4538,6 +4668,7 @@ public class ClassFileWriter {
             }
             MHandle mh = (MHandle) obj;
             return tag == mh.tag
+                    && isInterface == mh.isInterface
                     && owner.equals(mh.owner)
                     && name.equals(mh.name)
                     && desc.equals(mh.desc);
@@ -4615,6 +4746,8 @@ public class ClassFileWriter {
     private ArrayList<int[]> itsVarDescriptors;
     private ArrayList<BootstrapEntry> itsBootstrapMethods;
     private int itsBootstrapMethodsLength = 0;
+    private final Map<Class<?>, DynamicConstantDescriber<?>> itsConstantDescribers =
+            new HashMap<>();
 
     private char[] tmpCharBuffer = new char[64];
 }

--- a/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
+++ b/rhino/src/main/java/org/mozilla/classfile/ClassFileWriter.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.mozilla.javascript.Kit;
 import org.mozilla.javascript.config.RhinoConfig;
 
@@ -960,25 +959,19 @@ public class ClassFileWriter {
      *
      * @param constant the constant
      */
-    public void addLoadDynamicConstant(DynamicConstant constant) {
+    public <T extends DynamicConstant> void addLoadDynamicConstant(T constant) {
         // Class file version 55 is required for CONSTANT_Dynamic
         if (MajorVersion < 55) {
             throw new RuntimeException("Please build and run with JDK 11 for dynamic constants");
         }
 
-        Class<?> type = constant.getClass();
-        DynamicConstantDescriber<?> describer = findConstantDescriber(type);
+        @SuppressWarnings("unchecked")
+        var type = (Class<T>) constant.getClass();
+        var describer = (DynamicConstantDescriber<T>) findConstantDescriber(type);
         if (describer == null) {
             throw new IllegalArgumentException("no dynamic constant describer for " + type);
         }
-        DynamicConstantDesc<?> desc =
-                describe(describer, constant)
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "value cannot be described as a dynamic constant: "
-                                                        + constant));
-        addLoadConstant(desc);
+        addLoadConstant(describer.describe(constant));
     }
 
     /** Generate the load constant bytecode for an already described constant. */
@@ -1000,21 +993,12 @@ public class ClassFileWriter {
         return desc instanceof Long || desc instanceof Double;
     }
 
-    /** Find the describer registered for a type, or for its nearest described supertype. */
-    private DynamicConstantDescriber<?> findConstantDescriber(Class<?> type) {
-        return itsConstantDescribers.get(type);
-    }
-
-    /**
-     * The describer registry is a heterogeneous container: the registration API guarantees that
-     * each describer is keyed by the type it accepts, and lookup only ever reaches a describer
-     * whose key the value is assignable to, so the cast here is safe even though it cannot be
-     * expressed in the type system.
-     */
-    @SuppressWarnings("unchecked")
-    private static <T extends DynamicConstant> Optional<DynamicConstantDesc<T>> describe(
-            DynamicConstantDescriber<T> describer, DynamicConstant value) {
-        return describer.describe((T) value);
+    /** Find the describer registered for a type. */
+    private <T extends DynamicConstant> DynamicConstantDescriber<T> findConstantDescriber(
+            Class<T> type) {
+        @SuppressWarnings("unchecked")
+        var res = (DynamicConstantDescriber<T>) itsConstantDescribers.get(type);
+        return res;
     }
 
     /**
@@ -4746,8 +4730,10 @@ public class ClassFileWriter {
     private ArrayList<int[]> itsVarDescriptors;
     private ArrayList<BootstrapEntry> itsBootstrapMethods;
     private int itsBootstrapMethodsLength = 0;
-    private final Map<Class<?>, DynamicConstantDescriber<?>> itsConstantDescribers =
-            new HashMap<>();
+    private final Map<
+                    Class<? extends DynamicConstant>,
+                    DynamicConstantDescriber<? extends DynamicConstant>>
+            itsConstantDescribers = new HashMap<>();
 
     private char[] tmpCharBuffer = new char[64];
 }

--- a/rhino/src/main/java/org/mozilla/classfile/ConstantEntry.java
+++ b/rhino/src/main/java/org/mozilla/classfile/ConstantEntry.java
@@ -44,8 +44,10 @@ final class ConstantEntry {
             case ConstantPool.CONSTANT_Double:
                 return longval == entry.longval;
             case ConstantPool.CONSTANT_NameAndType:
+            case ConstantPool.CONSTANT_MethodType:
                 return str1.equals(entry.str1) && str2.equals(entry.str2);
             case ConstantPool.CONSTANT_InvokeDynamic:
+            case ConstantPool.CONSTANT_Dynamic:
                 return intval == entry.intval && str1.equals(entry.str1) && str2.equals(entry.str2);
             default:
                 throw new RuntimeException("unsupported constant type");

--- a/rhino/src/main/java/org/mozilla/classfile/ConstantPool.java
+++ b/rhino/src/main/java/org/mozilla/classfile/ConstantPool.java
@@ -6,6 +6,11 @@
 
 package org.mozilla.classfile;
 
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.util.HashMap;
 
 final class ConstantPool {
@@ -30,6 +35,7 @@ final class ConstantPool {
             CONSTANT_Utf8 = 1,
             CONSTANT_MethodType = 16,
             CONSTANT_MethodHandle = 15,
+            CONSTANT_Dynamic = 17,
             CONSTANT_InvokeDynamic = 18;
 
     int write(byte[] data, int offset) {
@@ -110,13 +116,57 @@ final class ConstantPool {
             return addConstant(((Double) value).doubleValue());
         } else if (value instanceof String) {
             return addConstant((String) value);
-            // } else if (value instanceof ClassFileWriter.MethodType) {
-            //    return addMethodType((ClassFileWriter.MethodType) value);
         } else if (value instanceof ClassFileWriter.MHandle) {
             return addMethodHandle((ClassFileWriter.MHandle) value);
+        } else if (value instanceof ConstantDesc) {
+            return addConstantDesc((ConstantDesc) value);
         } else {
             throw new IllegalArgumentException("value " + value);
         }
+    }
+
+    /**
+     * Add the constant described by the given {@code java.lang.constant} description, returning its
+     * constant pool index.
+     */
+    int addConstantDesc(ConstantDesc desc) {
+        if (desc instanceof DynamicConstantDesc) {
+            DynamicConstantDesc<?> dynamic = (DynamicConstantDesc<?>) desc;
+            return addDynamicConstant(
+                    dynamic.constantName(),
+                    dynamic.constantType().descriptorString(),
+                    cfw.getBootstrapMethodIndex(dynamic));
+        } else if (desc instanceof ClassDesc) {
+            return addClass(internalNameOf((ClassDesc) desc));
+        } else if (desc instanceof MethodTypeDesc) {
+            return addMethodType(((MethodTypeDesc) desc).descriptorString());
+        } else if (desc instanceof DirectMethodHandleDesc) {
+            return addMethodHandle(ClassFileWriter.MHandle.of((DirectMethodHandleDesc) desc));
+        } else if (desc instanceof String
+                || desc instanceof Integer
+                || desc instanceof Long
+                || desc instanceof Float
+                || desc instanceof Double) {
+            // Delegate to the overloads above. Guarded to the types they handle so that an
+            // unsupported description cannot bounce back here and recurse.
+            return addConstant((Object) desc);
+        }
+        throw new IllegalArgumentException("unsupported constant description " + desc);
+    }
+
+    /**
+     * The internal name to use for a {@code CONSTANT_Class} entry describing the given class. Array
+     * classes are named by their descriptor; primitives have no class constant form.
+     */
+    private static String internalNameOf(ClassDesc desc) {
+        String descriptor = desc.descriptorString();
+        if (desc.isPrimitive()) {
+            throw new IllegalArgumentException(
+                    "primitive type has no class constant: " + descriptor);
+        }
+        return desc.isArray()
+                ? descriptor
+                : ClassFileWriter.classDescriptorToInternalName(descriptor);
     }
 
     boolean isUnderUtfEncodingLimit(String s) {
@@ -319,6 +369,47 @@ final class ConstantPool {
         return (short) theIndex;
     }
 
+    /**
+     * Add a {@code CONSTANT_Dynamic} entry. Note that, unlike long and double constants, a dynamic
+     * constant occupies a single pool index whatever its type.
+     */
+    short addDynamicConstant(String name, String descriptor, int bootstrapIndex) {
+        ConstantEntry entry = new ConstantEntry(CONSTANT_Dynamic, bootstrapIndex, name, descriptor);
+        int theIndex = itsConstantHash.getOrDefault(entry, -1);
+
+        if (theIndex == -1) {
+            short nameTypeIndex = addNameAndType(name, descriptor);
+            ensure(5);
+            itsPool[itsTop++] = CONSTANT_Dynamic;
+            itsTop = ClassFileWriter.putInt16(bootstrapIndex, itsPool, itsTop);
+            itsTop = ClassFileWriter.putInt16(nameTypeIndex, itsPool, itsTop);
+            theIndex = itsTopIndex++;
+            itsConstantHash.put(entry, theIndex);
+            // The descriptor is what the stack map generator uses to work out the type that
+            // an "ldc" of this entry pushes.
+            setConstantData(theIndex, descriptor);
+            itsPoolTypes.put(theIndex, CONSTANT_Dynamic);
+        }
+        return (short) theIndex;
+    }
+
+    short addMethodType(String methodDescriptor) {
+        ConstantEntry entry = new ConstantEntry(CONSTANT_MethodType, 0, methodDescriptor, "");
+        int theIndex = itsConstantHash.getOrDefault(entry, -1);
+
+        if (theIndex == -1) {
+            int descriptorIndex = 0xFFFF & addUtf8(methodDescriptor);
+            ensure(3);
+            itsPool[itsTop++] = CONSTANT_MethodType;
+            itsTop = ClassFileWriter.putInt16(descriptorIndex, itsPool, itsTop);
+            theIndex = itsTopIndex++;
+            itsConstantHash.put(entry, theIndex);
+            setConstantData(theIndex, methodDescriptor);
+            itsPoolTypes.put(theIndex, CONSTANT_MethodType);
+        }
+        return (short) theIndex;
+    }
+
     short addMethodHandle(ClassFileWriter.MHandle mh) {
         int theIndex = itsConstantHash.getOrDefault(mh, -1);
 
@@ -326,7 +417,7 @@ final class ConstantPool {
             short ref;
             if (mh.tag <= ByteCode.MH_PUTSTATIC) {
                 ref = addFieldRef(mh.owner, mh.name, mh.desc);
-            } else if (mh.tag == ByteCode.MH_INVOKEINTERFACE) {
+            } else if (mh.tag == ByteCode.MH_INVOKEINTERFACE || mh.isInterface) {
                 ref = addInterfaceMethodRef(mh.owner, mh.name, mh.desc);
             } else {
                 ref = addMethodRef(mh.owner, mh.name, mh.desc);

--- a/rhino/src/main/java/org/mozilla/classfile/DynamicConstant.java
+++ b/rhino/src/main/java/org/mozilla/classfile/DynamicConstant.java
@@ -1,0 +1,22 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.classfile;
+
+/**
+ * Marker for values that may be written to a class file as a {@code CONSTANT_Dynamic} constant pool
+ * entry.
+ *
+ * <p>The marker carries no behaviour of its own: a {@link DynamicConstantDescriber} registered with
+ * the {@link ClassFileWriter} is what actually turns a value into a constant. Implementing this
+ * interface only declares that such a describer may exist, which is what lets {@link
+ * ClassFileWriter#addLoadDynamicConstant} accept the value at compile time.
+ *
+ * <p>This interface deliberately declares no methods and references nothing outside {@code
+ * java.lang}, so that runtime classes which are loaded on platforms without bytecode generation
+ * support can implement it safely.
+ */
+public interface DynamicConstant {}

--- a/rhino/src/main/java/org/mozilla/classfile/DynamicConstantDescriber.java
+++ b/rhino/src/main/java/org/mozilla/classfile/DynamicConstantDescriber.java
@@ -1,0 +1,31 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.classfile;
+
+import java.lang.constant.DynamicConstantDesc;
+import java.util.Optional;
+
+/**
+ * Turns values of a particular type into the {@code CONSTANT_Dynamic} description that {@link
+ * ClassFileWriter} writes to the constant pool.
+ *
+ * <p>Describers are registered with a writer using {@link
+ * ClassFileWriter#registerDynamicConstantDescriber}, which keys them on {@link #describedType}.
+ *
+ * @param <T> the type of value described
+ */
+public interface DynamicConstantDescriber<T extends DynamicConstant> {
+
+    /** The type of value this describer handles. Used as the registration key. */
+    Class<T> describedType();
+
+    /**
+     * Describe the given value as a dynamic constant, or return an empty result if this particular
+     * value cannot be represented as one.
+     */
+    Optional<DynamicConstantDesc<T>> describe(T value);
+}

--- a/rhino/src/main/java/org/mozilla/classfile/DynamicConstantDescriber.java
+++ b/rhino/src/main/java/org/mozilla/classfile/DynamicConstantDescriber.java
@@ -7,7 +7,6 @@
 package org.mozilla.classfile;
 
 import java.lang.constant.DynamicConstantDesc;
-import java.util.Optional;
 
 /**
  * Turns values of a particular type into the {@code CONSTANT_Dynamic} description that {@link
@@ -23,9 +22,6 @@ public interface DynamicConstantDescriber<T extends DynamicConstant> {
     /** The type of value this describer handles. Used as the registration key. */
     Class<T> describedType();
 
-    /**
-     * Describe the given value as a dynamic constant, or return an empty result if this particular
-     * value cannot be represented as one.
-     */
-    Optional<DynamicConstantDesc<T>> describe(T value);
+    /** Describe the given value as a dynamic constant. */
+    DynamicConstantDesc<T> describe(T value);
 }

--- a/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
+++ b/rhino/src/main/java/org/mozilla/javascript/EagerSourceCodeProvider.java
@@ -1,10 +1,12 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
+import org.mozilla.classfile.DynamicConstant;
 
 /** Stores a reference to the original source code and returns it as necessary. */
-public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable {
+public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable, DynamicConstant {
     private static final long serialVersionUID = 1L;
     private final String rawSource;
 
@@ -21,5 +23,16 @@ public class EagerSourceCodeProvider implements SourceCodeProvider, Serializable
     @Override
     public String getRawSource() {
         return rawSource;
+    }
+
+    /**
+     * Bootstrap method for the dynamic constant described by {@link
+     * org.mozilla.javascript.optimizer.EagerSourceCodeProviderDescriber}. The raw source is a
+     * bootstrap argument rather than the constant name, since a name may not contain the "[" and
+     * ";" characters that ordinary JavaScript source is full of.
+     */
+    public static EagerSourceCodeProvider sourceConstant(
+            MethodHandles.Lookup lookup, String name, Class<?> type, String rawSource) {
+        return new EagerSourceCodeProvider(rawSource);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/RegExpProxy.java
@@ -6,6 +6,9 @@
 
 package org.mozilla.javascript;
 
+import java.util.List;
+import org.mozilla.classfile.DynamicConstantDescriber;
+
 /**
  * A proxy for the regexp package, so that the regexp package can be loaded optionally.
  *
@@ -23,6 +26,33 @@ public interface RegExpProxy {
     public boolean isRegExp(Scriptable obj);
 
     public Object compileRegExp(Context cx, String source, String flags);
+
+    /**
+     * Compile a regexp literal that the caller intends to write to a class file as a {@code
+     * CONSTANT_Dynamic} entry, rather than to compile again on every run.
+     *
+     * <p>Anything wrong with the expression must be reported here, because the class file records
+     * only a description of the compiled form: whatever recreates it when the constant is resolved
+     * is not in a position to report an error against the script being compiled.
+     *
+     * @return a value that one of the {@link #getDynamicConstantDescribers describers} of this
+     *     proxy can describe, or null if this implementation has no constant form, in which case
+     *     the caller falls back to compiling the expression at run time.
+     */
+    default Object prepareRegExpConstant(Context cx, String source, String flags) {
+        return null;
+    }
+
+    /**
+     * Describers for the values this proxy returns from {@link #prepareRegExpConstant}, to be
+     * registered with the class file writer that will write them.
+     *
+     * <p>An implementation that returns describers here must also implement {@code
+     * prepareRegExpConstant}, and one that does not must return an empty list.
+     */
+    default List<DynamicConstantDescriber<?>> getDynamicConstantDescribers() {
+        return List.of();
+    }
 
     public Scriptable wrapRegExp(Context cx, VarScope scope, Object compiled);
 

--- a/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SymbolKey.java
@@ -4,13 +4,15 @@ import static org.mozilla.javascript.Symbol.Kind.BUILT_IN;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import org.mozilla.classfile.DynamicConstant;
 
 /**
  * A SymbolKey is one of the implementations of Symbol. It is really there so that we can easily use
  * pre-defined symbols as keys in native code. A SymbolKey has the special property that two
  * NativeSymbol objects with the same key are equal.
  */
-public class SymbolKey implements Symbol, Serializable {
+public class SymbolKey implements Symbol, Serializable, DynamicConstant {
     @Serial private static final long serialVersionUID = -6019782713330994754L;
 
     // These are common SymbolKeys that are equivalent to well-known symbols
@@ -80,5 +82,10 @@ public class SymbolKey implements Symbol, Serializable {
             return "Symbol()";
         }
         return "Symbol(" + name + ')';
+    }
+
+    public static SymbolKey symbolConstant(
+            MethodHandles.Lookup lookup, String name, Class<?> type, int dedupHash) {
+        return new SymbolKey(name, Kind.REGULAR);
     }
 }

--- a/rhino/src/main/java/org/mozilla/javascript/Undefined.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Undefined.java
@@ -8,6 +8,8 @@ package org.mozilla.javascript;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import org.mozilla.classfile.DynamicConstant;
 
 /**
  * This class implements the Undefined value in JavaScript.
@@ -19,20 +21,26 @@ import java.io.Serializable;
  * <p>Java code that needs to test whether something is undefined <b>must</b> use the "isUndefined"
  * method because of the multiple internal representations.
  */
-public class Undefined implements Serializable {
+public class Undefined implements Serializable, DynamicConstant {
     @Serial private static final long serialVersionUID = 9195680630202616767L;
 
     /**
      * This is the standard value for "undefined" in Rhino. Java code that needs to represent
      * "undefined" should use this object (rather than a new instance of this class).
      */
-    public static final Object instance = new Undefined();
+    public static final Undefined instance = new Undefined();
 
     private static final int instanceHash = System.identityHashCode(instance);
 
     private Undefined() {}
 
     public Object readResolve() {
+        return instance;
+    }
+
+    /** Bootstrap method used by {@code UndefinedDescriber} to resolve a dynamic constant. */
+    public static Undefined undefinedConstant(
+            MethodHandles.Lookup lookup, String name, Class<?> type) {
         return instance;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -1209,7 +1209,7 @@ class BodyCodegen {
                     if (constant != null) {
                         cfw.addLoadDynamicConstant(constant);
                     } else {
-                        throw new IllegalStateException("null rgexp constant.");
+                        throw new IllegalStateException("null regexp constant.");
                     }
                     cfw.addInvoke(
                             ByteCode.INVOKESTATIC,

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/BodyCodegen.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.classfile.DynamicConstant;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Kit;
@@ -1204,11 +1205,12 @@ class BodyCodegen {
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
                     int i = node.getExistingIntProp(Node.REGEXP_PROP);
-                    cfw.add(
-                            ByteCode.GETSTATIC,
-                            codegen.mainClassName,
-                            codegen.getCompiledRegexpName(scriptOrFn, i),
-                            "Ljava/lang/Object;");
+                    DynamicConstant constant = codegen.getRegExpConstant(scriptOrFn, i);
+                    if (constant != null) {
+                        cfw.addLoadDynamicConstant(constant);
+                    } else {
+                        throw new IllegalStateException("null rgexp constant.");
+                    }
                     cfw.addInvoke(
                             ByteCode.INVOKESTATIC,
                             "org/mozilla/javascript/ScriptRuntime",

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.EagerSourceCodeProvider;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSCode;
 import org.mozilla.javascript.JSDescriptor;
@@ -198,6 +199,7 @@ public class ClassCompiler {
         var mainName = mainClassName + "Main";
 
         var cfw = new ClassFileWriter(mainName, "java.lang.Object", "");
+        cfw.registerDynamicConstantDescriber(new EagerSourceCodeProviderDescriber());
         var builders = new ArrayList<JSDescriptor.Builder<?>>();
         buildDescriptor(cfw, builder, builder, classes, builders, mainClassName);
         cfw.startMethod("<clinit>", "()V", ACC_STATIC);
@@ -313,14 +315,8 @@ public class ClassCompiler {
         cfw.add(builder.hasRestArg ? ByteCode.ICONST_1 : ByteCode.ICONST_0);
         cfw.addLoadConstant(builder.sourceFile);
         if (compilerEnv.isGeneratingSource()) {
-            cfw.add(ByteCode.NEW, "org.mozilla.javascript.EagerSourceCodeProvider");
-            cfw.add(ByteCode.DUP);
-            cfw.addLoadConstant(root.sourceCodeProvider.getRawSource());
-            cfw.addInvoke(
-                    ByteCode.INVOKESPECIAL,
-                    "org.mozilla.javascript.EagerSourceCodeProvider",
-                    "<init>",
-                    "(Ljava/lang/String;)V");
+            cfw.addLoadDynamicConstant(
+                    new EagerSourceCodeProvider(root.sourceCodeProvider.getRawSource()));
         } else {
             cfw.add(ByteCode.ACONST_NULL);
         }

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
 import org.mozilla.javascript.EagerSourceCodeProvider;
 import org.mozilla.javascript.IRFactory;
 import org.mozilla.javascript.JSCode;
@@ -25,6 +26,7 @@ import org.mozilla.javascript.JavaAdapter;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.SourceCodeProvider;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -122,70 +124,72 @@ public class ClassCompiler {
      */
     public Object[] compileToClassFiles(
             String source, String sourceLocation, int lineno, String mainClassName) {
-        Parser p = new Parser(compilerEnv);
-        AstRoot ast = p.parse(source, sourceLocation, lineno);
-        IRFactory irf = new IRFactory(compilerEnv, source);
-        ScriptNode tree = irf.transformTree(ast);
+        try (Context cx = Context.enter()) {
+            cx.setLanguageVersion(compilerEnv.getLanguageVersion());
+            var global = ScriptRuntime.initSafeStandardObjects(cx, null, false);
+            Parser p = new Parser(compilerEnv);
+            AstRoot ast = p.parse(source, sourceLocation, lineno);
+            IRFactory irf = new IRFactory(compilerEnv, source);
+            ScriptNode tree = irf.transformTree(ast);
 
-        if (compilerEnv.isGeneratingSource()) {
-            tree.setRawSource(source);
-            tree.setRawSourceBounds(0, source.length());
-            compilerEnv.setSourceCodeProvider(SourceCodeProvider.make(true, null, source));
-        }
+            if (compilerEnv.isGeneratingSource()) {
+                tree.setRawSource(source);
+                tree.setRawSourceBounds(0, source.length());
+                compilerEnv.setSourceCodeProvider(SourceCodeProvider.make(true, null, source));
+            }
 
-        // release reference to original parse tree & parser
-        irf = null;
-        ast = null;
-        p = null;
+            // release reference to original parse tree & parser
+            irf = null;
+            ast = null;
+            p = null;
 
-        Class<?> superClass = getTargetExtends();
-        Class<?>[] interfaces = getTargetImplements();
-        String scriptClassName;
-        boolean isPrimary = (interfaces == null && superClass == null);
-        if (isPrimary) {
-            scriptClassName = mainClassName;
-        } else {
-            scriptClassName = makeAuxiliaryClassName(mainClassName, "1");
-        }
+            Class<?> superClass = getTargetExtends();
+            Class<?>[] interfaces = getTargetImplements();
+            String scriptClassName;
+            boolean isPrimary = (interfaces == null && superClass == null);
+            if (isPrimary) {
+                scriptClassName = mainClassName;
+            } else {
+                scriptClassName = makeAuxiliaryClassName(mainClassName, "1");
+            }
 
-        Codegen codegen = new Codegen();
-        codegen.setMainMethodClass(mainMethodClassName);
-        JSDescriptor.Builder<?> builder = new JSDescriptor.Builder<>();
-        MHJSCode.BuilderEnv builderEnv = new MHJSCode.BuilderEnv(scriptClassName);
-        byte[] scriptClassBytes =
-                codegen.compileToClassFile(
-                        compilerEnv, builder, builderEnv, scriptClassName, tree, source, false);
-        Object[] auxilaryClasses = buildDescriptorsAndMain(scriptClassName, builder);
-        if (isPrimary) {
-            var result = new Object[auxilaryClasses.length + 2];
-            System.arraycopy(auxilaryClasses, 0, result, 2, auxilaryClasses.length);
-            result[0] = scriptClassName;
-            result[1] = scriptClassBytes;
+            Codegen codegen = new Codegen();
+            codegen.setMainMethodClass(mainMethodClassName);
+            JSDescriptor.Builder<?> builder = new JSDescriptor.Builder<>();
+            MHJSCode.BuilderEnv builderEnv = new MHJSCode.BuilderEnv(scriptClassName);
+            byte[] scriptClassBytes = codegen.compileToClassFile(
+                    compilerEnv, builder, builderEnv, scriptClassName, tree, source, false);
+            Object[] auxilaryClasses = buildDescriptorsAndMain(scriptClassName, builder);
+            if (isPrimary) {
+                var result = new Object[auxilaryClasses.length + 2];
+                System.arraycopy(auxilaryClasses, 0, result, 2, auxilaryClasses.length);
+                result[0] = scriptClassName;
+                result[1] = scriptClassBytes;
+                return result;
+            }
+            int functionCount = tree.getFunctionCount();
+            HashMap<String, Integer> functionNames = new HashMap<>();
+            for (int i = 0; i != functionCount; ++i) {
+                FunctionNode ofn = tree.getFunctionNode(i);
+                String name = ofn.getName();
+                if (name != null && name.length() != 0) {
+                    functionNames.put(name, ofn.getParamCount());
+                }
+            }
+            if (superClass == null) {
+                superClass = ScriptRuntime.ObjectClass;
+            }
+            byte[] mainClassBytes = JavaAdapter.createAdapterCode(
+                    functionNames, mainClassName, superClass, interfaces, scriptClassName);
+
+            var result = new Object[auxilaryClasses.length + 4];
+            System.arraycopy(auxilaryClasses, 0, result, 4, auxilaryClasses.length);
+            result[0] = mainClassName;
+            result[1] = mainClassBytes;
+            result[2] = scriptClassName;
+            result[3] = scriptClassBytes;
             return result;
         }
-        int functionCount = tree.getFunctionCount();
-        HashMap<String, Integer> functionNames = new HashMap<>();
-        for (int i = 0; i != functionCount; ++i) {
-            FunctionNode ofn = tree.getFunctionNode(i);
-            String name = ofn.getName();
-            if (name != null && name.length() != 0) {
-                functionNames.put(name, ofn.getParamCount());
-            }
-        }
-        if (superClass == null) {
-            superClass = ScriptRuntime.ObjectClass;
-        }
-        byte[] mainClassBytes =
-                JavaAdapter.createAdapterCode(
-                        functionNames, mainClassName, superClass, interfaces, scriptClassName);
-
-        var result = new Object[auxilaryClasses.length + 4];
-        System.arraycopy(auxilaryClasses, 0, result, 4, auxilaryClasses.length);
-        result[0] = mainClassName;
-        result[1] = mainClassBytes;
-        result[2] = scriptClassName;
-        result[3] = scriptClassBytes;
-        return result;
     }
 
     /**

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/ClassCompiler.java
@@ -26,7 +26,6 @@ import org.mozilla.javascript.JavaAdapter;
 import org.mozilla.javascript.Parser;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.SourceCodeProvider;
-import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -157,9 +156,11 @@ public class ClassCompiler {
             codegen.setMainMethodClass(mainMethodClassName);
             JSDescriptor.Builder<?> builder = new JSDescriptor.Builder<>();
             MHJSCode.BuilderEnv builderEnv = new MHJSCode.BuilderEnv(scriptClassName);
-            byte[] scriptClassBytes = codegen.compileToClassFile(
-                    compilerEnv, builder, builderEnv, scriptClassName, tree, source, false);
-            Object[] auxilaryClasses = buildDescriptorsAndMain(scriptClassName, builder);
+            byte[] scriptClassBytes =
+                    codegen.compileToClassFile(
+                            compilerEnv, builder, builderEnv, scriptClassName, tree, source, false);
+            Object[] auxilaryClasses =
+                    buildDescriptorsAndMain(scriptClassName, builderEnv, builder);
             if (isPrimary) {
                 var result = new Object[auxilaryClasses.length + 2];
                 System.arraycopy(auxilaryClasses, 0, result, 2, auxilaryClasses.length);
@@ -179,8 +180,9 @@ public class ClassCompiler {
             if (superClass == null) {
                 superClass = ScriptRuntime.ObjectClass;
             }
-            byte[] mainClassBytes = JavaAdapter.createAdapterCode(
-                    functionNames, mainClassName, superClass, interfaces, scriptClassName);
+            byte[] mainClassBytes =
+                    JavaAdapter.createAdapterCode(
+                            functionNames, mainClassName, superClass, interfaces, scriptClassName);
 
             var result = new Object[auxilaryClasses.length + 4];
             System.arraycopy(auxilaryClasses, 0, result, 4, auxilaryClasses.length);
@@ -198,7 +200,7 @@ public class ClassCompiler {
      * first descriptor and pass that to the main method in the runtime.
      */
     private Object[] buildDescriptorsAndMain(
-            String mainClassName, JSDescriptor.Builder<?> builder) {
+            String mainClassName, MHJSCode.BuilderEnv builderEnv, JSDescriptor.Builder<?> builder) {
         var classes = new HashMap<String, byte[]>();
         var mainName = mainClassName + "Main";
 
@@ -207,6 +209,13 @@ public class ClassCompiler {
         var builders = new ArrayList<JSDescriptor.Builder<?>>();
         buildDescriptor(cfw, builder, builder, classes, builders, mainClassName);
         cfw.startMethod("<clinit>", "()V", ACC_STATIC);
+        if (builderEnv.hasTemplateLiterals) {
+            cfw.addInvoke(
+                    ByteCode.INVOKESTATIC,
+                    mainClassName,
+                    Codegen.TEMPLATE_LITERAL_INIT_METHOD_NAME,
+                    Codegen.TEMPLATE_LITERAL_INIT_METHOD_SIGNATURE);
+        }
         cfw.addLoadConstant(builders.size());
         cfw.add(ByteCode.ANEWARRAY, "org/mozilla/javascript/JSDescriptor");
         for (var b : builders) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -350,10 +350,16 @@ public class Codegen implements Evaluator {
                                 ? "org.mozilla.javascript.optimizer.OptJSFunctionCode"
                                 : "org.mozilla.javascript.optimizer.OptJSScriptCode",
                         sourceFile);
+        installConstantDescribers(cfw);
         generateOptJSCodeCtor(cfw, isFunction);
         generateOptJSCodeExecute(cfw, mainClass, methodName, methodType);
         generateOptJSCodeResume(cfw, mainClass, resumeName, GENERATOR_METHOD_SIGNATURE);
         return cfw.toByteArray();
+    }
+
+    /** Teach a writer about the runtime types that can be emitted as dynamic constants. */
+    private static void installConstantDescribers(ClassFileWriter cfw) {
+        cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
     }
 
     private static void generateOptJSCodeCtor(ClassFileWriter cfw, boolean isFunction) {
@@ -411,6 +417,7 @@ public class Codegen implements Evaluator {
 
         String sourceFile = scriptOrFnNodes[0].getSourceName();
         ClassFileWriter cfw = new ClassFileWriter(mainClassName, SUPER_CLASS_NAME, sourceFile);
+        installConstantDescribers(cfw);
         cfw.addField(ID_FIELD_NAME, "I", ACC_PRIVATE);
         cfw.addField(
                 DESCRIPTORS_FIELD_NAME,

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -365,6 +365,7 @@ public class Codegen implements Evaluator {
     /** Teach a writer about the runtime types that can be emitted as dynamic constants. */
     private static void installConstantDescribers(ClassFileWriter cfw) {
         cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
+        cfw.registerDynamicConstantDescriber(new EagerSourceCodeProviderDescriber());
     }
 
     private static void generateOptJSCodeCtor(ClassFileWriter cfw, boolean isFunction) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -181,10 +181,6 @@ public class Codegen implements Evaluator {
             var descs = new ArrayList<JSDescriptor<?>>();
             JSDescriptor<T> desc = compiled.builder.build(d -> descs.add(d));
             cl.getField(DESCRIPTORS_FIELD_NAME).set(null, descs.toArray(new JSDescriptor[0]));
-            if (compiled.builderEnv.hasRegExpLiterals) {
-                cl.getMethod(REGEXP_INIT_METHOD_NAME, Context.class)
-                        .invoke(null, Context.getCurrentContext());
-            }
             if (compiled.builderEnv.hasTemplateLiterals) {
                 cl.getMethod(TEMPLATE_LITERAL_INIT_METHOD_NAME).invoke(null);
             }
@@ -626,9 +622,7 @@ public class Codegen implements Evaluator {
      *
      * <p>Preparing them here is what lets the constants be resolved later without a context: the
      * regexp implementation reports anything wrong with an expression now, while there is still a
-     * script being compiled to report it against. If the implementation has no constant form, or
-     * there is no implementation at all, nothing is prepared and the literals are compiled when the
-     * class is defined by {@link #emitRegExpInit} instead.
+     * script being compiled to report it against.
      */
     private void prepareRegExpConstants(ClassFileWriter cfw, MHJSCode.BuilderEnv builderEnv) {
         if (!builderEnv.hasRegExpLiterals) {
@@ -637,7 +631,8 @@ public class Codegen implements Evaluator {
         Context cx = Context.getCurrentContext();
         RegExpProxy proxy = cx == null ? null : ScriptRuntime.getRegExpProxy(cx);
         if (proxy == null) {
-            return;
+            throw new IllegalStateException(
+                    "Compilation of regexps literals requires an enclosing context.");
         }
 
         DynamicConstant[][] constants = new DynamicConstant[scriptOrFnNodes.length][];
@@ -976,7 +971,6 @@ public class Codegen implements Evaluator {
     static final String DESCRIPTORS_FIELD_NAME = "_descriptors";
     static final String DESCRIPTORS_FIELD_SIGNATURE = "[" + DESCRIPTOR_CLASS_SIGNATURE;
 
-    static final String REGEXP_INIT_METHOD_NAME = "_reInit";
     static final String REGEXP_INIT_METHOD_SIGNATURE = "(Lorg/mozilla/javascript/Context;)V";
 
     static final String TEMPLATE_LITERAL_INIT_METHOD_NAME = "_qInit";

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -351,10 +351,16 @@ public class Codegen implements Evaluator {
                                 ? "org.mozilla.javascript.optimizer.OptJSFunctionCode"
                                 : "org.mozilla.javascript.optimizer.OptJSScriptCode",
                         sourceFile);
+        installConstantDescribers(cfw);
         generateOptJSCodeCtor(cfw, isFunction);
         generateOptJSCodeExecute(cfw, mainClass, methodName, methodType);
         generateOptJSCodeResume(cfw, mainClass, resumeName, GENERATOR_METHOD_SIGNATURE);
         return cfw.toByteArray();
+    }
+
+    /** Teach a writer about the runtime types that can be emitted as dynamic constants. */
+    private static void installConstantDescribers(ClassFileWriter cfw) {
+        cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
     }
 
     private static void generateOptJSCodeCtor(ClassFileWriter cfw, boolean isFunction) {
@@ -412,6 +418,7 @@ public class Codegen implements Evaluator {
 
         String sourceFile = scriptOrFnNodes[0].getSourceName();
         ClassFileWriter cfw = new ClassFileWriter(mainClassName, SUPER_CLASS_NAME, sourceFile);
+        installConstantDescribers(cfw);
         cfw.addField(ID_FIELD_NAME, "I", ACC_PRIVATE);
         cfw.addField(
                 DESCRIPTORS_FIELD_NAME,

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -39,6 +39,7 @@ import org.mozilla.javascript.ScriptOrFn;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.SecurityController;
 import org.mozilla.javascript.Token;
+import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.VarScope;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Name;
@@ -366,6 +367,7 @@ public class Codegen implements Evaluator {
     private static void installConstantDescribers(ClassFileWriter cfw) {
         cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
         cfw.registerDynamicConstantDescriber(new EagerSourceCodeProviderDescriber());
+        cfw.registerDynamicConstantDescriber(new UndefinedDescriber());
     }
 
     private static void generateOptJSCodeCtor(ClassFileWriter cfw, boolean isFunction) {
@@ -864,11 +866,7 @@ public class Codegen implements Evaluator {
     }
 
     static void pushUndefined(ClassFileWriter cfw) {
-        cfw.add(
-                ByteCode.GETSTATIC,
-                "org/mozilla/javascript/Undefined",
-                "instance",
-                "Ljava/lang/Object;");
+        cfw.addLoadDynamicConstant(Undefined.instance);
     }
 
     int getIndex(ScriptNode n) {

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.classfile.DynamicConstant;
+import org.mozilla.classfile.DynamicConstantDescriber;
 import org.mozilla.javascript.CodeGenUtils;
 import org.mozilla.javascript.CompilationResult;
 import org.mozilla.javascript.CompilerEnvirons;
@@ -30,9 +32,11 @@ import org.mozilla.javascript.GeneratedClassLoader;
 import org.mozilla.javascript.JSDescriptor;
 import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.JSScript;
+import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Script;
 import org.mozilla.javascript.ScriptOrFn;
+import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.SecurityController;
 import org.mozilla.javascript.Token;
 import org.mozilla.javascript.VarScope;
@@ -229,7 +233,7 @@ public class Codegen implements Evaluator {
 
         initScriptNodesData(scriptOrFn, builder, builderEnv);
 
-        return generateCode(rawSource);
+        return generateCode(rawSource, builderEnv);
     }
 
     private void transform(ScriptNode tree) {
@@ -411,7 +415,7 @@ public class Codegen implements Evaluator {
         // 5: this, cx, js function, new.target, scope, js this, args[]
     }
 
-    private byte[] generateCode(String rawSource) {
+    private byte[] generateCode(String rawSource, MHJSCode.BuilderEnv builderEnv) {
         boolean hasScript = (scriptOrFnNodes[0].getType() == Token.SCRIPT);
         boolean hasFunctions = (scriptOrFnNodes.length > 1 || !hasScript);
         boolean isStrictMode = scriptOrFnNodes[0].isInStrictMode();
@@ -419,6 +423,7 @@ public class Codegen implements Evaluator {
         String sourceFile = scriptOrFnNodes[0].getSourceName();
         ClassFileWriter cfw = new ClassFileWriter(mainClassName, SUPER_CLASS_NAME, sourceFile);
         installConstantDescribers(cfw);
+        prepareRegExpConstants(cfw, builderEnv);
         cfw.addField(ID_FIELD_NAME, "I", ACC_PRIVATE);
         cfw.addField(
                 DESCRIPTORS_FIELD_NAME,
@@ -459,7 +464,6 @@ public class Codegen implements Evaluator {
             }
         }
 
-        emitRegExpInit(cfw);
         emitTemplateLiteralInit(cfw);
         emitConstantDudeInitializers(cfw);
 
@@ -613,71 +617,54 @@ public class Codegen implements Evaluator {
         cfw.stopMethod(0);
     }
 
-    private void emitRegExpInit(ClassFileWriter cfw) {
-        // precompile all regexp literals
-
-        int totalRegCount = 0;
-        for (int i = 0; i != scriptOrFnNodes.length; ++i) {
-            totalRegCount += scriptOrFnNodes[i].getRegexpCount();
+    /**
+     * Compile the regexp literals ahead of time so that they can be written to the class file as
+     * dynamic constants, and register the describers that will write them.
+     *
+     * <p>Preparing them here is what lets the constants be resolved later without a context: the
+     * regexp implementation reports anything wrong with an expression now, while there is still a
+     * script being compiled to report it against. If the implementation has no constant form, or
+     * there is no implementation at all, nothing is prepared and the literals are compiled when the
+     * class is defined by {@link #emitRegExpInit} instead.
+     */
+    private void prepareRegExpConstants(ClassFileWriter cfw, MHJSCode.BuilderEnv builderEnv) {
+        if (!builderEnv.hasRegExpLiterals) {
+            return;
         }
-        if (totalRegCount == 0) {
+        Context cx = Context.getCurrentContext();
+        RegExpProxy proxy = cx == null ? null : ScriptRuntime.getRegExpProxy(cx);
+        if (proxy == null) {
             return;
         }
 
-        cfw.startMethod(
-                REGEXP_INIT_METHOD_NAME,
-                REGEXP_INIT_METHOD_SIGNATURE,
-                (short) (ACC_STATIC | ACC_PUBLIC));
-        cfw.addField("_reInitDone", "Z", (short) (ACC_STATIC | ACC_PRIVATE | ACC_VOLATILE));
-        cfw.add(ByteCode.GETSTATIC, mainClassName, "_reInitDone", "Z");
-        int doInit = cfw.acquireLabel();
-        cfw.add(ByteCode.IFEQ, doInit);
-        cfw.add(ByteCode.RETURN);
-        cfw.markLabel(doInit);
-
-        // get regexp proxy and store it in local slot 1
-        cfw.addALoad(0); // context
-        cfw.addInvoke(
-                ByteCode.INVOKESTATIC,
-                "org/mozilla/javascript/ScriptRuntime",
-                "checkRegExpProxy",
-                "(Lorg/mozilla/javascript/Context;" + ")Lorg/mozilla/javascript/RegExpProxy;");
-        cfw.addAStore(1); // proxy
-
-        // We could apply double-checked locking here but concurrency
-        // shouldn't be a problem in practice
+        DynamicConstant[][] constants = new DynamicConstant[scriptOrFnNodes.length][];
         for (int i = 0; i != scriptOrFnNodes.length; ++i) {
             ScriptNode n = scriptOrFnNodes[i];
             int regCount = n.getRegexpCount();
+            constants[i] = new DynamicConstant[regCount];
             for (int j = 0; j != regCount; ++j) {
-                String reFieldName = getCompiledRegexpName(n, j);
-                String reFieldType = "Ljava/lang/Object;";
-                String reString = n.getRegexpString(j);
-                String reFlags = n.getRegexpFlags(j);
-                cfw.addField(reFieldName, reFieldType, (short) (ACC_STATIC | ACC_PRIVATE));
-                cfw.addALoad(1); // proxy
-                cfw.addALoad(0); // context
-                cfw.addPush(reString);
-                if (reFlags == null) {
-                    cfw.add(ByteCode.ACONST_NULL);
-                } else {
-                    cfw.addPush(reFlags);
+                Object constant =
+                        proxy.prepareRegExpConstant(cx, n.getRegexpString(j), n.getRegexpFlags(j));
+                if (!(constant instanceof DynamicConstant)) {
+                    // This implementation has no constant form, so compile every literal of this
+                    // class at run time rather than mixing the two ways of doing it.
+                    return;
                 }
-                cfw.addInvoke(
-                        ByteCode.INVOKEINTERFACE,
-                        "org/mozilla/javascript/RegExpProxy",
-                        "compileRegExp",
-                        "(Lorg/mozilla/javascript/Context;"
-                                + "Ljava/lang/String;Ljava/lang/String;"
-                                + ")Ljava/lang/Object;");
-                cfw.add(ByteCode.PUTSTATIC, mainClassName, reFieldName, reFieldType);
+                constants[i][j] = (DynamicConstant) constant;
             }
         }
 
-        cfw.addPush(1);
-        cfw.add(ByteCode.PUTSTATIC, mainClassName, "_reInitDone", "Z");
-        cfw.add(ByteCode.RETURN);
-        cfw.stopMethod(2);
+        for (DynamicConstantDescriber<?> describer : proxy.getDynamicConstantDescribers()) {
+            cfw.registerDynamicConstantDescriber(describer);
+        }
+        regExpConstants = constants;
+        // With the literals in the constant pool there is nothing left to initialize.
+        builderEnv.hasRegExpLiterals = false;
+    }
+
+    /** The prepared constant for a regexp literal, or null if it is compiled at run time. */
+    DynamicConstant getRegExpConstant(ScriptNode n, int regexpIndex) {
+        return regExpConstants == null ? null : regExpConstants[getIndex(n)][regexpIndex];
     }
 
     /**
@@ -1035,6 +1022,12 @@ public class Codegen implements Evaluator {
 
     String mainClassName;
     String mainClassSignature;
+
+    /**
+     * The prepared form of every regexp literal, indexed as {@link #scriptOrFnNodes} is and then by
+     * the index of the literal, or null when the literals are compiled at run time instead.
+     */
+    private DynamicConstant[][] regExpConstants;
 
     private double[] itsConstantList;
     private int itsConstantListSize;

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/EagerSourceCodeProviderDescriber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/EagerSourceCodeProviderDescriber.java
@@ -1,0 +1,47 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.optimizer;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import org.mozilla.classfile.DynamicConstantDescriber;
+import org.mozilla.javascript.EagerSourceCodeProvider;
+
+/**
+ * Describes {@link EagerSourceCodeProvider} as a dynamic constant that is reconstructed from its
+ * raw source when the constant is first resolved.
+ *
+ * <p>The source cannot be carried in the constant's name, because a name may not be empty and may
+ * not contain the "[" and ";" characters that ordinary JavaScript source is full of. The source is
+ * therefore a bootstrap argument, and the name is a fixed placeholder.
+ */
+public class EagerSourceCodeProviderDescriber
+        implements DynamicConstantDescriber<EagerSourceCodeProvider> {
+
+    private static final ClassDesc CD_EAGER_SOURCE_CODE_PROVIDER =
+            ClassDesc.of(EagerSourceCodeProvider.class.getName());
+
+    private static final DirectMethodHandleDesc SOURCE_CONSTANT =
+            ConstantDescs.ofConstantBootstrap(
+                    CD_EAGER_SOURCE_CODE_PROVIDER,
+                    "sourceConstant",
+                    CD_EAGER_SOURCE_CODE_PROVIDER,
+                    ConstantDescs.CD_String);
+
+    @Override
+    public Class<EagerSourceCodeProvider> describedType() {
+        return EagerSourceCodeProvider.class;
+    }
+
+    @Override
+    public DynamicConstantDesc<EagerSourceCodeProvider> describe(EagerSourceCodeProvider value) {
+        return DynamicConstantDesc.ofNamed(
+                SOURCE_CONSTANT, "source", CD_EAGER_SOURCE_CODE_PROVIDER, value.getRawSource());
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/SymbolKeyDescriber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/SymbolKeyDescriber.java
@@ -14,9 +14,8 @@ import java.lang.constant.DirectMethodHandleDesc;
 import java.lang.constant.DynamicConstantDesc;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-import java.util.IdentityHashMap;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.mozilla.classfile.DynamicConstantDescriber;
 import org.mozilla.javascript.SymbolKey;
 
@@ -48,25 +47,23 @@ public class SymbolKeyDescriber implements DynamicConstantDescriber<SymbolKey> {
     }
 
     @Override
-    public Optional<DynamicConstantDesc<SymbolKey>> describe(SymbolKey value) {
+    public DynamicConstantDesc<SymbolKey> describe(SymbolKey value) {
         return switch (value.getKind()) {
             case BUILT_IN ->
-                    WellKnownFields.NAMES.get(value) == null
-                            ? Optional.empty()
-                            : Optional.of(
-                                    DynamicConstantDesc.ofNamed(
-                                            ConstantDescs.BSM_GET_STATIC_FINAL,
-                                            WellKnownFields.NAMES.get(value),
-                                            CD_SYMBOL_KEY,
-                                            CD_SYMBOL_KEY));
+                    DynamicConstantDesc.ofNamed(
+                            ConstantDescs.BSM_GET_STATIC_FINAL,
+                            WellKnownFields.NAMES.get(value),
+                            CD_SYMBOL_KEY,
+                            CD_SYMBOL_KEY);
             case REGULAR ->
-                    Optional.of(
-                            DynamicConstantDesc.ofNamed(
-                                    SYMBOL_REGULAR,
-                                    value.getName(),
-                                    CD_SYMBOL_KEY,
-                                    Integer.valueOf(System.identityHashCode(value))));
-            default -> Optional.empty();
+                    DynamicConstantDesc.ofNamed(
+                            SYMBOL_REGULAR,
+                            value.getName(),
+                            CD_SYMBOL_KEY,
+                            Integer.valueOf(System.identityHashCode(value)));
+            default -> {
+                throw new IllegalStateException("Symbol descriptor could not be generated");
+            }
         };
     }
 
@@ -79,7 +76,7 @@ public class SymbolKeyDescriber implements DynamicConstantDescriber<SymbolKey> {
         static final Map<SymbolKey, String> NAMES = scan();
 
         private static Map<SymbolKey, String> scan() {
-            Map<SymbolKey, String> names = new IdentityHashMap<>();
+            var names = new HashMap<SymbolKey, String>();
             for (Field field : SymbolKey.class.getDeclaredFields()) {
                 int modifiers = field.getModifiers();
                 if (field.getType() == SymbolKey.class

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/SymbolKeyDescriber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/SymbolKeyDescriber.java
@@ -1,0 +1,99 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.optimizer;
+
+import static org.mozilla.javascript.Symbol.Kind.BUILT_IN;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.mozilla.classfile.DynamicConstantDescriber;
+import org.mozilla.javascript.SymbolKey;
+
+/**
+ * Describes symbols as dynamic constants that resolve to the static fields of {@link SymbolKey}.
+ *
+ * <p>Because SymbolKey compares by identity, we need to include an additional parameter based on
+ * identify hash to avoid different symbols with the same name being accidentally conflated.
+ *
+ * <p>Symbols of any other kind are not describable: one created by {@code Symbol()} has an identity
+ * that cannot be reconstructed, and a registered symbol from {@code Symbol.for} must be looked up
+ * in the global registry rather than baked into a class file.
+ *
+ * <p>This lives alongside the rest of the bytecode back end rather than in SymbolKey itself, so
+ * that runtimes without bytecode generation support never have to resolve {@code
+ * java.lang.constant}.
+ */
+public class SymbolKeyDescriber implements DynamicConstantDescriber<SymbolKey> {
+
+    private static final ClassDesc CD_SYMBOL_KEY = ClassDesc.of(SymbolKey.class.getName());
+
+    private static final DirectMethodHandleDesc SYMBOL_REGULAR =
+            ConstantDescs.ofConstantBootstrap(
+                    CD_SYMBOL_KEY, "symbolConstant", CD_SYMBOL_KEY, ConstantDescs.CD_int);
+
+    @Override
+    public Class<SymbolKey> describedType() {
+        return SymbolKey.class;
+    }
+
+    @Override
+    public Optional<DynamicConstantDesc<SymbolKey>> describe(SymbolKey value) {
+        return switch (value.getKind()) {
+            case BUILT_IN ->
+                    WellKnownFields.NAMES.get(value) == null
+                            ? Optional.empty()
+                            : Optional.of(
+                                    DynamicConstantDesc.ofNamed(
+                                            ConstantDescs.BSM_GET_STATIC_FINAL,
+                                            WellKnownFields.NAMES.get(value),
+                                            CD_SYMBOL_KEY,
+                                            CD_SYMBOL_KEY));
+            case REGULAR ->
+                    Optional.of(
+                            DynamicConstantDesc.ofNamed(
+                                    SYMBOL_REGULAR,
+                                    value.getName(),
+                                    CD_SYMBOL_KEY,
+                                    Integer.valueOf(System.identityHashCode(value))));
+            default -> Optional.empty();
+        };
+    }
+
+    /**
+     * Maps each well-known symbol to the name of the SymbolKey field holding it. The field names
+     * differ from the symbol names, and scanning for them means a newly added well-known symbol
+     * becomes describable without anything here having to be updated.
+     */
+    private static final class WellKnownFields {
+        static final Map<SymbolKey, String> NAMES = scan();
+
+        private static Map<SymbolKey, String> scan() {
+            Map<SymbolKey, String> names = new IdentityHashMap<>();
+            for (Field field : SymbolKey.class.getDeclaredFields()) {
+                int modifiers = field.getModifiers();
+                if (field.getType() == SymbolKey.class
+                        && Modifier.isPublic(modifiers)
+                        && Modifier.isStatic(modifiers)
+                        && Modifier.isFinal(modifiers)) {
+                    try {
+                        names.put((SymbolKey) field.get(null), field.getName());
+                    } catch (IllegalAccessException iae) {
+                        throw new IllegalStateException(iae);
+                    }
+                }
+            }
+            return names;
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/UndefinedDescriber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/UndefinedDescriber.java
@@ -1,0 +1,36 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.optimizer;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import org.mozilla.classfile.DynamicConstantDescriber;
+import org.mozilla.javascript.Undefined;
+
+/**
+ * Describes {@link Undefined} as a dynamic constant that resolves to the canonical {@link
+ * Undefined#instance}.
+ */
+public class UndefinedDescriber implements DynamicConstantDescriber<Undefined> {
+
+    private static final ClassDesc CD_UNDEFINED = ClassDesc.of(Undefined.class.getName());
+
+    private static final DirectMethodHandleDesc UNDEFINED_CONSTANT =
+            ConstantDescs.ofConstantBootstrap(CD_UNDEFINED, "undefinedConstant", CD_UNDEFINED);
+
+    @Override
+    public Class<Undefined> describedType() {
+        return Undefined.class;
+    }
+
+    @Override
+    public DynamicConstantDesc<Undefined> describe(Undefined value) {
+        return DynamicConstantDesc.ofNamed(UNDEFINED_CONSTANT, "undefined", CD_UNDEFINED);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/NativeRegExp.java
@@ -11,6 +11,7 @@ import static org.mozilla.javascript.ClassDescriptor.Destination.PROTO;
 
 import java.io.Serial;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -18,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.function.IntPredicate;
+import org.mozilla.classfile.DynamicConstant;
 import org.mozilla.javascript.AbstractEcmaObjectOperations;
 import org.mozilla.javascript.AbstractEcmaStringOperations;
 import org.mozilla.javascript.AbstractEcmaStringOperations.ReplacementOperation;
@@ -869,6 +871,13 @@ public class NativeRegExp extends ScriptableObject {
         }
     }
 
+    /**
+     * Compile a regular expression.
+     *
+     * @param cx the current context, or null to compile without one. A null context skips the
+     *     language version check on the "u" flag and suppresses warnings, and is only appropriate
+     *     when the expression has already been compiled successfully with a real context.
+     */
     static RECompiled compileRE(Context cx, String str, String global, boolean flat) {
         RECompiled regexp = new RECompiled(str);
         int length = str.length();
@@ -900,7 +909,9 @@ public class NativeRegExp extends ScriptableObject {
         }
 
         // We support unicode mode in ES6 and later.
-        if ((flags & JSREG_UNICODE) != 0 && cx.getLanguageVersion() < Context.VERSION_ES6) {
+        if (cx != null
+                && (flags & JSREG_UNICODE) != 0
+                && cx.getLanguageVersion() < Context.VERSION_ES6) {
             reportError("msg.invalid.re.flag", "u");
         }
 
@@ -1014,6 +1025,20 @@ public class NativeRegExp extends ScriptableObject {
             }
         }
         return regexp;
+    }
+
+    /**
+     * Bootstrap method for a regexp literal written to a class file as a {@code CONSTANT_Dynamic}
+     * entry by {@link RECompiledDescriber}.
+     *
+     * <p>Resolution must not depend on the context that happens to be current, so this compiles
+     * without one. That is safe because {@link RegExpImpl#prepareRegExpConstant} has already
+     * compiled the same source and flags with a real context, and so has reported anything that
+     * could go wrong.
+     */
+    public static Object regExpConstant(
+            MethodHandles.Lookup lookup, String name, Class<?> type, String source, String flags) {
+        return compileRE(null, source, flags, false);
     }
 
     static boolean isDigit(char c) {
@@ -4277,7 +4302,7 @@ public class NativeRegExp extends ScriptableObject {
     }
 
     private static void reportWarning(Context cx, String messageId, String arg) {
-        if (cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
+        if (cx != null && cx.hasFeature(Context.FEATURE_STRICT_MODE)) {
             String msg = ScriptRuntime.getMessageById(messageId, arg);
             Context.reportWarning(msg);
         }
@@ -4991,7 +5016,7 @@ public class NativeRegExp extends ScriptableObject {
     private int lastIndexAttr = DONTENUM | PERMANENT;
 } // class NativeRegExp
 
-class RECompiled implements Serializable {
+class RECompiled implements Serializable, DynamicConstant {
     @Serial private static final long serialVersionUID = -6144956577595844213L;
 
     final char[] source; /* locked source string, sans // */

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RECompiledDescriber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RECompiledDescriber.java
@@ -1,0 +1,71 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.regexp;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import org.mozilla.classfile.DynamicConstantDescriber;
+
+/**
+ * Describes compiled regular expressions as dynamic constants that are recompiled from their source
+ * and flags when the constant is first resolved.
+ *
+ * <p>The described value is not the one that will exist at run time: it is a compiled form produced
+ * by {@link RegExpImpl#prepareRegExpConstant}, which this reads the source and flags back out of.
+ * Compiling it up front is what lets {@link NativeRegExp#regExpConstant} resolve the constant
+ * without a context, since anything wrong with the expression has already been reported.
+ *
+ * <p>The source cannot be carried in the constant's name, because a name may not be empty and may
+ * not contain the "[" and ";" characters that appear in ordinary regular expressions. Both the
+ * source and the flags are therefore bootstrap arguments, and the name is a fixed placeholder.
+ */
+public class RECompiledDescriber implements DynamicConstantDescriber<RECompiled> {
+
+    private static final ClassDesc CD_NATIVE_REG_EXP = ClassDesc.of(NativeRegExp.class.getName());
+
+    private static final DirectMethodHandleDesc REGEXP_CONSTANT =
+            ConstantDescs.ofConstantBootstrap(
+                    CD_NATIVE_REG_EXP,
+                    "regExpConstant",
+                    ConstantDescs.CD_Object,
+                    ConstantDescs.CD_String,
+                    ConstantDescs.CD_String);
+
+    @Override
+    public Class<RECompiled> describedType() {
+        return RECompiled.class;
+    }
+
+    @Override
+    public DynamicConstantDesc<RECompiled> describe(RECompiled value) {
+        return DynamicConstantDesc.ofNamed(
+                REGEXP_CONSTANT,
+                "regexp",
+                // The compiled form is package private, so the constant is typed as an object,
+                // which is also what everything consuming it expects.
+                ConstantDescs.CD_Object,
+                new String(value.source),
+                flagsToString(value.flags));
+    }
+
+    /**
+     * The flags in a canonical order, so that literals written with the same flags in a different
+     * order share a constant.
+     */
+    private static String flagsToString(int flags) {
+        var buf = new StringBuilder(6);
+        if ((flags & NativeRegExp.JSREG_GLOB) != 0) buf.append('g');
+        if ((flags & NativeRegExp.JSREG_FOLD) != 0) buf.append('i');
+        if ((flags & NativeRegExp.JSREG_MULTILINE) != 0) buf.append('m');
+        if ((flags & NativeRegExp.JSREG_DOTALL) != 0) buf.append('s');
+        if ((flags & NativeRegExp.JSREG_STICKY) != 0) buf.append('y');
+        if ((flags & NativeRegExp.JSREG_UNICODE) != 0) buf.append('u');
+        return buf.toString();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
+++ b/rhino/src/main/java/org/mozilla/javascript/regexp/RegExpImpl.java
@@ -6,6 +6,8 @@
 
 package org.mozilla.javascript.regexp;
 
+import java.util.List;
+import org.mozilla.classfile.DynamicConstantDescriber;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.Kit;
@@ -35,6 +37,16 @@ public class RegExpImpl implements RegExpProxy {
     @Override
     public Object compileRegExp(Context cx, String source, String flags) {
         return NativeRegExp.compileRE(cx, source, flags, false);
+    }
+
+    @Override
+    public Object prepareRegExpConstant(Context cx, String source, String flags) {
+        return NativeRegExp.compileRE(cx, source, flags, false);
+    }
+
+    @Override
+    public List<DynamicConstantDescriber<?>> getDynamicConstantDescribers() {
+        return List.of(new RECompiledDescriber());
     }
 
     @Override

--- a/rhino/src/test/java/org/mozilla/javascript/tests/ClassCompilerTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/ClassCompilerTest.java
@@ -9,29 +9,87 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import org.junit.jupiter.api.Test;
+import java.util.Collection;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mozilla.javascript.CompilerEnvirons;
 import org.mozilla.javascript.DefiningClassLoader;
 import org.mozilla.javascript.optimizer.ClassCompiler;
 
 public class ClassCompilerTest {
-    private static String SOURCE =
-            "function f(str) { return (s) => (str + s); }\n"
-                    + "\n"
-                    + "function g() {\n"
-                    + "    function h() {\n"
-                    + "        function i() {\n"
-                    + "        }\n"
-                    + "    }\n"
-                    + "}\n"
-                    + "\n"
-                    + "java.lang.System.out.println(f('hi, ')('mom!'));\n";
+    public static Collection<Object[]> testSources() {
+        var res = new ArrayList<Object[]>();
+        res.add(
+                new Object[] {
+                    """
+                function f(str) { return (s) => (str + s); }
 
-    @Test
-    public void testClassesCompile() {
+                function g() {
+                  function h() {
+                    function i() {
+                    }
+                  }
+                }
+
+                java.lang.System.out.println(f('hi, ')('mom!'));
+                """
+                });
+        res.add(
+                new Object[] {
+                    """
+                function f(str) { return (s) => (str.replaceAll(/i/g, 'ello'), + s); }
+
+                function g() {
+                  function h() {
+                    function i() {
+                    }
+                  }
+                }
+
+                java.lang.System.out.println(f('hi, ')('mom!'));
+                """
+                });
+        res.add(
+                new Object[] {
+                    """
+                function f(str) { return (s) => (`${str}${s}`); }
+
+                function g() {
+                  function h() {
+                    function i() {
+                    }
+                  }
+                }
+
+                java.lang.System.out.println(f('hi, ')('mom!'));
+                """
+                });
+        res.add(
+                new Object[] {
+                    """
+                function f(str) { return (s) => (greeting`${str}, ${s}`); }
+                function greeting(strings, greet, person) {
+                  return greet + strings[1] + person;
+                }
+                function g() {
+                  function h() {
+                    function i() {
+                    }
+                  }
+                }
+
+                java.lang.System.out.println(f('hi')('mom!'));
+                """
+                });
+        return res;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSources")
+    public void testClassesCompile(String source) {
         var compilerEnv = new CompilerEnvirons();
         ClassCompiler compiler = new ClassCompiler(compilerEnv);
-        var result = compiler.compileToClassFiles(SOURCE, "test", 0, "test");
+        var result = compiler.compileToClassFiles(source, "test", 0, "test");
         assertTrue(result.length > 0, "Expected > 0 entries in result array");
         assertTrue(result.length % 2 == 0, "Expected even number of results");
         boolean foundMain = false;
@@ -49,11 +107,12 @@ public class ClassCompilerTest {
         assertTrue(foundMain, "Expected an entry for our main class");
     }
 
-    @Test
-    public void testClassesLoadAndLink() {
+    @ParameterizedTest
+    @MethodSource("testSources")
+    public void testClassesLoadAndLink(String source) {
         var compilerEnv = new CompilerEnvirons();
         ClassCompiler compiler = new ClassCompiler(compilerEnv);
-        var result = compiler.compileToClassFiles(SOURCE, "test", 0, "test");
+        var result = compiler.compileToClassFiles(source, "test", 0, "test");
         var loader = new DefiningClassLoader();
 
         var classes = new ArrayList<Class<?>>();
@@ -68,12 +127,13 @@ public class ClassCompilerTest {
         }
     }
 
-    @Test
-    public void testMainMethodExecutesWithoutError()
+    @ParameterizedTest
+    @MethodSource("testSources")
+    public void testMainMethodExecutesWithoutError(String source)
             throws IllegalAccessException, InvocationTargetException {
         var compilerEnv = new CompilerEnvirons();
         ClassCompiler compiler = new ClassCompiler(compilerEnv);
-        var result = compiler.compileToClassFiles(SOURCE, "test", 0, "test");
+        var result = compiler.compileToClassFiles(source, "test", 0, "test");
         var loader = new DefiningClassLoader();
 
         var classes = new ArrayList<Class<?>>();

--- a/rhino/src/test/java/org/mozilla/javascript/tests/RegExpConstantTest.java
+++ b/rhino/src/test/java/org/mozilla/javascript/tests/RegExpConstantTest.java
@@ -1,0 +1,140 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.CompilerEnvirons;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.DefiningClassLoader;
+import org.mozilla.javascript.optimizer.ClassCompiler;
+import org.mozilla.javascript.testutils.Utils;
+
+/**
+ * Regexp literals are written to generated class files as dynamic constants, rather than compiled
+ * into static fields when the class is defined.
+ */
+public class RegExpConstantTest {
+
+    @Test
+    public void literalsMatch() {
+        Utils.assertWithAllModes_ES6("bar", "'foobarbaz'.match(/b.r/)[0]");
+        Utils.assertWithAllModes_ES6(true, "/a[bc];/.test('xab;y')");
+        Utils.assertWithAllModes_ES6("BAR", "'fooBARbaz'.match(/b[a-z]r/i)[0]");
+        Utils.assertWithAllModes_ES6("b", "/(?<letter>b)/.exec('abc').groups.letter");
+    }
+
+    @Test
+    public void repeatedLiteralsKeepSeparateState() {
+        // The two literals share a compiled form, but each evaluation must produce a regexp with a
+        // "lastIndex" of its own.
+        Utils.assertWithAllModes_ES6(
+                "0|2",
+                "var a = /b/g, b = /b/g;\n"
+                        + "a.exec('abcbd');\n"
+                        + "'' + b.lastIndex + '|' + a.lastIndex");
+    }
+
+    @Test
+    public void literalIsANewObjectEachTimeItIsEvaluated() {
+        Utils.assertWithAllModes_ES6(
+                false,
+                "var previous = null, same = true;\n"
+                        + "for (var i = 0; i < 2; i++) {\n"
+                        + "  var re = /x/;\n"
+                        + "  if (previous !== null) same = (previous === re);\n"
+                        + "  previous = re;\n"
+                        + "}\n"
+                        + "same");
+    }
+
+    @Test
+    public void literalsInFunctionsMatch() {
+        Utils.assertWithAllModes_ES6(
+                "a|b",
+                "function f() { return 'xax'.match(/a/)[0]; }\n"
+                        + "function g() { return 'xbx'.match(/b/)[0]; }\n"
+                        + "f() + '|' + g()");
+    }
+
+    @Test
+    public void invalidLiteralIsRejected() {
+        // Compiled, this is reported while the constant is prepared, which is the whole reason
+        // resolving it later can do without a context to report against.
+        Utils.assertEcmaErrorES6(
+                "SyntaxError: Invalid regular expression: The quantifier maximum '1' is less than"
+                        + " the minimum '2'.",
+                "var re = /a{2,1}/;");
+    }
+
+    @Test
+    public void generatedClassHasNoRegExpInitializer() {
+        Class<?> script = compileAndDefine("var re = /a[bc];/g; re.source").get(0);
+
+        for (Method method : script.getDeclaredMethods()) {
+            assertFalse(
+                    method.getName().startsWith("_reInit"),
+                    "the literal should be a constant rather than something initialized when the"
+                            + " class is defined, but found "
+                            + method.getName());
+        }
+        for (Field field : script.getDeclaredFields()) {
+            assertFalse(
+                    field.getName().startsWith("_re"),
+                    "the literal should be a constant rather than a field, but found "
+                            + field.getName());
+        }
+    }
+
+    @Test
+    public void aheadOfTimeCompiledLiteralRuns() throws Exception {
+        // The script throws if the regexp does not work, and its constants resolve here, on a
+        // thread with no context of its own and long after the class was compiled.
+        var classes =
+                compileAndDefine(
+                        "if ('foobarbaz'.match(/b(.)r/i)[1] !== 'a') throw new Error('no match');");
+
+        Method main = null;
+        for (var cl : classes) {
+            try {
+                main = cl.getMethod("main", String[].class);
+            } catch (NoSuchMethodException e) {
+                // Only the generated main class has one.
+            }
+        }
+        assertNotNull(main, "expected a main method");
+        main.invoke(null, (Object) new String[0]);
+    }
+
+    /**
+     * Compile a script the way the class compiler tool does and define the result, with the script
+     * class itself first.
+     */
+    private static ArrayList<Class<?>> compileAndDefine(String source) {
+        Object[] compiled;
+        try (Context cx = Context.enter()) {
+            CompilerEnvirons env = new CompilerEnvirons();
+            env.initFromContext(cx);
+            compiled = new ClassCompiler(env).compileToClassFiles(source, "test.js", 1, "test");
+        }
+
+        var loader = new DefiningClassLoader();
+        var classes = new ArrayList<Class<?>>();
+        for (int i = 0; i != compiled.length; i += 2) {
+            classes.add(loader.defineClass((String) compiled[i], (byte[]) compiled[i + 1]));
+        }
+        for (var cl : classes) {
+            loader.linkClass(cl);
+        }
+        return classes;
+    }
+}

--- a/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
+++ b/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
@@ -1,0 +1,482 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.classfile.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mozilla.classfile.ClassFileWriter.ACC_PUBLIC;
+import static org.mozilla.classfile.ClassFileWriter.ACC_STATIC;
+import static org.mozilla.javascript.Symbol.Kind.REGULAR;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.DirectMethodHandleDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.mozilla.classfile.ByteCode;
+import org.mozilla.classfile.ClassFileWriter;
+import org.mozilla.classfile.DynamicConstant;
+import org.mozilla.classfile.DynamicConstantDescriber;
+import org.mozilla.javascript.DefiningClassLoader;
+import org.mozilla.javascript.Symbol;
+import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.optimizer.SymbolKeyDescriber;
+
+public class DynamicConstantTest {
+
+    private static final ClassDesc CD_SELF = ClassDesc.of(DynamicConstantTest.class.getName());
+
+    // ---------------------------------------------------------------- constants under test
+
+    /** A constant resolved by {@link #stringBootstrap}, carrying its value in the constant name. */
+    public static class StringConstant implements DynamicConstant {
+        final String value;
+
+        StringConstant(String value) {
+            this.value = value;
+        }
+    }
+
+    /** A two word constant, so that the "ldc2_w" path is exercised. */
+    public static class LongConstant implements DynamicConstant {
+        final long value;
+
+        LongConstant(long value) {
+            this.value = value;
+        }
+    }
+
+    /** A constant whose describer takes a MethodType static argument. */
+    public static class MethodTypeConstant implements DynamicConstant {}
+
+    /** A constant that no describer can describe. */
+    public static class UndescribableConstant implements DynamicConstant {}
+
+    // ---------------------------------------------------------------- bootstrap methods
+
+    public static String stringBootstrap(MethodHandles.Lookup lookup, String name, Class<?> type) {
+        return "resolved:" + name;
+    }
+
+    public static long longBootstrap(MethodHandles.Lookup lookup, String name, Class<?> type) {
+        return Long.parseLong(name);
+    }
+
+    public static String methodTypeBootstrap(
+            MethodHandles.Lookup lookup, String name, Class<?> type, MethodType methodType) {
+        return methodType.toString();
+    }
+
+    private static DirectMethodHandleDesc bootstrap(String name, MethodTypeDesc type) {
+        return MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_SELF, name, type);
+    }
+
+    // ---------------------------------------------------------------- describers
+
+    private static final DynamicConstantDescriber<StringConstant> STRING_DESCRIBER =
+            new DynamicConstantDescriber<>() {
+                @Override
+                public Class<StringConstant> describedType() {
+                    return StringConstant.class;
+                }
+
+                @Override
+                public Optional<DynamicConstantDesc<StringConstant>> describe(
+                        StringConstant value) {
+                    return Optional.of(
+                            DynamicConstantDesc.ofNamed(
+                                    bootstrap(
+                                            "stringBootstrap",
+                                            MethodTypeDesc.of(
+                                                    ConstantDescs.CD_String,
+                                                    ConstantDescs.CD_MethodHandles_Lookup,
+                                                    ConstantDescs.CD_String,
+                                                    ConstantDescs.CD_Class)),
+                                    value.value,
+                                    ConstantDescs.CD_String));
+                }
+            };
+
+    private static final DynamicConstantDescriber<LongConstant> LONG_DESCRIBER =
+            new DynamicConstantDescriber<>() {
+                @Override
+                public Class<LongConstant> describedType() {
+                    return LongConstant.class;
+                }
+
+                @Override
+                public Optional<DynamicConstantDesc<LongConstant>> describe(LongConstant value) {
+                    return Optional.of(
+                            DynamicConstantDesc.ofNamed(
+                                    bootstrap(
+                                            "longBootstrap",
+                                            MethodTypeDesc.of(
+                                                    ConstantDescs.CD_long,
+                                                    ConstantDescs.CD_MethodHandles_Lookup,
+                                                    ConstantDescs.CD_String,
+                                                    ConstantDescs.CD_Class)),
+                                    Long.toString(value.value),
+                                    ConstantDescs.CD_long));
+                }
+            };
+
+    private static final MethodTypeDesc DESCRIBED_METHOD_TYPE =
+            MethodTypeDesc.of(ConstantDescs.CD_int, ConstantDescs.CD_String, ConstantDescs.CD_long);
+
+    private static final DynamicConstantDescriber<MethodTypeConstant> METHOD_TYPE_DESCRIBER =
+            new DynamicConstantDescriber<>() {
+                @Override
+                public Class<MethodTypeConstant> describedType() {
+                    return MethodTypeConstant.class;
+                }
+
+                @Override
+                public Optional<DynamicConstantDesc<MethodTypeConstant>> describe(
+                        MethodTypeConstant value) {
+                    return Optional.of(
+                            DynamicConstantDesc.ofNamed(
+                                    bootstrap(
+                                            "methodTypeBootstrap",
+                                            MethodTypeDesc.of(
+                                                    ConstantDescs.CD_String,
+                                                    ConstantDescs.CD_MethodHandles_Lookup,
+                                                    ConstantDescs.CD_String,
+                                                    ConstantDescs.CD_Class,
+                                                    ConstantDescs.CD_MethodType)),
+                                    "unused",
+                                    ConstantDescs.CD_String,
+                                    DESCRIBED_METHOD_TYPE));
+                }
+            };
+
+    private static final DynamicConstantDescriber<UndescribableConstant> EMPTY_DESCRIBER =
+            new DynamicConstantDescriber<>() {
+                @Override
+                public Class<UndescribableConstant> describedType() {
+                    return UndescribableConstant.class;
+                }
+
+                @Override
+                public Optional<DynamicConstantDesc<UndescribableConstant>> describe(
+                        UndescribableConstant value) {
+                    return Optional.empty();
+                }
+            };
+
+    // ---------------------------------------------------------------- tests
+
+    @Test
+    public void wellKnownSymbolResolvesToTheCanonicalInstance() throws Exception {
+        // SymbolKey compares by identity, so the constant has to be the very same object the
+        // runtime uses, not merely an equal one.
+        ClassFileWriter cfw = writer("TestSymbolConstant");
+        cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(SymbolKey.ITERATOR);
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        assertSame(SymbolKey.ITERATOR, invoke(cfw, "TestSymbolConstant", "get"));
+    }
+
+    @Test
+    public void regularSymbolResolvesToSymbolWithSameName() throws Exception {
+        // SymbolKey compares by identity, so the constant has to be the very same object the
+        // runtime uses, not merely an equal one.
+        ClassFileWriter cfw = writer("TestSymbolConstant");
+        cfw.registerDynamicConstantDescriber(new SymbolKeyDescriber());
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new SymbolKey("foo", REGULAR));
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        assertEquals("foo", ((SymbolKey) invoke(cfw, "TestSymbolConstant", "get")).getName());
+    }
+
+    @Test
+    public void constantTypeFlowsIntoTheStackMapTable() throws Exception {
+        // The branch forces a stack map frame while the dynamic constant is still on the stack,
+        // which only works if the writer can derive its type from the constant pool entry.
+        ClassFileWriter cfw = writer("TestConstantStackMap");
+        cfw.registerDynamicConstantDescriber(STRING_DESCRIBER);
+        cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new StringConstant("branched"));
+        cfw.add(ByteCode.DUP);
+        int target = cfw.acquireLabel();
+        cfw.add(ByteCode.IFNULL, target);
+        cfw.markLabel(target);
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        assertEquals("resolved:branched", invoke(cfw, "TestConstantStackMap", "get"));
+    }
+
+    @Test
+    public void twoWordConstantUsesLdc2w() throws Exception {
+        // A long constant must be loaded with ldc2_w and must occupy two stack words in the
+        // frame generated at the branch target.
+        ClassFileWriter cfw = writer("TestLongConstant");
+        cfw.registerDynamicConstantDescriber(LONG_DESCRIBER);
+        cfw.startMethod("get", "()J", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new LongConstant(1234567890123L));
+        cfw.add(ByteCode.DUP2);
+        cfw.add(ByteCode.LCONST_0);
+        cfw.add(ByteCode.LCMP);
+        int target = cfw.acquireLabel();
+        cfw.add(ByteCode.IFEQ, target);
+        cfw.markLabel(target);
+        cfw.add(ByteCode.LRETURN);
+        cfw.stopMethod((short) 0);
+
+        byte[] bytecode = cfw.toByteArray();
+        assertEquals(1234567890123L, invoke(bytecode, "TestLongConstant", "get"));
+        assertEquals(1, ClassFileInfo.parse(bytecode).count(TAG_DYNAMIC));
+    }
+
+    @Test
+    public void methodTypeStaticArgument() throws Exception {
+        ClassFileWriter cfw = writer("TestMethodTypeArg");
+        cfw.registerDynamicConstantDescriber(METHOD_TYPE_DESCRIBER);
+        cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new MethodTypeConstant());
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        byte[] bytecode = cfw.toByteArray();
+        assertEquals(
+                MethodType.fromMethodDescriptorString(
+                                DESCRIBED_METHOD_TYPE.descriptorString(),
+                                getClass().getClassLoader())
+                        .toString(),
+                invoke(bytecode, "TestMethodTypeArg", "get"));
+        assertEquals(1, ClassFileInfo.parse(bytecode).count(TAG_METHOD_TYPE));
+    }
+
+    @Test
+    public void repeatedConstantsAreShared() throws Exception {
+        ClassFileWriter cfw = writer("TestSharedConstants");
+        cfw.registerDynamicConstantDescriber(STRING_DESCRIBER);
+        cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new StringConstant("same"));
+        cfw.add(ByteCode.POP);
+        cfw.addLoadDynamicConstant(new StringConstant("same"));
+        cfw.add(ByteCode.POP);
+        // A distinct constant sharing the same bootstrap method.
+        cfw.addLoadDynamicConstant(new StringConstant("other"));
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        byte[] bytecode = cfw.toByteArray();
+        ClassFileInfo info = ClassFileInfo.parse(bytecode);
+        assertEquals(2, info.count(TAG_DYNAMIC), "equal constants should share a pool entry");
+        assertEquals(1, info.bootstrapMethodCount, "one bootstrap method should be shared");
+        assertEquals("resolved:other", invoke(bytecode, "TestSharedConstants", "get"));
+    }
+
+    @Test
+    public void unregisteredTypeIsRejected() {
+        ClassFileWriter cfw = writer("TestUnregistered");
+        cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
+
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> cfw.addLoadDynamicConstant(new StringConstant("x")));
+        assertTrue(e.getMessage().contains("no dynamic constant describer"), e.getMessage());
+    }
+
+    @Test
+    public void undescribableValueIsRejected() {
+        ClassFileWriter cfw = writer("TestUndescribable");
+        cfw.registerDynamicConstantDescriber(EMPTY_DESCRIBER);
+        cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
+
+        IllegalArgumentException e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> cfw.addLoadDynamicConstant(new UndescribableConstant()));
+        assertTrue(e.getMessage().contains("cannot be described"), e.getMessage());
+    }
+
+    @Test
+    public void regularSymbolsAreDescribable() {
+        SymbolKeyDescriber describer = new SymbolKeyDescriber();
+
+        assertTrue(describer.describe(SymbolKey.ITERATOR).isPresent());
+        assertTrue(describer.describe(SymbolKey.TO_PRIMITIVE).isPresent());
+        // A symbol from "Symbol()" has an identity that cannot be reconstructed, and one from
+        // "Symbol.for" belongs to the global registry.
+        assertTrue(describer.describe(new SymbolKey("regular", Symbol.Kind.REGULAR)).isPresent());
+        assertTrue(
+                describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)).isEmpty());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static ClassFileWriter writer(String className) {
+        return new ClassFileWriter(className, "java/lang/Object", "DynamicConstantTest.java");
+    }
+
+    private static Object invoke(ClassFileWriter cfw, String className, String methodName)
+            throws Exception {
+        return invoke(cfw.toByteArray(), className, methodName);
+    }
+
+    private static Object invoke(byte[] bytecode, String className, String methodName)
+            throws Exception {
+        // Defining the class runs the verifier, which is what checks the StackMapTable we wrote.
+        DefiningClassLoader loader = new DefiningClassLoader();
+        Class<?> cl = loader.defineClass(className, bytecode);
+        Method method = cl.getMethod(methodName);
+        return method.invoke(null);
+    }
+
+    private static final int TAG_UTF8 = 1;
+    private static final int TAG_LONG = 5;
+    private static final int TAG_DOUBLE = 6;
+    private static final int TAG_METHOD_HANDLE = 15;
+    private static final int TAG_METHOD_TYPE = 16;
+    private static final int TAG_DYNAMIC = 17;
+
+    /**
+     * Just enough of a class file reader to count constant pool entries and bootstrap methods. The
+     * JVM checks that what we wrote is loadable; these counts check that we did not write more than
+     * we needed to.
+     */
+    private static final class ClassFileInfo {
+        private final int[] tagCounts = new int[21];
+        private int bootstrapMethodCount;
+
+        int count(int tag) {
+            return tagCounts[tag];
+        }
+
+        static ClassFileInfo parse(byte[] data) {
+            ClassFileInfo info = new ClassFileInfo();
+            int pos = 8; // magic, minor, major
+            int poolCount = u2(data, pos);
+            pos += 2;
+            // Constant pool indices start at 1, and long and double entries take two of them.
+            for (int index = 1; index < poolCount; index++) {
+                int tag = data[pos++] & 0xFF;
+                info.tagCounts[tag]++;
+                switch (tag) {
+                    case TAG_UTF8:
+                        pos += 2 + u2(data, pos);
+                        break;
+                    case TAG_LONG:
+                    case TAG_DOUBLE:
+                        pos += 8;
+                        index++;
+                        break;
+                    case TAG_METHOD_HANDLE:
+                        pos += 3;
+                        break;
+                    case TAG_METHOD_TYPE:
+                        pos += 2;
+                        break;
+                    default:
+                        pos += entrySize(tag);
+                        break;
+                }
+            }
+            pos += 6; // access flags, this class, super class
+            pos += 2 + u2(data, pos) * 2; // interfaces
+            pos = skipMembers(data, pos); // fields
+            pos = skipMembers(data, pos); // methods
+            int attributeCount = u2(data, pos);
+            pos += 2;
+            for (int i = 0; i < attributeCount; i++) {
+                int length = (int) u4(data, pos + 2);
+                if ("BootstrapMethods".equals(utf8At(data, u2(data, pos)))) {
+                    // The attribute payload begins with num_bootstrap_methods.
+                    info.bootstrapMethodCount = u2(data, pos + 6);
+                }
+                pos += 6 + length;
+            }
+            return info;
+        }
+
+        /** Resolve a Utf8 pool entry by index, used to identify attributes by name. */
+        private static String utf8At(byte[] data, int wantedIndex) {
+            int pos = 10;
+            int poolCount = u2(data, 8);
+            for (int index = 1; index < poolCount; index++) {
+                int tag = data[pos++] & 0xFF;
+                if (tag == TAG_UTF8) {
+                    int length = u2(data, pos);
+                    if (index == wantedIndex) {
+                        return new String(
+                                data, pos + 2, length, java.nio.charset.StandardCharsets.UTF_8);
+                    }
+                    pos += 2 + length;
+                } else if (tag == TAG_LONG || tag == TAG_DOUBLE) {
+                    pos += 8;
+                    index++;
+                } else if (tag == TAG_METHOD_HANDLE) {
+                    pos += 3;
+                } else if (tag == TAG_METHOD_TYPE) {
+                    pos += 2;
+                } else {
+                    pos += entrySize(tag);
+                }
+            }
+            return null;
+        }
+
+        private static int skipMembers(byte[] data, int pos) {
+            int count = u2(data, pos);
+            pos += 2;
+            for (int i = 0; i < count; i++) {
+                pos += 6; // access flags, name, descriptor
+                int attributeCount = u2(data, pos);
+                pos += 2;
+                for (int a = 0; a < attributeCount; a++) {
+                    pos += 6 + (int) u4(data, pos + 2);
+                }
+            }
+            return pos;
+        }
+
+        private static int entrySize(int tag) {
+            switch (tag) {
+                case 7: // Class
+                case 8: // String
+                case 19: // Module
+                case 20: // Package
+                    return 2;
+                case 3: // Integer
+                case 4: // Float
+                case 9: // Fieldref
+                case 10: // Methodref
+                case 11: // InterfaceMethodref
+                case 12: // NameAndType
+                case 17: // Dynamic
+                case 18: // InvokeDynamic
+                    return 4;
+                default:
+                    throw new IllegalStateException("unexpected constant pool tag " + tag);
+            }
+        }
+
+        private static int u2(byte[] data, int pos) {
+            return ((data[pos] & 0xFF) << 8) | (data[pos + 1] & 0xFF);
+        }
+
+        private static long u4(byte[] data, int pos) {
+            return ((long) u2(data, pos) << 16) | u2(data, pos + 2);
+        }
+    }
+}

--- a/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
+++ b/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
@@ -7,6 +7,7 @@
 package org.mozilla.classfile.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,7 +24,6 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
@@ -93,19 +93,17 @@ public class DynamicConstantTest {
                 }
 
                 @Override
-                public Optional<DynamicConstantDesc<StringConstant>> describe(
-                        StringConstant value) {
-                    return Optional.of(
-                            DynamicConstantDesc.ofNamed(
-                                    bootstrap(
-                                            "stringBootstrap",
-                                            MethodTypeDesc.of(
-                                                    ConstantDescs.CD_String,
-                                                    ConstantDescs.CD_MethodHandles_Lookup,
-                                                    ConstantDescs.CD_String,
-                                                    ConstantDescs.CD_Class)),
-                                    value.value,
-                                    ConstantDescs.CD_String));
+                public DynamicConstantDesc<StringConstant> describe(StringConstant value) {
+                    return DynamicConstantDesc.ofNamed(
+                            bootstrap(
+                                    "stringBootstrap",
+                                    MethodTypeDesc.of(
+                                            ConstantDescs.CD_String,
+                                            ConstantDescs.CD_MethodHandles_Lookup,
+                                            ConstantDescs.CD_String,
+                                            ConstantDescs.CD_Class)),
+                            value.value,
+                            ConstantDescs.CD_String);
                 }
             };
 
@@ -117,18 +115,17 @@ public class DynamicConstantTest {
                 }
 
                 @Override
-                public Optional<DynamicConstantDesc<LongConstant>> describe(LongConstant value) {
-                    return Optional.of(
-                            DynamicConstantDesc.ofNamed(
-                                    bootstrap(
-                                            "longBootstrap",
-                                            MethodTypeDesc.of(
-                                                    ConstantDescs.CD_long,
-                                                    ConstantDescs.CD_MethodHandles_Lookup,
-                                                    ConstantDescs.CD_String,
-                                                    ConstantDescs.CD_Class)),
-                                    Long.toString(value.value),
-                                    ConstantDescs.CD_long));
+                public DynamicConstantDesc<LongConstant> describe(LongConstant value) {
+                    return DynamicConstantDesc.ofNamed(
+                            bootstrap(
+                                    "longBootstrap",
+                                    MethodTypeDesc.of(
+                                            ConstantDescs.CD_long,
+                                            ConstantDescs.CD_MethodHandles_Lookup,
+                                            ConstantDescs.CD_String,
+                                            ConstantDescs.CD_Class)),
+                            Long.toString(value.value),
+                            ConstantDescs.CD_long);
                 }
             };
 
@@ -143,21 +140,19 @@ public class DynamicConstantTest {
                 }
 
                 @Override
-                public Optional<DynamicConstantDesc<MethodTypeConstant>> describe(
-                        MethodTypeConstant value) {
-                    return Optional.of(
-                            DynamicConstantDesc.ofNamed(
-                                    bootstrap(
-                                            "methodTypeBootstrap",
-                                            MethodTypeDesc.of(
-                                                    ConstantDescs.CD_String,
-                                                    ConstantDescs.CD_MethodHandles_Lookup,
-                                                    ConstantDescs.CD_String,
-                                                    ConstantDescs.CD_Class,
-                                                    ConstantDescs.CD_MethodType)),
-                                    "unused",
-                                    ConstantDescs.CD_String,
-                                    DESCRIBED_METHOD_TYPE));
+                public DynamicConstantDesc<MethodTypeConstant> describe(MethodTypeConstant value) {
+                    return DynamicConstantDesc.ofNamed(
+                            bootstrap(
+                                    "methodTypeBootstrap",
+                                    MethodTypeDesc.of(
+                                            ConstantDescs.CD_String,
+                                            ConstantDescs.CD_MethodHandles_Lookup,
+                                            ConstantDescs.CD_String,
+                                            ConstantDescs.CD_Class,
+                                            ConstantDescs.CD_MethodType)),
+                            "unused",
+                            ConstantDescs.CD_String,
+                            DESCRIBED_METHOD_TYPE);
                 }
             };
 
@@ -169,9 +164,9 @@ public class DynamicConstantTest {
                 }
 
                 @Override
-                public Optional<DynamicConstantDesc<UndescribableConstant>> describe(
+                public DynamicConstantDesc<UndescribableConstant> describe(
                         UndescribableConstant value) {
-                    return Optional.empty();
+                    throw new IllegalStateException("");
                 }
             };
 
@@ -303,24 +298,23 @@ public class DynamicConstantTest {
         cfw.registerDynamicConstantDescriber(EMPTY_DESCRIBER);
         cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
 
-        IllegalArgumentException e =
-                assertThrows(
-                        IllegalArgumentException.class,
-                        () -> cfw.addLoadDynamicConstant(new UndescribableConstant()));
-        assertTrue(e.getMessage().contains("cannot be described"), e.getMessage());
+        assertThrows(
+            IllegalStateException.class,
+            () -> cfw.addLoadDynamicConstant(new UndescribableConstant()));
     }
 
     @Test
     public void regularSymbolsAreDescribable() {
         SymbolKeyDescriber describer = new SymbolKeyDescriber();
 
-        assertTrue(describer.describe(SymbolKey.ITERATOR).isPresent());
-        assertTrue(describer.describe(SymbolKey.TO_PRIMITIVE).isPresent());
+        assertNotNull(describer.describe(SymbolKey.ITERATOR));
+        assertNotNull(describer.describe(SymbolKey.TO_PRIMITIVE));
         // A symbol from "Symbol()" has an identity that cannot be reconstructed, and one from
         // "Symbol.for" belongs to the global registry.
-        assertTrue(describer.describe(new SymbolKey("regular", Symbol.Kind.REGULAR)).isPresent());
-        assertTrue(
-                describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)).isEmpty());
+        assertNotNull(describer.describe(new SymbolKey("regular", Symbol.Kind.REGULAR)));
+        assertThrows(
+                IllegalStateException.class,
+                () -> describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)));
     }
 
     // ---------------------------------------------------------------- helpers

--- a/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
+++ b/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
@@ -36,8 +36,10 @@ import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.Symbol;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.Undefined;
 import org.mozilla.javascript.optimizer.EagerSourceCodeProviderDescriber;
 import org.mozilla.javascript.optimizer.SymbolKeyDescriber;
+import org.mozilla.javascript.optimizer.UndefinedDescriber;
 import org.mozilla.javascript.regexp.RegExpImpl;
 
 public class DynamicConstantTest {
@@ -321,6 +323,20 @@ public class DynamicConstantTest {
         assertThrows(
                 IllegalStateException.class,
                 () -> describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)));
+    }
+
+    @Test
+    public void undefinedResolvesToTheCanonicalInstance() throws Exception {
+        // Undefined compares by identity, so the constant has to be the very same object the
+        // runtime uses, not merely an equal one.
+        ClassFileWriter cfw = writer("TestUndefinedConstant");
+        cfw.registerDynamicConstantDescriber(new UndefinedDescriber());
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant((Undefined) Undefined.instance);
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        assertSame(Undefined.instance, invoke(cfw, "TestUndefinedConstant", "get"));
     }
 
     @Test

--- a/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
+++ b/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
@@ -29,10 +29,14 @@ import org.mozilla.classfile.ByteCode;
 import org.mozilla.classfile.ClassFileWriter;
 import org.mozilla.classfile.DynamicConstant;
 import org.mozilla.classfile.DynamicConstantDescriber;
+import org.mozilla.javascript.Context;
 import org.mozilla.javascript.DefiningClassLoader;
+import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.Symbol;
 import org.mozilla.javascript.SymbolKey;
+import org.mozilla.javascript.TopLevel;
 import org.mozilla.javascript.optimizer.SymbolKeyDescriber;
+import org.mozilla.javascript.regexp.RegExpImpl;
 
 public class DynamicConstantTest {
 
@@ -299,8 +303,8 @@ public class DynamicConstantTest {
         cfw.startMethod("get", "()Ljava/lang/String;", (short) (ACC_PUBLIC | ACC_STATIC));
 
         assertThrows(
-            IllegalStateException.class,
-            () -> cfw.addLoadDynamicConstant(new UndescribableConstant()));
+                IllegalStateException.class,
+                () -> cfw.addLoadDynamicConstant(new UndescribableConstant()));
     }
 
     @Test
@@ -315,6 +319,63 @@ public class DynamicConstantTest {
         assertThrows(
                 IllegalStateException.class,
                 () -> describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)));
+    }
+
+    @Test
+    public void regExpConstantResolvesWithoutAContext() throws Exception {
+        // The source contains the "[" and ";" characters that a constant name may not, which is
+        // why the describer passes it as a bootstrap argument instead.
+        ClassFileWriter cfw = writer("TestRegExpConstant");
+        RegExpProxy proxy = new RegExpImpl();
+        Object prepared;
+        try (Context cx = Context.enter()) {
+            prepared = proxy.prepareRegExpConstant(cx, "a[bc];", "gi");
+            for (DynamicConstantDescriber<?> describer : proxy.getDynamicConstantDescribers()) {
+                cfw.registerDynamicConstantDescriber(describer);
+            }
+        }
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant((DynamicConstant) prepared);
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        // Resolution happens here, with no context on this thread.
+        Object resolved = invoke(cfw, "TestRegExpConstant", "get");
+        assertNotNull(resolved);
+
+        try (Context cx = Context.enter()) {
+            TopLevel scope = cx.initStandardObjects();
+            assertEquals("/a[bc];/gi", proxy.wrapRegExp(cx, scope, resolved).toString());
+        }
+    }
+
+    @Test
+    public void equivalentRegExpsShareAConstant() throws Exception {
+        ClassFileWriter cfw = writer("TestSharedRegExpConstants");
+        RegExpProxy proxy = new RegExpImpl();
+        Object gi, ig, g;
+        try (Context cx = Context.enter()) {
+            gi = proxy.prepareRegExpConstant(cx, "a", "gi");
+            ig = proxy.prepareRegExpConstant(cx, "a", "ig");
+            g = proxy.prepareRegExpConstant(cx, "a", "g");
+            for (DynamicConstantDescriber<?> describer : proxy.getDynamicConstantDescribers()) {
+                cfw.registerDynamicConstantDescriber(describer);
+            }
+        }
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant((DynamicConstant) gi);
+        cfw.add(ByteCode.POP);
+        cfw.addLoadDynamicConstant((DynamicConstant) ig);
+        cfw.add(ByteCode.POP);
+        cfw.addLoadDynamicConstant((DynamicConstant) g);
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        ClassFileInfo info = ClassFileInfo.parse(cfw.toByteArray());
+        assertEquals(2, info.count(TAG_DYNAMIC), "flag order should not affect the constant");
+        // The source and flags are bootstrap arguments, so each distinct expression also needs an
+        // entry of its own in the BootstrapMethods attribute.
+        assertEquals(2, info.bootstrapMethodCount);
     }
 
     // ---------------------------------------------------------------- helpers

--- a/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
+++ b/tests/src/test/java/org/mozilla/classfile/tests/DynamicConstantTest.java
@@ -31,10 +31,12 @@ import org.mozilla.classfile.DynamicConstant;
 import org.mozilla.classfile.DynamicConstantDescriber;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.DefiningClassLoader;
+import org.mozilla.javascript.EagerSourceCodeProvider;
 import org.mozilla.javascript.RegExpProxy;
 import org.mozilla.javascript.Symbol;
 import org.mozilla.javascript.SymbolKey;
 import org.mozilla.javascript.TopLevel;
+import org.mozilla.javascript.optimizer.EagerSourceCodeProviderDescriber;
 import org.mozilla.javascript.optimizer.SymbolKeyDescriber;
 import org.mozilla.javascript.regexp.RegExpImpl;
 
@@ -319,6 +321,44 @@ public class DynamicConstantTest {
         assertThrows(
                 IllegalStateException.class,
                 () -> describer.describe(new SymbolKey("registered", Symbol.Kind.REGISTERED)));
+    }
+
+    @Test
+    public void eagerSourceCodeProviderResolvesFromRawSource() throws Exception {
+        // The source contains the "[" and ";" characters that a constant name may not, which is
+        // why the describer passes it as a bootstrap argument instead.
+        ClassFileWriter cfw = writer("TestEagerSourceConstant");
+        cfw.registerDynamicConstantDescriber(new EagerSourceCodeProviderDescriber());
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new EagerSourceCodeProvider("a[bc];"));
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        Object resolved = invoke(cfw, "TestEagerSourceConstant", "get");
+        assertEquals("a[bc];", ((EagerSourceCodeProvider) resolved).getRawSource());
+    }
+
+    @Test
+    public void equalSourceSharesAConstant() throws Exception {
+        ClassFileWriter cfw = writer("TestSharedEagerSourceConstants");
+        cfw.registerDynamicConstantDescriber(new EagerSourceCodeProviderDescriber());
+        cfw.startMethod("get", "()Ljava/lang/Object;", (short) (ACC_PUBLIC | ACC_STATIC));
+        cfw.addLoadDynamicConstant(new EagerSourceCodeProvider("same"));
+        cfw.add(ByteCode.POP);
+        cfw.addLoadDynamicConstant(new EagerSourceCodeProvider("same"));
+        cfw.add(ByteCode.POP);
+        cfw.addLoadDynamicConstant(new EagerSourceCodeProvider("other"));
+        cfw.add(ByteCode.ARETURN);
+        cfw.stopMethod((short) 0);
+
+        byte[] bytecode = cfw.toByteArray();
+        ClassFileInfo info = ClassFileInfo.parse(bytecode);
+        assertEquals(2, info.count(TAG_DYNAMIC), "equal source should share a pool entry");
+        assertEquals(
+                "other",
+                ((EagerSourceCodeProvider)
+                                invoke(bytecode, "TestSharedEagerSourceConstants", "get"))
+                        .getRawSource());
     }
 
     @Test


### PR DESCRIPTION
When working on the lazy source provider API I wanted to be able to easily create a constant `SourceCodeProvider` and have that de-duplicated by the class writer. The class file format allows for these constant dynamics in a similar manner to invoke dynamic bootstraps.

This prototype is a little rough, Claude wrote some of it but got some of the symbol stuff very wrong so I mostly rewrote that and edited a bunch of the related tests. `SymbolKey` was chosen as a reasonable tractable example that we might conceivably want, but `EagerSourceCodeProvider` and other more complex constants would be my real uses for this.