### PR TITLE
PoC: Make `Scriptable` objects work with more ES property methods.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AbstractEcmaObjectOperations.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Predicate;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * Abstract Object Operations as defined by EcmaScript
@@ -84,7 +83,7 @@ public class AbstractEcmaObjectOperations {
             ids = obj.getIds(map, true, true);
         }
         for (Object name : ids) {
-            DescriptorInfo desc = obj.getOwnPropertyDescriptor(cx, name);
+            PropertyDescriptor desc = obj.getOwnPropertyDescriptor(cx, name);
             if (desc.isConfigurable()) return false;
 
             if (level == INTEGRITY_LEVEL.FROZEN && desc.isDataDescriptor() && desc.isWritable())
@@ -150,7 +149,7 @@ public class AbstractEcmaObjectOperations {
             ids = obj.getIds(map, true, true);
         }
         for (Object key : ids) {
-            DescriptorInfo desc = obj.getOwnPropertyDescriptor(cx, key);
+            PropertyDescriptor desc = obj.getOwnPropertyDescriptor(cx, key);
 
             if (level == INTEGRITY_LEVEL.SEALED) {
                 if (desc.isConfigurable()) {
@@ -401,7 +400,7 @@ public class AbstractEcmaObjectOperations {
      * IsCompatiblePropertyDescriptor (Extensible, Desc, Current)</a>
      */
     static boolean isCompatiblePropertyDescriptor(
-            Context cx, boolean extensible, DescriptorInfo desc, DescriptorInfo current) {
+            Context cx, boolean extensible, PropertyDescriptor desc, PropertyDescriptor current) {
         return validateAndApplyPropertyDescriptor(
                 cx,
                 Undefined.SCRIPTABLE_UNDEFINED,
@@ -423,8 +422,8 @@ public class AbstractEcmaObjectOperations {
             Scriptable o,
             Scriptable p,
             boolean extensible,
-            DescriptorInfo desc,
-            DescriptorInfo current) {
+            PropertyDescriptor desc,
+            PropertyDescriptor current) {
         if (Undefined.isUndefined(current)) {
             if (!extensible) {
                 return false;
@@ -563,7 +562,7 @@ public class AbstractEcmaObjectOperations {
          * 1. Let ownDesc be ? O.[[GetOwnProperty]](P).
          * 2. Return ? OrdinarySetWithOwnDescriptor(O, P, V, Receiver, ownDesc).
          */
-        DescriptorInfo ownDesc =
+        PropertyDescriptor ownDesc =
                 ScriptRuntime.isSymbol(p)
                         ? o.getOwnPropertyDescriptor(cx, p)
                         : o.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
@@ -584,7 +583,7 @@ public class AbstractEcmaObjectOperations {
             Object p,
             Object v,
             Scriptable receiver,
-            DescriptorInfo ownDesc) {
+            PropertyDescriptor ownDesc) {
         /*
          * 1. If ownDesc is undefined, then
          *    a. Let parent be ? O.[[GetPrototypeOf]]().
@@ -626,7 +625,7 @@ public class AbstractEcmaObjectOperations {
                 return true;
             }
 
-            ownDesc = new DescriptorInfo(true, true, true, Undefined.instance);
+            ownDesc = new PropertyDescriptor(true, true, true, Undefined.instance);
         }
 
         if (ownDesc.isDataDescriptor()) {
@@ -635,7 +634,7 @@ public class AbstractEcmaObjectOperations {
             }
             ScriptableObject receiverObj = (ScriptableObject) receiver;
 
-            DescriptorInfo existingDesc =
+            PropertyDescriptor existingDesc =
                     ScriptRuntime.isSymbol(p)
                             ? receiverObj.getOwnPropertyDescriptor(cx, p)
                             : receiverObj.getOwnPropertyDescriptor(cx, ScriptRuntime.toString(p));
@@ -644,13 +643,13 @@ public class AbstractEcmaObjectOperations {
                 if (existingDesc.isAccessorDescriptor() || existingDesc.isWritable(false)) {
                     return false;
                 }
-                DescriptorInfo valueDesc =
-                        new DescriptorInfo(
+                PropertyDescriptor valueDesc =
+                        new PropertyDescriptor(
                                 NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, NOT_FOUND, v);
                 return receiverObj.defineOwnProperty(cx, p, valueDesc);
             }
 
-            DescriptorInfo newDesc = new DescriptorInfo(true, true, true, v);
+            PropertyDescriptor newDesc = new PropertyDescriptor(true, true, true, v);
             receiverObj.defineOwnProperty(cx, p, newDesc);
             return true;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/AccessorSlot.java
@@ -1,7 +1,6 @@
 package org.mozilla.javascript;
 
 import java.io.Serial;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * This is a specialization of Slot to store various types of values that are retrieved dynamically
@@ -46,22 +45,22 @@ public class AccessorSlot extends StandardSlot<Scriptable> {
     }
 
     @Override
-    DescriptorInfo getPropertyDescriptor(Context cx, Scriptable scope) {
+    PropertyDescriptor getPropertyDescriptor(Context cx, Scriptable scope) {
         // It sounds logical that this would be the same as the logic for a normal Slot,
         // but the spec is super pedantic about things like the order of properties here,
         // so we need special support here.
 
         int attr = getAttributes();
-        DescriptorInfo desc;
+        PropertyDescriptor desc;
         boolean es6 = cx.getLanguageVersion() >= Context.VERSION_ES6;
         if (es6) {
-            desc = new DescriptorInfo(ScriptableObject.NOT_FOUND, attr, false);
+            desc = new PropertyDescriptor(ScriptableObject.NOT_FOUND, attr, false);
             if (getter == null && setter == null) {
                 desc.writable = (attr & ScriptableObject.READONLY) == 0;
             }
         } else {
             desc =
-                    new DescriptorInfo(
+                    new PropertyDescriptor(
                             ScriptableObject.NOT_FOUND, attr, getter == null && setter == null);
         }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Arguments.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Arguments.java
@@ -250,7 +250,7 @@ class Arguments extends ScriptableObject {
     }
 
     @Override
-    protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         if (ScriptRuntime.isSymbol(id) || id instanceof Scriptable) {
             return super.getOwnPropertyDescriptor(cx, id);
         }
@@ -268,7 +268,7 @@ class Arguments extends ScriptableObject {
             value = getFromActivation(index);
         }
         if (super.has(index, this)) { // the descriptor has been redefined
-            DescriptorInfo desc = super.getOwnPropertyDescriptor(cx, id);
+            PropertyDescriptor desc = super.getOwnPropertyDescriptor(cx, id);
             desc.value = value;
             return desc;
         }
@@ -276,8 +276,8 @@ class Arguments extends ScriptableObject {
     }
 
     @Override
-    protected boolean defineOwnProperty(
-            Context cx, Object id, DescriptorInfo desc, boolean checkValid) {
+    public boolean defineOwnProperty(
+            Context cx, Object id, PropertyDescriptor desc, boolean checkValid) {
         super.defineOwnProperty(cx, id, desc, checkValid);
         if (ScriptRuntime.isSymbol(id)) {
             return true;

--- a/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ArrayLikeAbstractOperations.java
@@ -6,7 +6,6 @@ import static org.mozilla.javascript.Scriptable.NOT_FOUND;
 
 import java.io.Serializable;
 import java.util.Comparator;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /** Contains implementation of shared methods useful for arrays and typed arrays. */
 public class ArrayLikeAbstractOperations {
@@ -231,7 +230,7 @@ public class ArrayLikeAbstractOperations {
         if (!(target instanceof NativeArray && ((NativeArray) target).getDenseOnly())
                 && target instanceof ScriptableObject) {
             var so = (ScriptableObject) target;
-            var desc = new DescriptorInfo(true, true, true, value);
+            var desc = new PropertyDescriptor(true, true, true, value);
             so.defineOwnProperty(cx, index, desc);
             return;
         }

--- a/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BaseFunction.java
@@ -283,7 +283,7 @@ public class BaseFunction extends ScriptableObject implements Function {
             BaseFunction builtIn,
             BuiltInSlot<BaseFunction> current,
             Object id,
-            ScriptableObject.DescriptorInfo info,
+            PropertyDescriptor info,
             boolean checkValid,
             Object key,
             int index) {
@@ -306,9 +306,9 @@ public class BaseFunction extends ScriptableObject implements Function {
         }
     }
 
-    static DescriptorInfo createThrowingProp(Context cx, VarScope scope, ScriptableObject obj) {
+    static PropertyDescriptor createThrowingProp(Context cx, VarScope scope, ScriptableObject obj) {
         var thrower = ScriptRuntime.typeErrorThrower(scope);
-        return new DescriptorInfo(false, NOT_FOUND, true, thrower, thrower, null);
+        return new PropertyDescriptor(false, NOT_FOUND, true, thrower, thrower, null);
     }
 
     protected final boolean defaultHas(String name) {

--- a/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BoundFunction.java
@@ -40,7 +40,7 @@ public class BoundFunction extends BaseFunction {
         ScriptRuntime.setFunctionProtoAndParent(this, cx, scope, false);
 
         Function thrower = ScriptRuntime.typeErrorThrower(cx);
-        var throwing = new DescriptorInfo(false, NOT_FOUND, false, thrower, thrower, NOT_FOUND);
+        var throwing = new PropertyDescriptor(false, NOT_FOUND, false, thrower, thrower, NOT_FOUND);
 
         defineOwnProperty(cx, "caller", throwing, false);
         if (cx.getLanguageVersion() < Context.VERSION_ES6) {

--- a/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/BuiltInSlot.java
@@ -2,7 +2,6 @@ package org.mozilla.javascript;
 
 import java.io.Serial;
 import java.io.Serializable;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * This is a specialization of property access using some lambda functions designed for properties
@@ -44,7 +43,7 @@ public class BuiltInSlot<T extends ScriptableObject>
                 T builtIn,
                 BuiltInSlot<T> current,
                 Object id,
-                DescriptorInfo info,
+                PropertyDescriptor info,
                 boolean checkValid,
                 Object key,
                 int index);
@@ -160,7 +159,7 @@ public class BuiltInSlot<T extends ScriptableObject>
             T builtIn,
             BuiltInSlot<T> current,
             Object id,
-            DescriptorInfo info,
+            PropertyDescriptor info,
             boolean checkValid,
             Object key,
             int index) {
@@ -197,7 +196,7 @@ public class BuiltInSlot<T extends ScriptableObject>
 
     @SuppressWarnings("unchecked")
     boolean applyNewDescriptor(
-            Object id, DescriptorInfo info, boolean checkValid, Object key, int index) {
+            Object id, PropertyDescriptor info, boolean checkValid, Object key, int index) {
         return descriptor.propDescSetter.apply(
                 ((T) this.value), this, id, info, checkValid, key, index);
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassDescriptor.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 import org.mozilla.javascript.ScriptableObject.LambdaGetterFunction;
 import org.mozilla.javascript.ScriptableObject.LambdaSetterFunction;
 
@@ -160,7 +159,7 @@ public class ClassDescriptor {
     }
 
     public interface ValueCreator {
-        DescriptorInfo apply(Context cx, VarScope scope, ScriptableObject obj);
+        PropertyDescriptor apply(Context cx, VarScope scope, ScriptableObject obj);
     }
 
     private static class CreateValuePropDesc extends PropDesc {
@@ -710,7 +709,8 @@ public class ClassDescriptor {
          * attributes.
          */
         public static ValueCreator alias(String original, int attributes) {
-            return (cx, scope, obj) -> new DescriptorInfo(obj.get(original, obj), attributes, true);
+            return (cx, scope, obj) ->
+                    new PropertyDescriptor(obj.get(original, obj), attributes, true);
         }
 
         /** Convenience method to create an alias of the orignally named slot. */
@@ -724,7 +724,7 @@ public class ClassDescriptor {
          * constant between contexts.
          */
         public static ValueCreator value(Object value, int attributes) {
-            return (c, s, o) -> new DescriptorInfo(value, attributes, true);
+            return (c, s, o) -> new PropertyDescriptor(value, attributes, true);
         }
 
         /**

--- a/rhino/src/main/java/org/mozilla/javascript/CompactSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CompactSlot.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Objects;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 public abstract class CompactSlot<
                 T extends CompactSlot.Descriptor<T, U, O>,
@@ -45,7 +44,7 @@ public abstract class CompactSlot<
             slot.attributes = (short) value;
         }
 
-        DescriptorInfo getPropertyDescriptor(CompactSlot<T, U, O> slot, Context cx, U start) {
+        PropertyDescriptor getPropertyDescriptor(CompactSlot<T, U, O> slot, Context cx, U start) {
             return ScriptableObject.buildDataDescriptor(
                     getValue(slot, start), slot.getAttributes());
         }
@@ -102,7 +101,7 @@ public abstract class CompactSlot<
     }
 
     @Override
-    final DescriptorInfo getPropertyDescriptor(Context cx, U start) {
+    final PropertyDescriptor getPropertyDescriptor(Context cx, U start) {
         return descriptor.getPropertyDescriptor(this, cx, start);
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/IdScriptableObject.java
@@ -854,8 +854,8 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     @Override
-    protected boolean defineOwnProperty(
-            Context cx, Object key, DescriptorInfo desc, boolean checkValid) {
+    public boolean defineOwnProperty(
+            Context cx, Object key, PropertyDescriptor desc, boolean checkValid) {
         if (key instanceof CharSequence) {
             String name = key.toString();
             int info = findInstanceIdInfo(name);
@@ -920,7 +920,7 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
     }
 
     @Override
-    protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         var desc = super.getOwnPropertyDescriptor(cx, id);
         if (desc == null) {
             if (id instanceof String) {
@@ -956,9 +956,9 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         return slot;
     }
 
-    private DescriptorInfo getBuiltInDataDescriptor(String name) {
+    private PropertyDescriptor getBuiltInDataDescriptor(String name) {
         var slot = getBuiltInSlot(name);
-        return slot == null ? null : new DescriptorInfo(slot.value, slot.getAttributes(), true);
+        return slot == null ? null : new PropertyDescriptor(slot.value, slot.getAttributes(), true);
     }
 
     private Slot<?> getBuiltInSlot(String name) {
@@ -984,9 +984,9 @@ public abstract class IdScriptableObject extends ScriptableObject implements IdF
         return null;
     }
 
-    private DescriptorInfo getBuiltInDataDescriptor(Symbol key) {
+    private PropertyDescriptor getBuiltInDataDescriptor(Symbol key) {
         var slot = getBuiltInSlot(key);
-        return slot == null ? null : new DescriptorInfo(slot.value, slot.getAttributes(), true);
+        return slot == null ? null : new PropertyDescriptor(slot.value, slot.getAttributes(), true);
     }
 
     private StandardSlot getBuiltInSlot(Symbol key) {

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaAccessorSlot.java
@@ -1,7 +1,5 @@
 package org.mozilla.javascript;
 
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
-
 /**
  * A specialized property accessor using lambda functions, similar to {@link LambdaSlot}, but allows
  * defining properties with getter and setter lambdas that require access to the owner object
@@ -62,7 +60,7 @@ public class LambdaAccessorSlot extends StandardSlot<Scriptable> {
     }
 
     @Override
-    DescriptorInfo getPropertyDescriptor(Context cx, Scriptable scope) {
+    PropertyDescriptor getPropertyDescriptor(Context cx, Scriptable scope) {
         return buildPropertyDescriptor(cx);
     }
 
@@ -72,18 +70,18 @@ public class LambdaAccessorSlot extends StandardSlot<Scriptable> {
      * it can be problematic when called from inside ThreadSafeSlotMapContainer::compute lambda
      * which can lead to deadlocks.
      */
-    public DescriptorInfo buildPropertyDescriptor(Context cx) {
+    public PropertyDescriptor buildPropertyDescriptor(Context cx) {
         int attr = getAttributes();
-        DescriptorInfo desc;
+        PropertyDescriptor desc;
         boolean es6 = cx.getLanguageVersion() >= Context.VERSION_ES6;
         if (es6) {
-            desc = new DescriptorInfo(ScriptableObject.NOT_FOUND, attr, false);
+            desc = new PropertyDescriptor(ScriptableObject.NOT_FOUND, attr, false);
             if (getterFunction == null && setterFunction == null) {
                 desc.writable = (attr & ScriptableObject.READONLY) == 0;
             }
         } else {
             desc =
-                    new DescriptorInfo(
+                    new PropertyDescriptor(
                             ScriptableObject.NOT_FOUND,
                             attr,
                             getterFunction == null && setterFunction == null);

--- a/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/LambdaSlot.java
@@ -3,7 +3,6 @@ package org.mozilla.javascript;
 import java.io.Serial;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * This is a specialization of property access using some lambda functions. It behaves exactly like
@@ -49,8 +48,8 @@ public class LambdaSlot extends StandardSlot<Scriptable> {
     }
 
     @Override
-    DescriptorInfo getPropertyDescriptor(Context cx, Scriptable scope) {
-        return new DescriptorInfo(getter == null ? value : getter.get(), getAttributes(), true);
+    PropertyDescriptor getPropertyDescriptor(Context cx, Scriptable scope) {
+        return new PropertyDescriptor(getter == null ? value : getter.get(), getAttributes(), true);
     }
 
     @Override

--- a/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeArray.java
@@ -224,7 +224,7 @@ public class NativeArray extends ScriptableObject implements List {
         }
     }
 
-    private static DescriptorInfo makeUnscopables(
+    private static PropertyDescriptor makeUnscopables(
             Context cx, VarScope scope, ScriptableObject obj) {
         NativeObject res;
 
@@ -235,7 +235,7 @@ public class NativeArray extends ScriptableObject implements List {
             res.defineOwnProperty(cx, k, desc);
         }
         res.setPrototype(null); // unscopables don't have any prototype
-        return new DescriptorInfo(res, DONTENUM | READONLY, true);
+        return new PropertyDescriptor(res, DONTENUM | READONLY, true);
     }
 
     @Override
@@ -440,8 +440,8 @@ public class NativeArray extends ScriptableObject implements List {
         return indices;
     }
 
-    private DescriptorInfo defaultIndexPropertyDescriptor(Object value) {
-        return new DescriptorInfo(true, true, true, NOT_FOUND, NOT_FOUND, value);
+    private PropertyDescriptor defaultIndexPropertyDescriptor(Object value) {
+        return new PropertyDescriptor(true, true, true, NOT_FOUND, NOT_FOUND, value);
     }
 
     @Override
@@ -453,7 +453,7 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     @Override
-    protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         if (dense != null) {
             int index = toDenseIndex(id);
             if (0 <= index && index < dense.length && dense[index] != NOT_FOUND) {
@@ -465,8 +465,8 @@ public class NativeArray extends ScriptableObject implements List {
     }
 
     @Override
-    protected boolean defineOwnProperty(
-            Context cx, Object id, DescriptorInfo desc, boolean checkValid) {
+    public boolean defineOwnProperty(
+            Context cx, Object id, PropertyDescriptor desc, boolean checkValid) {
         long index = toArrayIndex(id);
         if (index >= length) {
             length = index + 1;
@@ -551,7 +551,7 @@ public class NativeArray extends ScriptableObject implements List {
 
     private static Slot<Scriptable> lengthDescSetValue(
             ScriptableObject owner,
-            DescriptorInfo info,
+            PropertyDescriptor info,
             Object key,
             Slot<Scriptable> existing,
             CompoundOperationMap<Scriptable> map,
@@ -564,7 +564,7 @@ public class NativeArray extends ScriptableObject implements List {
             NativeArray builtIn,
             BuiltInSlot<NativeArray> current,
             Object id,
-            DescriptorInfo info,
+            PropertyDescriptor info,
             boolean checkValid,
             Object key,
             int index) {

--- a/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeNumber.java
@@ -71,12 +71,14 @@ final class NativeNumber extends ScriptableObject {
                                 CTOR,
                                 "parseFloat",
                                 (c, s, o) ->
-                                        new DescriptorInfo(s.get("parseFloat", s), DONTENUM, true))
+                                        new PropertyDescriptor(
+                                                s.get("parseFloat", s), DONTENUM, true))
                         .withProp(
                                 CTOR,
                                 "parseInt",
                                 (c, s, o) ->
-                                        new DescriptorInfo(s.get("parseInt", s), DONTENUM, true))
+                                        new PropertyDescriptor(
+                                                s.get("parseInt", s), DONTENUM, true))
                         .withMethod(PROTO, "toString", 1, NativeNumber::js_toString)
                         .withMethod(PROTO, "toLocaleString", 0, NativeNumber::js_toLocaleString)
                         .withMethod(PROTO, "toSource", 0, NativeNumber::js_toSource)

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -569,7 +569,7 @@ public class NativeObject extends ScriptableObject implements Map {
         ScriptableObject obj = ensureScriptableObject(arg);
         Object name = args.length < 2 ? Undefined.instance : args[1];
         Object descArg = args.length < 3 ? Undefined.instance : args[2];
-        var desc = new DescriptorInfo(ensureScriptableObject(descArg));
+        var desc = new PropertyDescriptor(ensureScriptableObject(descArg));
         ScriptableObject.checkPropertyDefinition(desc);
         obj.defineOwnProperty(cx, name, desc);
         return obj;

--- a/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeObject.java
@@ -527,11 +527,11 @@ public class NativeObject extends ScriptableObject implements Map {
     private static Object js_getOwnPropDesc(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
-        // TODO(norris): There's a deeper issue here if
-        // arg instanceof Scriptable. Should we create a new
-        // interface to admit the new ECMAScript 5 operations?
         Scriptable s2 = getCompatibleObject(cx, s, arg);
-        ScriptableObject obj = ensureScriptableObject(s2);
+        Scriptable obj = s2;
+        if (s2 instanceof Delegator) {
+            obj = ((Delegator) s2).getDelegee();
+        }
         Object nameArg = args.length < 2 ? Undefined.instance : args[1];
         var desc = obj.getOwnPropertyDescriptor(cx, nameArg);
         return desc == null ? Undefined.instance : desc.toObject(f.getDeclarationScope());
@@ -541,12 +541,20 @@ public class NativeObject extends ScriptableObject implements Map {
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
         Scriptable s2 = getCompatibleObject(cx, s, arg);
-        ScriptableObject obj = ensureScriptableObject(s2);
+        Scriptable obj = s2;
+        if (s2 instanceof Delegator) {
+            obj = ((Delegator) s2).getDelegee();
+        }
 
         ScriptableObject descs = (ScriptableObject) cx.newObject(f.getDeclarationScope());
         Object[] ids;
-        try (var map = obj.startCompoundOp(false)) {
-            ids = obj.getIds(map, true, true);
+        if (obj instanceof ScriptableObject) {
+            ScriptableObject soObj = (ScriptableObject) obj;
+            try (var map = soObj.startCompoundOp(false)) {
+                ids = soObj.getIds(map, true, true);
+            }
+        } else {
+            ids = obj.getIds();
         }
         for (Object key : ids) {
             var desc = obj.getOwnPropertyDescriptor(cx, key);
@@ -566,13 +574,17 @@ public class NativeObject extends ScriptableObject implements Map {
     private static Object js_defineProperty(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
-        ScriptableObject obj = ensureScriptableObject(arg);
+        Scriptable s2 = ensureScriptable(arg);
+        Scriptable obj = s2;
+        if (s2 instanceof Delegator) {
+            obj = ((Delegator) s2).getDelegee();
+        }
         Object name = args.length < 2 ? Undefined.instance : args[1];
         Object descArg = args.length < 3 ? Undefined.instance : args[2];
         var desc = new PropertyDescriptor(ensureScriptableObject(descArg));
         ScriptableObject.checkPropertyDefinition(desc);
         obj.defineOwnProperty(cx, name, desc);
-        return obj;
+        return s2;
     }
 
     private static Object js_isExtensible(
@@ -603,10 +615,12 @@ public class NativeObject extends ScriptableObject implements Map {
     private static Object js_defineProperties(
             Context cx, JSFunction f, Object nt, VarScope s, Object thisObj, Object[] args) {
         Object arg = args.length < 1 ? Undefined.instance : args[0];
-        ScriptableObject obj = ensureScriptableObject(arg);
+        Scriptable obj = ensureScriptable(arg);
         Object propsObj = args.length < 2 ? Undefined.instance : args[1];
         Scriptable props = Context.toObject(propsObj, s);
-        obj.defineOwnProperties(cx, ensureScriptableObject(props));
+        if (obj instanceof ScriptableObject) {
+            ((ScriptableObject) obj).defineOwnProperties(cx, ensureScriptableObject(props));
+        }
         return obj;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -127,7 +127,7 @@ class NativeProxy extends ScriptableObject {
             boolean booleanTrapResult =
                     ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, name}));
             if (!booleanTrapResult) {
-                DescriptorInfo targetDesc =
+                PropertyDescriptor targetDesc =
                         target.getOwnPropertyDescriptor(Context.getContext(), name);
                 if (targetDesc != null) {
                     if (targetDesc.isConfigurable(false) || !target.isExtensible()) {
@@ -180,7 +180,7 @@ class NativeProxy extends ScriptableObject {
                     ScriptRuntime.toBoolean(
                             callTrap(trap, new Object[] {target, ScriptRuntime.toString(index)}));
             if (!booleanTrapResult) {
-                DescriptorInfo targetDesc =
+                PropertyDescriptor targetDesc =
                         target.getOwnPropertyDescriptor(Context.getContext(), index);
                 if (targetDesc != null) {
                     if (targetDesc.isConfigurable(false) || !target.isExtensible()) {
@@ -213,7 +213,7 @@ class NativeProxy extends ScriptableObject {
             boolean booleanTrapResult =
                     ScriptRuntime.toBoolean(callTrap(trap, new Object[] {target, key}));
             if (!booleanTrapResult) {
-                DescriptorInfo targetDesc =
+                PropertyDescriptor targetDesc =
                         target.getOwnPropertyDescriptor(Context.getContext(), key);
                 if (targetDesc != null) {
                     if (targetDesc.isConfigurable(false) || !target.isExtensible()) {
@@ -315,7 +315,7 @@ class NativeProxy extends ScriptableObject {
             ArrayList<Object> targetConfigurableKeys = new ArrayList<>();
             ArrayList<Object> targetNonconfigurableKeys = new ArrayList<>();
             for (Object targetKey : targetKeys) {
-                DescriptorInfo desc = target.getOwnPropertyDescriptor(cx, targetKey);
+                PropertyDescriptor desc = target.getOwnPropertyDescriptor(cx, targetKey);
                 if (desc != null && desc.isConfigurable(false)) {
                     targetNonconfigurableKeys.add(targetKey);
                 } else {
@@ -389,7 +389,8 @@ class NativeProxy extends ScriptableObject {
         if (trap != null) {
             Object trapResult = callTrap(trap, new Object[] {target, name, start});
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), name);
             if (targetDesc != null && targetDesc.isConfigurable(false)) {
                 if (targetDesc.isDataDescriptor() && targetDesc.isWritable(false)) {
                     if (!Objects.equals(trapResult, targetDesc.value)) {
@@ -445,7 +446,7 @@ class NativeProxy extends ScriptableObject {
             Object trapResult =
                     callTrap(trap, new Object[] {target, ScriptRuntime.toString(index), start});
 
-            DescriptorInfo targetDesc =
+            PropertyDescriptor targetDesc =
                     target.getOwnPropertyDescriptor(Context.getContext(), index);
             if (targetDesc != null
                     && !Undefined.isUndefined(targetDesc)
@@ -503,7 +504,8 @@ class NativeProxy extends ScriptableObject {
         if (trap != null) {
             Object trapResult = callTrap(trap, new Object[] {target, key, start});
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), key);
             if (targetDesc != null
                     && !Undefined.isUndefined(targetDesc)
                     && targetDesc.isConfigurable(false)) {
@@ -567,7 +569,8 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), name);
             if (targetDesc != null
                     && !Undefined.isUndefined(targetDesc)
                     && targetDesc.isConfigurable(false)) {
@@ -631,7 +634,7 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc =
+            PropertyDescriptor targetDesc =
                     target.getOwnPropertyDescriptor(Context.getContext(), index);
             if (targetDesc != null
                     && !Undefined.isUndefined(targetDesc)
@@ -692,7 +695,8 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), key);
             if (targetDesc != null
                     && !Undefined.isUndefined(targetDesc)
                     && targetDesc.isConfigurable(false)) {
@@ -751,7 +755,8 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), name);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), name);
             if (targetDesc == null) {
                 return; // true
             }
@@ -802,7 +807,7 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc =
+            PropertyDescriptor targetDesc =
                     target.getOwnPropertyDescriptor(Context.getContext(), index);
             if (targetDesc == null) {
                 return; // true
@@ -853,7 +858,8 @@ class NativeProxy extends ScriptableObject {
                 return; // false
             }
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), key);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), key);
             if (targetDesc == null) {
                 return; // true
             }
@@ -875,7 +881,7 @@ class NativeProxy extends ScriptableObject {
      * [[GetOwnProperty]] (P)</a>
      */
     @Override
-    protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         /*
          * 1. Assert: IsPropertyKey(P) is true.
          * 2. Let handler be O.[[ProxyHandler]].
@@ -966,7 +972,7 @@ class NativeProxy extends ScriptableObject {
      * [[DefineOwnProperty]] (P, Desc)</a>
      */
     @Override
-    public boolean defineOwnProperty(Context cx, Object id, DescriptorInfo desc) {
+    public boolean defineOwnProperty(Context cx, Object id, PropertyDescriptor desc) {
         /*
          * 1. Assert: IsPropertyKey(P) is true.
          * 2. Let handler be O.[[ProxyHandler]].
@@ -1009,7 +1015,8 @@ class NativeProxy extends ScriptableObject {
                 return false;
             }
 
-            DescriptorInfo targetDesc = target.getOwnPropertyDescriptor(Context.getContext(), id);
+            PropertyDescriptor targetDesc =
+                    target.getOwnPropertyDescriptor(Context.getContext(), id);
             boolean extensibleTarget = target.isExtensible();
 
             boolean settingConfigFalse = desc.isConfigurable(false);

--- a/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeReflect.java
@@ -212,7 +212,8 @@ final class NativeReflect extends ScriptableObject {
         }
 
         ScriptableObject target = checkTarget(args);
-        DescriptorInfo desc = new DescriptorInfo(ScriptableObject.ensureScriptableObject(args[2]));
+        PropertyDescriptor desc =
+                new PropertyDescriptor(ScriptableObject.ensureScriptableObject(args[2]));
 
         Object key = args[1];
 

--- a/rhino/src/main/java/org/mozilla/javascript/NativeString.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeString.java
@@ -542,7 +542,7 @@ final class NativeString extends ScriptableObject {
     }
 
     @Override
-    protected ScriptableObject.DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         if (!(id instanceof Symbol)
                 && (cx != null)
                 && (cx.getLanguageVersion() >= Context.VERSION_ES6)) {
@@ -555,8 +555,8 @@ final class NativeString extends ScriptableObject {
         return super.getOwnPropertyDescriptor(cx, id);
     }
 
-    private ScriptableObject.DescriptorInfo defaultIndexPropertyDescriptor(Object value) {
-        return new ScriptableObject.DescriptorInfo(true, false, false, NOT_FOUND, NOT_FOUND, value);
+    private PropertyDescriptor defaultIndexPropertyDescriptor(Object value) {
+        return new PropertyDescriptor(true, false, false, NOT_FOUND, NOT_FOUND, value);
     }
 
     /*

--- a/rhino/src/main/java/org/mozilla/javascript/PropertyDescriptor.java
+++ b/rhino/src/main/java/org/mozilla/javascript/PropertyDescriptor.java
@@ -1,0 +1,189 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript;
+
+/**
+ * Represents a property descriptor as defined by the ECMAScript specification.
+ *
+ * <p>A property descriptor is a record that captures information about how a property may be
+ * accessed and modified. Property descriptors can describe either data properties (with value and
+ * writable attributes) or accessor properties (with get and set attributes).
+ *
+ * @see <a href="https://tc39.es/ecma262/#sec-property-descriptor-specification-type">ECMAScript
+ *     Property Descriptor Specification Type</a>
+ */
+public final class PropertyDescriptor {
+    public Object enumerable = ScriptableObject.NOT_FOUND;
+    public Object writable = ScriptableObject.NOT_FOUND;
+    public Object configurable = ScriptableObject.NOT_FOUND;
+    public Object getter = ScriptableObject.NOT_FOUND;
+    public Object setter = ScriptableObject.NOT_FOUND;
+    public Object value = ScriptableObject.NOT_FOUND;
+    boolean accessorDescriptor;
+
+    /**
+     * Create a property descriptor from a JavaScript descriptor object.
+     *
+     * <p>The descriptor object should have properties corresponding to the descriptor attributes:
+     * value, writable, get, set, enumerable, configurable.
+     *
+     * @param desc the descriptor object
+     */
+    public PropertyDescriptor(ScriptableObject desc) {
+        enumerable = ScriptableObject.getProperty(desc, "enumerable");
+        writable = ScriptableObject.getProperty(desc, "writable");
+        configurable = ScriptableObject.getProperty(desc, "configurable");
+        getter = ScriptableObject.getProperty(desc, "get");
+        setter = ScriptableObject.getProperty(desc, "set");
+        value = ScriptableObject.getProperty(desc, "value");
+        accessorDescriptor =
+                getter != ScriptableObject.NOT_FOUND || setter != ScriptableObject.NOT_FOUND;
+    }
+
+    /**
+     * Create a data property descriptor.
+     *
+     * @param enumerable whether the property is enumerable
+     * @param writable whether the property is writable
+     * @param configurable whether the property is configurable
+     * @param value the property value
+     */
+    public PropertyDescriptor(
+            boolean enumerable, boolean writable, boolean configurable, Object value) {
+        this.enumerable = enumerable;
+        this.writable = writable;
+        this.configurable = configurable;
+        this.getter = ScriptableObject.NOT_FOUND;
+        this.setter = ScriptableObject.NOT_FOUND;
+        this.value = value;
+        accessorDescriptor = false;
+    }
+
+    /**
+     * Create a property descriptor with explicit attribute objects.
+     *
+     * <p>Attributes can be either Boolean objects or NOT_FOUND to indicate absence.
+     *
+     * @param enumerable the enumerable attribute
+     * @param writable the writable attribute
+     * @param configurable the configurable attribute
+     * @param getter the get function
+     * @param setter the set function
+     * @param value the property value
+     */
+    public PropertyDescriptor(
+            Object enumerable,
+            Object writable,
+            Object configurable,
+            Object getter,
+            Object setter,
+            Object value) {
+        this.enumerable = enumerable;
+        this.writable = writable;
+        this.configurable = configurable;
+        this.getter = getter;
+        this.setter = setter;
+        this.value = value;
+        accessorDescriptor =
+                getter != ScriptableObject.NOT_FOUND || setter != ScriptableObject.NOT_FOUND;
+    }
+
+    /**
+     * Create a property descriptor from a value and attributes.
+     *
+     * @param value the property value
+     * @param attributes the ScriptableObject attributes (READONLY, DONTENUM, PERMANENT)
+     * @param defineWritable whether to define the writable attribute
+     */
+    public PropertyDescriptor(Object value, int attributes, boolean defineWritable) {
+        this.value = value;
+        if (defineWritable) {
+            writable = (attributes & ScriptableObject.READONLY) == 0;
+        }
+        enumerable = (attributes & ScriptableObject.DONTENUM) == 0;
+        configurable = (attributes & ScriptableObject.PERMANENT) == 0;
+    }
+
+    /**
+     * Convert this descriptor to a JavaScript descriptor object.
+     *
+     * @param scope the scope in which to create the object
+     * @return a JavaScript descriptor object
+     */
+    public Scriptable toObject(VarScope scope) {
+        ScriptableObject desc = new NativeObject();
+        ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
+        if (hasValue()) desc.defineProperty("value", value, ScriptableObject.EMPTY);
+        if (hasWritable()) desc.defineProperty("writable", writable, ScriptableObject.EMPTY);
+        if (hasGetter()) desc.defineProperty("get", getter, ScriptableObject.EMPTY);
+        if (hasSetter()) desc.defineProperty("set", setter, ScriptableObject.EMPTY);
+        if (hasEnumerable()) desc.defineProperty("enumerable", enumerable, ScriptableObject.EMPTY);
+        if (hasConfigurable())
+            desc.defineProperty("configurable", configurable, ScriptableObject.EMPTY);
+        return desc;
+    }
+
+    public boolean isWritable() {
+        return Boolean.TRUE.equals(writable);
+    }
+
+    public boolean isWritable(boolean value) {
+        return ((Boolean) value).equals(writable);
+    }
+
+    public boolean hasWritable() {
+        return writable != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean isEnumerable() {
+        return Boolean.TRUE.equals(enumerable);
+    }
+
+    public boolean isEnumerable(boolean value) {
+        return ((Boolean) value).equals(enumerable);
+    }
+
+    public boolean hasEnumerable() {
+        return enumerable != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean isConfigurable() {
+        return Boolean.TRUE.equals(configurable);
+    }
+
+    public boolean isConfigurable(boolean value) {
+        return ((Boolean) value).equals(configurable);
+    }
+
+    public boolean hasConfigurable() {
+        return configurable != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean hasValue() {
+        return value != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean hasGetter() {
+        return getter != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean hasSetter() {
+        return setter != ScriptableObject.NOT_FOUND;
+    }
+
+    public boolean isDataDescriptor() {
+        return hasValue() || hasWritable();
+    }
+
+    public boolean isAccessorDescriptor() {
+        return hasGetter() || hasSetter();
+    }
+
+    public boolean isGenericDescriptor() {
+        return !isDataDescriptor() && !isAccessorDescriptor();
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntimeES6.java
@@ -6,8 +6,6 @@
 
 package org.mozilla.javascript;
 
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
-
 public class ScriptRuntimeES6 {
 
     public static Object requireObjectCoercible(
@@ -31,13 +29,13 @@ public class ScriptRuntimeES6 {
 
     /** Registers the symbol {@code [Symbol.species]} on the given constructor function. */
     public static void addSymbolSpecies(Context cx, VarScope scope, ScriptableObject constructor) {
-        DescriptorInfo desc = symbolSpecies(cx, scope, constructor);
+        PropertyDescriptor desc = symbolSpecies(cx, scope, constructor);
         constructor.defineOwnProperty(cx, SymbolKey.SPECIES, desc, false);
     }
 
-    public static DescriptorInfo symbolSpecies(
+    public static PropertyDescriptor symbolSpecies(
             Context cx, VarScope scope, ScriptableObject constructor) {
-        return new DescriptorInfo(
+        return new PropertyDescriptor(
                 false,
                 ScriptableObject.NOT_FOUND,
                 true,

--- a/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
@@ -221,7 +221,17 @@ public interface Scriptable extends PropHolder<Scriptable> {
      * @see ScriptableObject#getOwnPropertyDescriptor(Context, Object)
      */
     default PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object key) {
-        return null;
+        Object v;
+        if (key instanceof String) {
+            v = get((String) key, this);
+        } else if (key instanceof Number) {
+            v = get(((Number) key).intValue(), this);
+        } else if (key instanceof Symbol && this instanceof SymbolScriptable) {
+            v = ((SymbolScriptable) this).get((Symbol) key, this);
+        } else {
+            v = NOT_FOUND;
+        }
+        return v == NOT_FOUND ? null : new PropertyDescriptor(v, 0, false);
     }
 
     /**
@@ -240,6 +250,17 @@ public interface Scriptable extends PropHolder<Scriptable> {
      * @see ScriptableObject#defineOwnProperty(Context, Object, PropertyDescriptor)
      */
     default boolean defineOwnProperty(Context cx, Object key, PropertyDescriptor desc) {
+        if (key instanceof String) {
+            put((String) key, this, desc.value);
+            return has((String) key, this);
+        } else if (key instanceof Number) {
+            var k = ((Number) key).intValue();
+            put(k, this, desc.value);
+            return has(k, this);
+        } else if (key instanceof Symbol && this instanceof SymbolScriptable) {
+            ((SymbolScriptable) this).put((Symbol) key, this, desc.value);
+            return ((SymbolScriptable) this).has((Symbol) key, this);
+        }
         return false;
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Scriptable.java
@@ -207,6 +207,43 @@ public interface Scriptable extends PropHolder<Scriptable> {
     default void put(Symbol key, Scriptable start, Object value) {}
 
     /**
+     * Get the property descriptor for a named property.
+     *
+     * <p>This method allows any Scriptable implementation to describe the attributes of one of its
+     * properties, following the ECMAScript [[GetOwnProperty]] operation.
+     *
+     * <p>The default implementation returns null, indicating that this object does not support
+     * property descriptors or the property was not found.
+     *
+     * @param cx the current Context
+     * @param key the property key (String, Integer, or Symbol)
+     * @return a PropertyDescriptor if the property exists, null otherwise
+     * @see ScriptableObject#getOwnPropertyDescriptor(Context, Object)
+     */
+    default PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object key) {
+        return null;
+    }
+
+    /**
+     * Define or update a property descriptor on this object.
+     *
+     * <p>This method allows any Scriptable implementation to define properties with full descriptor
+     * support, following the ECMAScript [[DefineOwnProperty]] operation.
+     *
+     * <p>The default implementation returns false, indicating that property definition is not
+     * supported by this Scriptable implementation.
+     *
+     * @param cx the current Context
+     * @param key the property key (String, Integer, or Symbol)
+     * @param desc the property descriptor
+     * @return true if the property was successfully defined, false otherwise
+     * @see ScriptableObject#defineOwnProperty(Context, Object, PropertyDescriptor)
+     */
+    default boolean defineOwnProperty(Context cx, Object key, PropertyDescriptor desc) {
+        return false;
+    }
+
+    /**
      * Removes a property from this object. This operation corresponds to the ECMA [[Delete]] except
      * that the no result is returned. The runtime will guarantee that this method is called only if
      * the property exists. After this method is called, the runtime will call Scriptable.has to see

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -126,8 +126,8 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         }
     }
 
-    protected static DescriptorInfo buildDataDescriptor(Object value, int attributes) {
-        return new DescriptorInfo(value, attributes, true);
+    protected static PropertyDescriptor buildDataDescriptor(Object value, int attributes) {
+        return new PropertyDescriptor(value, attributes, true);
     }
 
     protected void setCommonDescriptorProperties(int attributes, boolean defineWritable) {
@@ -1457,10 +1457,10 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         try (var map = props.startCompoundOp(false)) {
             ids = props.getIds(map, false, true);
         }
-        DescriptorInfo[] descs = new DescriptorInfo[ids.length];
+        PropertyDescriptor[] descs = new PropertyDescriptor[ids.length];
         for (int i = 0, len = ids.length; i < len; ++i) {
             Object descObj = ScriptRuntime.getObjectElem(props, ids[i], cx);
-            var desc = new DescriptorInfo(ensureScriptableObject(descObj));
+            var desc = new PropertyDescriptor(ensureScriptableObject(descObj));
             checkPropertyDefinition(desc);
             descs[i] = desc;
         }
@@ -1478,10 +1478,10 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      */
     public boolean defineOwnProperty(Context cx, Object id, ScriptableObject desc) {
         checkPropertyDefinition(desc);
-        return defineOwnProperty(cx, id, new DescriptorInfo(desc), true);
+        return defineOwnProperty(cx, id, new PropertyDescriptor(desc), true);
     }
 
-    public boolean defineOwnProperty(Context cx, Object id, DescriptorInfo desc) {
+    public boolean defineOwnProperty(Context cx, Object id, PropertyDescriptor desc) {
         return defineOwnProperty(cx, id, desc, true);
     }
 
@@ -1498,7 +1498,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
      * @return always true at the moment
      */
     protected boolean defineOwnProperty(
-            Context cx, Object id, DescriptorInfo desc, boolean checkValid) {
+            Context cx, Object id, PropertyDescriptor desc, boolean checkValid) {
 
         Object key = null;
         int index = 0;
@@ -1543,140 +1543,12 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         }
     }
 
-    public static final class DescriptorInfo {
-        public Object enumerable = NOT_FOUND;
-        public Object writable = NOT_FOUND;
-        public Object configurable = NOT_FOUND;
-        public Object getter = NOT_FOUND;
-        public Object setter = NOT_FOUND;
-        public Object value = NOT_FOUND;
-        boolean accessorDescriptor;
-
-        public DescriptorInfo(ScriptableObject desc) {
-            enumerable = getProperty(desc, "enumerable");
-            writable = getProperty(desc, "writable");
-            configurable = getProperty(desc, "configurable");
-            getter = getProperty(desc, "get");
-            setter = getProperty(desc, "set");
-            value = getProperty(desc, "value");
-            accessorDescriptor = getter != NOT_FOUND || setter != NOT_FOUND;
-        }
-
-        public DescriptorInfo(
-                boolean enumerable, boolean writable, boolean configurable, Object value) {
-            this.enumerable = enumerable;
-            this.writable = writable;
-            this.configurable = configurable;
-            this.getter = NOT_FOUND;
-            this.setter = NOT_FOUND;
-            this.value = value;
-            accessorDescriptor = false;
-        }
-
-        public DescriptorInfo(
-                Object enumerable,
-                Object writable,
-                Object configurable,
-                Object getter,
-                Object setter,
-                Object value) {
-            this.enumerable = enumerable;
-            this.writable = writable;
-            this.configurable = configurable;
-            this.getter = getter;
-            this.setter = setter;
-            this.value = value;
-            accessorDescriptor = getter != NOT_FOUND || setter != NOT_FOUND;
-        }
-
-        DescriptorInfo(Object value, int attributes, boolean defineWritable) {
-            this.value = value;
-            if (defineWritable) {
-                writable = (attributes & READONLY) == 0;
-            }
-            enumerable = (attributes & DONTENUM) == 0;
-            configurable = (attributes & PERMANENT) == 0;
-        }
-
-        Scriptable toObject(VarScope scope) {
-            ScriptableObject desc = new NativeObject();
-            ScriptRuntime.setBuiltinProtoAndParent(desc, scope, TopLevel.Builtins.Object);
-            if (hasValue()) desc.defineProperty("value", value, EMPTY);
-            if (hasWritable()) desc.defineProperty("writable", writable, EMPTY);
-            if (hasGetter()) desc.defineProperty("get", getter, EMPTY);
-            if (hasSetter()) desc.defineProperty("set", setter, EMPTY);
-            if (hasEnumerable()) desc.defineProperty("enumerable", enumerable, EMPTY);
-            if (hasConfigurable()) desc.defineProperty("configurable", configurable, EMPTY);
-            return desc;
-        }
-
-        public boolean isWritable() {
-            return Boolean.TRUE.equals(writable);
-        }
-
-        public boolean isWritable(boolean value) {
-            return ((Boolean) value).equals(writable);
-        }
-
-        public boolean hasWritable() {
-            return writable != NOT_FOUND;
-        }
-
-        public boolean isEnumerable() {
-            return Boolean.TRUE.equals(enumerable);
-        }
-
-        public boolean isEnumerable(boolean value) {
-            return ((Boolean) value).equals(enumerable);
-        }
-
-        public boolean hasEnumerable() {
-            return enumerable != NOT_FOUND;
-        }
-
-        public boolean isConfigurable() {
-            return Boolean.TRUE.equals(configurable);
-        }
-
-        public boolean isConfigurable(boolean value) {
-            return ((Boolean) value).equals(configurable);
-        }
-
-        public boolean hasConfigurable() {
-            return configurable != NOT_FOUND;
-        }
-
-        public boolean hasValue() {
-            return value != NOT_FOUND;
-        }
-
-        public boolean hasGetter() {
-            return getter != NOT_FOUND;
-        }
-
-        public boolean hasSetter() {
-            return setter != NOT_FOUND;
-        }
-
-        public boolean isDataDescriptor() {
-            return hasValue() || hasWritable();
-        }
-
-        public boolean isAccessorDescriptor() {
-            return hasGetter() || hasSetter();
-        }
-
-        public boolean isGenericDescriptor() {
-            return !isDataDescriptor() && !isAccessorDescriptor();
-        }
-    }
-
     static boolean defineOrdinaryProperty(
             PropDescValueSetter descValueSetter,
             ScriptableObject owner,
             CompoundOperationMap<Scriptable> compoundOp,
             Object id,
-            DescriptorInfo info,
+            PropertyDescriptor info,
             boolean checkValid,
             Object key,
             int index) {
@@ -1725,7 +1597,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
     interface PropDescValueSetter {
         Slot<Scriptable> execute(
                 ScriptableObject owner,
-                DescriptorInfo info,
+                PropertyDescriptor info,
                 Object key,
                 Slot<Scriptable> existing,
                 CompoundOperationMap<Scriptable> map,
@@ -1734,7 +1606,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
 
     static Slot<Scriptable> setSlotValue(
             ScriptableObject owner,
-            DescriptorInfo info,
+            PropertyDescriptor info,
             Object key,
             Slot<Scriptable> existing,
             CompoundOperationMap<Scriptable> map,
@@ -1935,7 +1807,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         }
     }
 
-    protected static void checkPropertyDefinition(DescriptorInfo desc) {
+    protected static void checkPropertyDefinition(PropertyDescriptor desc) {
         Object getter = desc.getter;
         if (getter != NOT_FOUND && getter != Undefined.instance && !(getter instanceof Callable)) {
             throw ScriptRuntime.notFunctionError(getter);
@@ -1951,11 +1823,11 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
 
     protected final void checkPropertyChangeForSlot(
             Object id, Slot<?> current, ScriptableObject desc) {
-        checkPropertyChangeForSlot(id, current, new DescriptorInfo(desc));
+        checkPropertyChangeForSlot(id, current, new PropertyDescriptor(desc));
     }
 
     protected final void checkPropertyChangeForSlot(
-            Object id, Slot<?> current, DescriptorInfo info) {
+            Object id, Slot<?> current, PropertyDescriptor info) {
 
         if (current == null) { // new property
             if (!isExtensible()) throw ScriptRuntime.typeErrorById("msg.not.extensible");
@@ -2085,7 +1957,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         return hasProperty(desc, "get") || hasProperty(desc, "set");
     }
 
-    protected static boolean isAccessorDescriptor(DescriptorInfo desc) {
+    protected static boolean isAccessorDescriptor(PropertyDescriptor desc) {
         return desc.hasGetter() || desc.hasSetter();
     }
 
@@ -2099,7 +1971,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         return !isDataDescriptor(desc) && !isAccessorDescriptor(desc);
     }
 
-    protected static boolean isGenericDescriptor(DescriptorInfo desc) {
+    protected static boolean isGenericDescriptor(PropertyDescriptor desc) {
         return desc.isDataDescriptor() && !desc.isAccessorDescriptor();
     }
 
@@ -3017,7 +2889,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         readMaps(in);
     }
 
-    protected DescriptorInfo getOwnPropertyDescriptor(Context cx, Object id) {
+    public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         var slot = querySlot(cx, id);
         if (slot == null) return null;
         return slot.getPropertyDescriptor(cx, this);

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptableObject.java
@@ -1481,6 +1481,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         return defineOwnProperty(cx, id, new PropertyDescriptor(desc), true);
     }
 
+    @Override
     public boolean defineOwnProperty(Context cx, Object id, PropertyDescriptor desc) {
         return defineOwnProperty(cx, id, desc, true);
     }
@@ -2889,6 +2890,7 @@ public abstract class ScriptableObject extends SlotMapOwner<Scriptable>
         readMaps(in);
     }
 
+    @Override
     public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object id) {
         var slot = querySlot(cx, id);
         if (slot == null) return null;

--- a/rhino/src/main/java/org/mozilla/javascript/Slot.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Slot.java
@@ -1,7 +1,6 @@
 package org.mozilla.javascript;
 
 import java.io.Serializable;
-import org.mozilla.javascript.ScriptableObject.DescriptorInfo;
 
 /**
  * A Slot is the base class for all properties stored in the ScriptableObject class. There are a
@@ -53,7 +52,7 @@ public abstract class Slot<T extends PropHolder<T>> implements Serializable {
 
     abstract void setAttributes(int value);
 
-    DescriptorInfo getPropertyDescriptor(Context cx, T scope) {
+    PropertyDescriptor getPropertyDescriptor(Context cx, T scope) {
         return ScriptableObject.buildDataDescriptor(value, getAttributes());
     }
 

--- a/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
+++ b/rhino/src/main/java/org/mozilla/javascript/typedarrays/NativeTypedArrayView.java
@@ -38,6 +38,7 @@ import org.mozilla.javascript.NativeArray;
 import org.mozilla.javascript.NativeArrayIterator;
 import org.mozilla.javascript.NativeArrayIterator.ARRAY_ITERATOR_TYPE;
 import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.PropertyDescriptor;
 import org.mozilla.javascript.ScriptRuntime;
 import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.ScriptableObject;
@@ -253,8 +254,8 @@ public abstract class NativeTypedArrayView<T> extends NativeArrayBufferView
     }
 
     @Override
-    protected boolean defineOwnProperty(
-            Context cx, Object id, DescriptorInfo desc, boolean checkValid) {
+    public boolean defineOwnProperty(
+            Context cx, Object id, PropertyDescriptor desc, boolean checkValid) {
         if (id instanceof CharSequence) {
             // Definition of [[DefineOwnProperty]] for typed array from the spec
             Optional<Double> num = ScriptRuntime.canonicalNumericIndexString(id.toString());

--- a/tests/src/test/java/org/mozilla/javascript/tests/CustomScriptableDescriptorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/CustomScriptableDescriptorTest.java
@@ -1,0 +1,151 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.PropertyDescriptor;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
+
+/**
+ * Test property descriptor operations on custom Scriptable implementations that are not
+ * ScriptableObject.
+ */
+class CustomScriptableDescriptorTest {
+    private Context cx;
+    private VarScope root;
+
+    /** A simple custom Scriptable that supports property descriptors. */
+    static class CustomScriptableWithDescriptors extends NativeObject {
+        private final java.util.Map<String, PropertyDescriptor> descriptors =
+                new java.util.HashMap<>();
+
+        @Override
+        public PropertyDescriptor getOwnPropertyDescriptor(Context cx, Object key) {
+            if (key instanceof String) {
+                return descriptors.get((String) key);
+            }
+            return super.getOwnPropertyDescriptor(cx, key);
+        }
+
+        @Override
+        public boolean defineOwnProperty(Context cx, Object key, PropertyDescriptor desc) {
+            if (key instanceof String) {
+                String strKey = (String) key;
+                if (desc.hasValue()) {
+                    put(strKey, this, desc.value);
+                }
+                descriptors.put(strKey, desc);
+                return true;
+            }
+            return super.defineOwnProperty(cx, key, desc);
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        cx = Context.enter();
+        cx.setLanguageVersion(Context.VERSION_ES6);
+        root = cx.initStandardObjects();
+    }
+
+    @Test
+    void testCustomScriptableGetOwnPropertyDescriptor() {
+        CustomScriptableWithDescriptors obj = new CustomScriptableWithDescriptors();
+        obj.put("prop", obj, 42);
+        obj.defineOwnProperty(
+                cx,
+                "prop",
+                new PropertyDescriptor(
+                        true,
+                        true,
+                        false,
+                        ScriptableObject.NOT_FOUND,
+                        ScriptableObject.NOT_FOUND,
+                        42));
+
+        Object result =
+                cx.evaluateString(
+                        root,
+                        "let o = {}; o.prop = 42; Object.defineProperty(o, 'x', {"
+                                + "value: 100, writable: true, enumerable: false, configurable: false"
+                                + "}); Object.getOwnPropertyDescriptor(o, 'x');",
+                        "test",
+                        1,
+                        null);
+        assertTrue(result instanceof Scriptable);
+        Scriptable desc = (Scriptable) result;
+        assertEquals(100, ScriptableObject.getProperty(desc, "value"));
+    }
+
+    @Test
+    void testObjectDefinePropertyOnCustomScriptable() {
+        CustomScriptableWithDescriptors obj = new CustomScriptableWithDescriptors();
+        root.put("customObj", root, obj);
+
+        Object result =
+                cx.evaluateString(
+                        root,
+                        "Object.defineProperty(customObj, 'myProp', {"
+                                + "value: 'hello', writable: false, enumerable: true, configurable: true"
+                                + "}); customObj.myProp;",
+                        "test",
+                        1,
+                        null);
+        assertEquals("hello", result.toString());
+    }
+
+    @Test
+    void testObjectGetOwnPropertyNames() {
+        CustomScriptableWithDescriptors obj = new CustomScriptableWithDescriptors();
+        obj.put("foo", obj, 1);
+        obj.put("bar", obj, 2);
+        root.put("customObj", root, obj);
+
+        Object result =
+                cx.evaluateString(root, "Object.getOwnPropertyNames(customObj);", "test", 1, null);
+        assertTrue(result instanceof Scriptable);
+    }
+
+    @Test
+    void testDescriptorAttributesEnforced() {
+        String script =
+                "let obj = {};"
+                        + "Object.defineProperty(obj, 'readonlyProp', {"
+                        + "  value: 42,"
+                        + "  writable: false,"
+                        + "  enumerable: true,"
+                        + "  configurable: false"
+                        + "});"
+                        + "let desc = Object.getOwnPropertyDescriptor(obj, 'readonlyProp');"
+                        + "desc.writable === false && desc.configurable === false;";
+
+        Object result = cx.evaluateString(root, script, "test", 1, null);
+        assertTrue((Boolean) result);
+    }
+
+    @Test
+    void testdefineProperties() {
+        String script =
+                "let obj = {};"
+                        + "Object.defineProperties(obj, {"
+                        + "  a: { value: 1, enumerable: true },"
+                        + "  b: { value: 2, enumerable: true }"
+                        + "});"
+                        + "obj.a === 1 && obj.b === 2;";
+
+        Object result = cx.evaluateString(root, script, "test", 1, null);
+        assertTrue((Boolean) result);
+    }
+}

--- a/tests/src/test/java/org/mozilla/javascript/tests/PropertyDescriptorTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/PropertyDescriptorTest.java
@@ -1,0 +1,120 @@
+/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.javascript.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.PropertyDescriptor;
+import org.mozilla.javascript.ScriptableObject;
+import org.mozilla.javascript.VarScope;
+
+/** Test the PropertyDescriptor class. */
+class PropertyDescriptorTest {
+
+    @Test
+    void testDataDescriptorFromValues() {
+        PropertyDescriptor desc = new PropertyDescriptor(true, false, true, "test value");
+        assertTrue(desc.isEnumerable());
+        assertFalse(desc.isWritable());
+        assertTrue(desc.isConfigurable());
+        assertEquals("test value", desc.value);
+        assertTrue(desc.hasValue());
+        assertTrue(desc.hasWritable());
+        assertTrue(desc.hasEnumerable());
+        assertTrue(desc.hasConfigurable());
+        assertTrue(desc.isDataDescriptor());
+        assertFalse(desc.isAccessorDescriptor());
+        assertFalse(desc.isGenericDescriptor());
+    }
+
+    @Test
+    void testAccessorDescriptor() {
+        Object getter = new Object();
+        Object setter = new Object();
+        PropertyDescriptor desc =
+                new PropertyDescriptor(
+                        true,
+                        ScriptableObject.NOT_FOUND,
+                        true,
+                        getter,
+                        setter,
+                        ScriptableObject.NOT_FOUND);
+
+        assertTrue(desc.isEnumerable());
+        assertFalse(desc.hasWritable());
+        assertTrue(desc.hasGetter());
+        assertTrue(desc.hasSetter());
+        assertTrue(desc.isAccessorDescriptor());
+        assertFalse(desc.isDataDescriptor());
+    }
+
+    @Test
+    void testGenericDescriptor() {
+        PropertyDescriptor desc =
+                new PropertyDescriptor(
+                        true,
+                        ScriptableObject.NOT_FOUND,
+                        false,
+                        ScriptableObject.NOT_FOUND,
+                        ScriptableObject.NOT_FOUND,
+                        ScriptableObject.NOT_FOUND);
+
+        assertTrue(desc.isGenericDescriptor());
+        assertFalse(desc.isDataDescriptor());
+        assertFalse(desc.isAccessorDescriptor());
+    }
+
+    @Test
+    void testFromScriptableObject() {
+        try (Context cx = Context.enter()) {
+            ScriptableObject desc = new NativeObject();
+            desc.defineProperty("value", "test", ScriptableObject.EMPTY);
+            desc.defineProperty("writable", true, ScriptableObject.EMPTY);
+            desc.defineProperty("enumerable", false, ScriptableObject.EMPTY);
+            desc.defineProperty("configurable", true, ScriptableObject.EMPTY);
+
+            PropertyDescriptor pd = new PropertyDescriptor(desc);
+            assertEquals("test", pd.value);
+            assertTrue(pd.isWritable());
+            assertFalse(pd.isEnumerable());
+            assertTrue(pd.isConfigurable());
+        }
+    }
+
+    @Test
+    void testFromAttributeFlags() {
+        PropertyDescriptor desc =
+                new PropertyDescriptor(
+                        "value", ScriptableObject.READONLY | ScriptableObject.PERMANENT, true);
+
+        assertEquals("value", desc.value);
+        assertFalse(desc.isWritable());
+        assertTrue(desc.isConfigurable() == false);
+    }
+
+    @Test
+    void testToObject() {
+        try (Context cx = Context.enter()) {
+            VarScope scope = cx.initStandardObjects();
+            PropertyDescriptor desc = new PropertyDescriptor(true, false, true, "test");
+
+            Object obj = desc.toObject(scope);
+            assertTrue(obj instanceof ScriptableObject);
+
+            ScriptableObject so = (ScriptableObject) obj;
+            assertEquals("test", ScriptableObject.getProperty(so, "value"));
+            assertEquals(false, ScriptableObject.getProperty(so, "writable"));
+            assertEquals(true, ScriptableObject.getProperty(so, "enumerable"));
+            assertEquals(true, ScriptableObject.getProperty(so, "configurable"));
+        }
+    }
+}


### PR DESCRIPTION
Very rough quick prototype built by my robot friend. Open questions:
1. Should we do this on `Scriptable` or a subclass?
2. Should we do this at all?
3. Are there other APIs that should also be expanded to support `Scriptable`s? Should we delay that until we can maybe refactor things to be closer to ES primitives in terms of return results? Does any of us even have a strategy for how to make that transition?