### PR TITLE
Proxy construct parameter forwarding.

### DIFF
--- a/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
+++ b/rhino/src/main/java/org/mozilla/javascript/NativeProxy.java
@@ -1316,7 +1316,8 @@ class NativeProxy extends ScriptableObject {
 
             Function trap = getTrap(TRAP_CONSTRUCT);
             if (trap != null) {
-                Object result = callTrap(trap, new Object[] {target, args, this});
+                Scriptable argumentsList = cx.newArray(scope, args);
+                Object result = callTrap(trap, new Object[] {target, argumentsList, this});
                 if (!(result instanceof Scriptable) || ScriptRuntime.isSymbol(result)) {
                     throw ScriptRuntime.typeError("Constructor trap has to return a scriptable.");
                 }

--- a/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
+++ b/tests/src/test/java/org/mozilla/javascript/tests/es6/NativeProxyTest.java
@@ -103,6 +103,28 @@ public class NativeProxyTest {
         Utils.assertWithAllModes_ES6("true true true 2 1 4", js);
     }
 
+    /**
+     * Test parameter forwarding when the Proxy 'construct' trap forwards its argument list to
+     * Reflect.construct. Verifies that the internal arguments array is correctly passed to the
+     * target constructor.
+     */
+    @Test
+    public void constructWithTrapArgumentsConsumedByReflect() {
+        final String script =
+                "  var res = '';\n"
+                        + "function foo(a, b) {\n"
+                        + "  res += 'foo(' + a + ' ' + b + ')';\n"
+                        + "}\n"
+                        + "var p = new Proxy(foo, {\n"
+                        + "  construct: function(target, args, newTarget) {\n"
+                        + "    return Reflect.construct(target, args, newTarget);\n"
+                        + "  }\n"
+                        + "});\n"
+                        + "new p(1, 'test');\n"
+                        + "res;";
+        Utils.assertWithAllModes_ES6("foo(1 test)", script);
+    }
+
     @Test
     public void apply() {
         String js =

--- a/tests/testsrc/test262.properties
+++ b/tests/testsrc/test262.properties
@@ -1915,9 +1915,7 @@ built-ins/Promise 416/677 (61.45%)
     resolve-thenable-deferred.js {unsupported: [async]}
     resolve-thenable-immed.js {unsupported: [async]}
 
-built-ins/Proxy 64/311 (20.58%)
-    construct/arguments-realm.js
-    construct/call-parameters.js
+built-ins/Proxy 62/311 (19.94%)
     construct/call-parameters-new-target.js
     construct/trap-is-missing-target-is-proxy.js {unsupported: [class]}
     construct/trap-is-null.js


### PR DESCRIPTION
Fixed parameter forwarding when the Proxy 'construct' trap forwards its argument list to  Reflect.construct.