### PR TITLE
Define a Java toolchain to remove errors

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,7 @@ build --java_language_version=17
 # Ensure that Java 17-compatible bytecode is produced
 build --java_runtime_version=remotejdk_17
 # Force Bazel to use Java 25 for its own internal tools/helpers
+build --extra_toolchains=//bazel:custom_toolchain_jdk_17_definition
 build --extra_toolchains=@rules_java//java:all
 build --tool_java_runtime_version=remotejdk_25
 

--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -1,1 +1,20 @@
 # This class contains common Bazel build rules used elsewhere.
+
+load("@rules_java//toolchains:default_java_toolchain.bzl", "DEFAULT_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
+
+default_java_toolchain(
+    name = "custom_toolchain_jdk_17",
+    java_runtime = "@rules_java//toolchains:remotejdk_25",
+    jvm_opts = DEFAULT_TOOLCHAIN_CONFIGURATION["jvm_opts"] + [
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "--sun-misc-unsafe-memory-access=allow",
+    ],
+    source_version = "17",
+    target_version = "17",
+    turbine_jvm_opts = DEFAULT_TOOLCHAIN_CONFIGURATION["turbine_jvm_opts"] + [
+        "-XX:+IgnoreUnrecognizedVMOptions",
+        "--sun-misc-unsafe-memory-access=allow",
+    ],
+    visibility = ["//visibility:public"],
+)
+


### PR DESCRIPTION
This removes a huge list of warnings that happens when using Bazel for remote build execution.