### PR TITLE
JFR instrumentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ When running the benchmarks you may find a couple of environment variables usefu
   argument. This allows for things like running JFR as the profiler to
   collect information on lock contention or other events.
 
+### JFR events
+
+Rhino will produces JFR events for a number of internal operations
+such as initialising global objects, parsing, compiling, and script
+execution These, along with standard junit events, can be enabled for
+`rhino:test` and `tests:test` by adding `-PjfrTestRecording` to the
+gradle options. If test recording is switched on then a jfr file will
+be created in the `build/jfr/test/` directory of the task for each JVM
+process which runs tests. You'll likely only want these types of
+traces for large tests such as `Test262SuiteTest`.
+
 ### Testing on other Java Versions
 
 It is a good idea to test major changes on Java 17 before assuming that they will pass the CI

--- a/rhino/build.gradle
+++ b/rhino/build.gradle
@@ -5,6 +5,19 @@ plugins {
 
 dependencies {
     testImplementation project(':testutils')
+    // Emits JFR events for test discovery and execution. Run with
+    // "-PjfrTestRecording" to record them.
+    testRuntimeOnly 'org.junit.platform:junit-platform-jfr'
+}
+
+tasks.withType(Test).configureEach {
+    if (project.hasProperty('jfrTestRecording')) {
+        def jfrDir = layout.buildDirectory.dir("jfr/${name}").get().asFile
+        doFirst {
+            jfrDir.mkdirs()
+        }
+        jvmArgs += "-XX:StartFlightRecording=settings=profile,dumponexit=true,filename=${jfrDir}"
+    }
 }
 
 jar {

--- a/rhino/src/main/java/module-info.java
+++ b/rhino/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module org.mozilla.rhino {
 
     requires java.compiler;
     requires jdk.dynalink;
+    requires jdk.jfr;
     requires transitive java.desktop;
     requires java.logging;
 

--- a/rhino/src/main/java/org/mozilla/javascript/ClassCompileEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ClassCompileEvent.java
@@ -1,0 +1,31 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.ClassCompileEvent")
+@Description("Class compilation")
+@Registered(true)
+@Enabled(false)
+public class ClassCompileEvent extends JFREmitter.RhinoEvent {
+    @Label("Source Name")
+    public String name;
+
+    ClassCompileEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            name = (String) data[0];
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
+++ b/rhino/src/main/java/org/mozilla/javascript/CodeGenerator.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.mozilla.javascript.InstrumentEmitter.Type;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.ast.Jump;
 import org.mozilla.javascript.ast.ScriptNode;
@@ -56,6 +57,19 @@ class CodeGenerator<T extends ScriptOrFn<T>> {
     private static final int ECF_TAIL = 1 << 0;
 
     public JSDescriptor<T> compile(
+            CompilerEnvirons compilerEnv,
+            ScriptNode tree,
+            String rawSource,
+            boolean returnFunction) {
+        var event = InstrumentEmitter.emitter.startEvent(Type.COMPILE_INTERPRETER);
+        try {
+            return compileInt(compilerEnv, tree, rawSource, returnFunction);
+        } finally {
+            InstrumentEmitter.emitter.endEvent(event, tree.getSourceName());
+        }
+    }
+
+    private JSDescriptor<T> compileInt(
             CompilerEnvirons compilerEnv,
             ScriptNode tree,
             String rawSource,

--- a/rhino/src/main/java/org/mozilla/javascript/Context.java
+++ b/rhino/src/main/java/org/mozilla/javascript/Context.java
@@ -32,6 +32,7 @@ import java.util.TimeZone;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.mozilla.classfile.ClassFileWriter.ClassSizeException;
+import org.mozilla.javascript.InstrumentEmitter.Type;
 import org.mozilla.javascript.ast.AstRoot;
 import org.mozilla.javascript.ast.ScriptNode;
 import org.mozilla.javascript.debug.DebuggableScript;
@@ -2768,6 +2769,27 @@ public class Context implements Closeable {
     }
 
     private ScriptNode parse(
+            String sourceString,
+            String sourceName,
+            int lineno,
+            CompilerEnvirons compilerEnv,
+            ErrorReporter compilationErrorReporter,
+            boolean returnFunction) {
+        var event = InstrumentEmitter.emitter.startEvent(Type.PARSE);
+        try {
+            return parseInt(
+                    sourceString,
+                    sourceName,
+                    lineno,
+                    compilerEnv,
+                    compilationErrorReporter,
+                    returnFunction);
+        } finally {
+            InstrumentEmitter.emitter.endEvent(event, sourceName, sourceString.length());
+        }
+    }
+
+    private ScriptNode parseInt(
             String sourceString,
             String sourceName,
             int lineno,

--- a/rhino/src/main/java/org/mozilla/javascript/InstrumentEmitter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InstrumentEmitter.java
@@ -1,0 +1,56 @@
+package org.mozilla.javascript;
+
+import java.lang.reflect.Constructor;
+
+public abstract class InstrumentEmitter {
+
+    public enum Type {
+        PARSE,
+        COMPILE_INTERPRETER,
+        COMPILE_CLASSFILE,
+        SCRIPT_EXEC,
+        SAFE_OBJECTS_INIT,
+        OBJECTS_INIT,
+        TEST_EVENT
+    }
+
+    public static final InstrumentEmitter emitter;
+
+    static {
+        InstrumentEmitter emitterTmp;
+        try {
+            Class<?> jfrClass = Class.forName("jdk.jfr.Event");
+            if (jfrClass != null) {
+                @SuppressWarnings("unchecked")
+                var c =
+                        (Constructor<? extends InstrumentEmitter>)
+                                Class.forName("org.mozilla.javascript.JFREmitter").getConstructor();
+                emitterTmp = c.newInstance();
+            } else {
+                emitterTmp = new NullEmitter();
+            }
+        } catch (Throwable t) {
+            t.printStackTrace();
+            emitterTmp = new NullEmitter();
+        }
+        emitter = emitterTmp;
+    }
+
+    public abstract Object startEvent(Type type);
+
+    public abstract void endEvent(Object event, Object... data);
+
+    private static class NullEmitter extends InstrumentEmitter {
+
+        private NullEmitter() {}
+
+        @Override
+        public Object startEvent(Type type) {
+            return null;
+        }
+
+        public void endEvent(Object event, Object... data) {
+            // Do nothing here.
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/InterpreterCompileEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/InterpreterCompileEvent.java
@@ -1,0 +1,31 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.InterpreterCompileEvent")
+@Description("Interpreter compilation")
+@Registered(true)
+@Enabled(false)
+public class InterpreterCompileEvent extends JFREmitter.RhinoEvent {
+    @Label("Source Name")
+    public String name;
+
+    public InterpreterCompileEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            name = (String) data[0];
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/JFREmitter.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JFREmitter.java
@@ -1,0 +1,81 @@
+package org.mozilla.javascript;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import jdk.jfr.Event;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.FlightRecorderListener;
+import jdk.jfr.Recording;
+import jdk.jfr.RecordingState;
+
+class JFREmitter extends InstrumentEmitter {
+
+    private static final AtomicInteger INFLIGHT_COUNT;
+
+    static {
+        INFLIGHT_COUNT = new AtomicInteger();
+        FlightRecorder.addListener(new RhinoRecordingListener());
+        FlightRecorder.register(ParseEvent.class);
+        FlightRecorder.register(InterpreterCompileEvent.class);
+        FlightRecorder.register(ClassCompileEvent.class);
+        FlightRecorder.register(ScriptExecEvent.class);
+        FlightRecorder.register(ObjectsInitEvent.class);
+        FlightRecorder.register(SafeObjectsInitEvent.class);
+    }
+
+    private static class RhinoRecordingListener implements FlightRecorderListener {
+        @Override
+        public void recorderInitialized(FlightRecorder recorder) {
+            for (var recording : recorder.getRecordings()) {
+                if (recording.getState() == RecordingState.RUNNING) {
+                    INFLIGHT_COUNT.incrementAndGet();
+                }
+            }
+        }
+
+        @Override
+        public void recordingStateChanged(Recording recording) {
+            RecordingState state = recording.getState();
+            if (state == RecordingState.RUNNING) {
+                INFLIGHT_COUNT.incrementAndGet();
+            } else if (state == RecordingState.STOPPED) {
+                INFLIGHT_COUNT.decrementAndGet();
+            }
+        }
+    }
+
+    public JFREmitter() {}
+
+    @Override
+    public Object startEvent(Type type) {
+        if (INFLIGHT_COUNT.get() == 0) {
+            return null;
+        }
+        return buildEvent(type);
+    }
+
+    private static Object buildEvent(Type type) {
+        return switch (type) {
+            case PARSE -> new ParseEvent();
+            case COMPILE_INTERPRETER -> new InterpreterCompileEvent();
+            case COMPILE_CLASSFILE -> new ClassCompileEvent();
+            case SCRIPT_EXEC -> new ScriptExecEvent();
+            case SAFE_OBJECTS_INIT -> new SafeObjectsInitEvent();
+            case OBJECTS_INIT -> new ObjectsInitEvent();
+            case TEST_EVENT -> new TestEvent();
+            default -> {
+                throw new UnsupportedOperationException("Unsupported event type");
+            }
+        };
+    }
+
+    @Override
+    public void endEvent(Object event, Object... data) {
+        if (event != null) {
+            ((RhinoEvent) event).fillAndSubmit(data);
+        }
+    }
+
+    abstract static class RhinoEvent extends Event {
+        abstract void fillAndSubmit(Object... data);
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/JSScript.java
+++ b/rhino/src/main/java/org/mozilla/javascript/JSScript.java
@@ -1,5 +1,7 @@
 package org.mozilla.javascript;
 
+import org.mozilla.javascript.InstrumentEmitter.Type;
+
 /**
  * Represents a script object built upon a {@link JSDescriptor}. This class does not support the
  * {@link Callable} interface scripts do not support arguments or some other parts of a call
@@ -36,10 +38,15 @@ public class JSScript implements Script, ScriptOrFn<JSScript> {
             ret = ScriptRuntime.doTopCall(this, cx, scope, thisObj, descriptor.isStrict());
             cx.processMicrotasks();
         } else {
-            ret =
-                    descriptor
-                            .getCode()
-                            .execute(cx, this, null, scope, thisObj, ScriptRuntime.emptyArgs);
+            var event = InstrumentEmitter.emitter.startEvent(Type.SCRIPT_EXEC);
+            try {
+                ret =
+                        descriptor
+                                .getCode()
+                                .execute(cx, this, null, scope, thisObj, ScriptRuntime.emptyArgs);
+            } finally {
+                InstrumentEmitter.emitter.endEvent(event, getDescriptor().getSourceName());
+            }
         }
         return ret;
     }

--- a/rhino/src/main/java/org/mozilla/javascript/ObjectsInitEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ObjectsInitEvent.java
@@ -1,0 +1,26 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.ObjectsInitEvent")
+@Description("Safe objects initialisation")
+@Registered(true)
+@Enabled(false)
+public class ObjectsInitEvent extends JFREmitter.RhinoEvent {
+    public ObjectsInitEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ParseEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ParseEvent.java
@@ -1,0 +1,35 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.ParseEvent")
+@Description("Script parsing")
+@Registered(true)
+@Enabled(false)
+public class ParseEvent extends JFREmitter.RhinoEvent {
+    @Label("Source Name")
+    public String name;
+
+    @Label("Source Length")
+    public int length;
+
+    public ParseEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            name = (String) data[0];
+            length = (Integer) data[1];
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/SafeObjectsInitEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/SafeObjectsInitEvent.java
@@ -1,0 +1,26 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.SafeObjectsInitEvent")
+@Description("Safe objects initialisation")
+@Registered(true)
+@Enabled(false)
+public class SafeObjectsInitEvent extends JFREmitter.RhinoEvent {
+    public SafeObjectsInitEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptExecEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptExecEvent.java
@@ -1,0 +1,31 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.ScriptExecEvent")
+@Description("Script execution")
+@Registered(true)
+@Enabled(false)
+public class ScriptExecEvent extends JFREmitter.RhinoEvent {
+    @Label("Source Name")
+    public String name;
+
+    public ScriptExecEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            name = (String) data[0];
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
+++ b/rhino/src/main/java/org/mozilla/javascript/ScriptRuntime.java
@@ -28,6 +28,7 @@ import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.mozilla.javascript.InstrumentEmitter.Type;
 import org.mozilla.javascript.ast.FunctionNode;
 import org.mozilla.javascript.dtoa.DoubleFormatter;
 import org.mozilla.javascript.lc.type.TypeInfo;
@@ -206,6 +207,15 @@ public class ScriptRuntime {
     }
 
     public static TopLevel initSafeStandardObjects(Context cx, TopLevel scope, boolean sealed) {
+        var event = InstrumentEmitter.emitter.startEvent(Type.SAFE_OBJECTS_INIT);
+        try {
+            return initSafeStandardObjectsInt(cx, scope, sealed);
+        } finally {
+            InstrumentEmitter.emitter.endEvent(event);
+        }
+    }
+
+    private static TopLevel initSafeStandardObjectsInt(Context cx, TopLevel scope, boolean sealed) {
         if (scope == null) {
             scope = new TopLevel();
         }
@@ -323,6 +333,15 @@ public class ScriptRuntime {
     }
 
     public static TopLevel initStandardObjects(Context cx, TopLevel scope, boolean sealed) {
+        var event = InstrumentEmitter.emitter.startEvent(Type.OBJECTS_INIT);
+        try {
+            return initStandardObjectsInt(cx, scope, sealed);
+        } finally {
+            InstrumentEmitter.emitter.endEvent(event);
+        }
+    }
+
+    private static TopLevel initStandardObjectsInt(Context cx, TopLevel scope, boolean sealed) {
         TopLevel s = initSafeStandardObjects(cx, scope, sealed);
 
         // These depend on the legacy initialization behavior of the lazy loading mechanism

--- a/rhino/src/main/java/org/mozilla/javascript/TestEvent.java
+++ b/rhino/src/main/java/org/mozilla/javascript/TestEvent.java
@@ -1,0 +1,31 @@
+package org.mozilla.javascript;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Enabled;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Registered;
+
+@Category({"Mozilla", "Rhino"})
+@Name("org.mozilla.javascript.TestEvent")
+@Description("Test event")
+@Registered(true)
+@Enabled(true)
+public class TestEvent extends JFREmitter.RhinoEvent {
+    @Label("Source Name")
+    public String name;
+
+    public TestEvent() {
+        super();
+        begin();
+    }
+
+    @Override
+    void fillAndSubmit(Object... data) {
+        if (this.shouldCommit()) {
+            name = (String) data[0];
+            this.commit();
+        }
+    }
+}

--- a/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/rhino/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -27,6 +27,8 @@ import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Evaluator;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.GeneratedClassLoader;
+import org.mozilla.javascript.InstrumentEmitter;
+import org.mozilla.javascript.InstrumentEmitter.Type;
 import org.mozilla.javascript.JSDescriptor;
 import org.mozilla.javascript.JSFunction;
 import org.mozilla.javascript.JSScript;
@@ -108,6 +110,19 @@ public class Codegen implements Evaluator {
     }
 
     private <T extends ScriptOrFn<T>> CodegenCompilationResult<T> doCompile(
+            CompilerEnvirons compilerEnv,
+            ScriptNode tree,
+            String rawSource,
+            boolean returnFunction) {
+        var event = InstrumentEmitter.emitter.startEvent(Type.COMPILE_CLASSFILE);
+        try {
+            return doCompileInt(compilerEnv, tree, rawSource, returnFunction);
+        } finally {
+            InstrumentEmitter.emitter.endEvent(event, tree.getSourceName());
+        }
+    }
+
+    private <T extends ScriptOrFn<T>> CodegenCompilationResult<T> doCompileInt(
             CompilerEnvirons compilerEnv,
             ScriptNode tree,
             String rawSource,

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation project(':rhino-xml')
 
     testImplementation project(':testutils')
+    // Emits JFR events for test discovery and execution. Run with
+    // "-PjfrTestRecording" to record them.
+    testRuntimeOnly 'org.junit.platform:junit-platform-jfr'
     testImplementation(libs.archunit.get()) {
         exclude group: 'junit'
     }
@@ -38,6 +41,20 @@ dependencies {
 
     osgiIntegrationBundles platform("org.ow2.asm:asm-bom:9.9.1")
     osgiIntegrationBundles "org.apache.aries.spifly:org.apache.aries.spifly.dynamic.bundle:1.3.7"
+}
+
+tasks.withType(Test).configureEach {
+    if (project.hasProperty('jfrTestRecording')) {
+        def jfrDir = layout.buildDirectory.dir("jfr/${name}").get().asFile
+        def jfcFile = layout.projectDirectory.file("tests.jfc")
+        doFirst {
+            jfrDir.mkdirs()
+        }
+        // Ensure the stack depth is deep enough to avoid truncation.
+        jvmArgs += "-XX:FlightRecorderOptions=stackdepth=256"
+        // Set recording to run from start, and with a configuraiton that enables our internal event types.
+        jvmArgs += "-XX:StartFlightRecording=settings=${jfcFile},dumponexit=true,filename=${jfrDir},maxsize=1GB"
+    }
 }
 
 tasks.withType(JavaCompile) {

--- a/tests/tests.jfc
+++ b/tests/tests.jfc
@@ -1,0 +1,1203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Recommended way to edit .jfc files is to use the configure command of
+the 'jfr' tool, i.e. jfr configure, or JDK Mission Control
+see Window -> Flight Recorder Template Manager
+
+-->
+<configuration label="Custom" version="2.0">
+
+  <event name="jdk.ResidentSetSize">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadAllocationStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ClassLoadingStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ClassLoaderStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.JavaThreadStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.SymbolTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.StringTableStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.ThreadStart">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadEnd">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ThreadSleep">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadPark">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.VirtualThreadStart">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.VirtualThreadEnd">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.VirtualThreadPinned">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.VirtualThreadSubmitFailed">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorEnter">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorWait">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold" control="locking-threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorNotify">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorInflate">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorDeflate">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.JavaMonitorStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.SyncOnValueBasedClass">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ContinuationFreeze">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ContinuationThaw">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ContinuationFreezeFast">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.ContinuationFreezeSlow">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.ContinuationThawFast">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.ContinuationThawSlow">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.ReservedStackActivation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ClassLoad">
+    <setting name="enabled" control="class-loading">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ClassDefine">
+    <setting name="enabled" control="class-loading">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.RedefineClasses">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.RetransformClasses">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ClassRedefinition">
+    <setting name="enabled" control="class-loading">true</setting>
+  </event>
+
+  <event name="jdk.ClassUnload">
+    <setting name="enabled" control="class-loading">false</setting>
+  </event>
+
+  <event name="jdk.JVMInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.InitialSystemProperty">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ExecutionSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-java-interval">20 ms</setting>
+  </event>
+
+  <event name="jdk.NativeMethodSample">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+    <setting name="period" control="method-sampling-native-interval">20 ms</setting>
+  </event>
+
+  <event name="jdk.MethodTrace">
+    <setting name="enabled">true</setting>
+    <setting name="filter" control="method-trace"/>
+    <setting name="threshold">0 ms</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MethodTiming">
+    <setting name="enabled">true</setting>
+    <setting name="filter" control="method-timing"/>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.SafepointLatency">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+    <setting name="throttle">off</setting>
+  </event>
+
+  <event name="jdk.CPUTimeSample">
+    <setting name="enabled" control="method-sampling-enabled">false</setting>
+    <setting name="throttle">500/s</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.CPUTimeSamplesLost">
+    <setting name="enabled" control="method-sampling-enabled">true</setting>
+  </event>
+
+  <event name="jdk.SafepointBegin">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointStateSynchronization">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.SafepointEnd">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.ExecuteVMOperation">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">10 ms</setting>
+  </event>
+
+  <event name="jdk.Shutdown">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ThreadDump">
+    <setting name="enabled" control="thread-dump-enabled">true</setting>
+    <setting name="period" control="thread-dump">everyChunk</setting>
+  </event>
+
+  <event name="jdk.IntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.LongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.DoubleFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.BooleanFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.StringFlag">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.IntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedIntFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.LongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.UnsignedLongFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DoubleFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.BooleanFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.StringFlagChanged">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ObjectCount">
+    <setting name="enabled" control="gc-enabled-all">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCHeapConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.YoungGenerationConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCTLABConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.GCSurvivorConfiguration">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectCountAfterGC">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.GCHeapMemoryUsage">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCHeapMemoryPoolUsage">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.GCHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PSHeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceGCThreshold">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceAllocationFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceOOM">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.MetaspaceChunkFreeListSummary">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.SystemGC">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ParallelOldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.YoungGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.OldGarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.G1GarbageCollection">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePause">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel1">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel2">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel3">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhasePauseLevel4">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrent">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrentLevel1">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCPhaseConcurrentLevel2">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.GCReferenceStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GCCPUTime">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromotionFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationFailed">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.EvacuationInformation">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1MMU">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationYoungStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1EvacuationOldStatistics">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.GCPhaseParallel">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.G1BasicIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1AdaptiveIHOP">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectInNewPLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.PromoteObjectOutsidePLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.ConcurrentModeFailure">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.AllocationRequiringGC">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.TenuringDistribution">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionInformation">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.G1HeapRegionTypeChange">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.ShenandoahHeapRegionInformation">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ShenandoahHeapRegionStateChange">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.ShenandoahEvacuationInformation">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+  </event>
+
+  <event name="jdk.OldObjectSample">
+    <setting name="enabled" control="old-objects-enabled">true</setting>
+    <setting name="stackTrace" control="old-objects-stack-trace">false</setting>
+    <setting name="cutoff" control="old-objects-cutoff">0 ns</setting>
+  </event>
+
+  <event name="jdk.NativeMemoryUsage">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.NativeMemoryUsageTotal">
+    <setting name="enabled" control="gc-enabled-normal">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.CompilerConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CompilerStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.Compilation">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-compilation-threshold">1000 ms</setting>
+  </event>
+
+  <event name="jdk.CompilerPhase">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="threshold" control="compiler-phase-threshold">60 s</setting>
+  </event>
+
+  <event name="jdk.CompilationFailure">
+    <setting name="enabled" control="compiler-enabled-failure">false</setting>
+  </event>
+
+  <event name="jdk.CompilerInlining">
+    <setting name="enabled" control="compiler-enabled-failure">false</setting>
+  </event>
+
+  <event name="jdk.JITRestart">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+  </event>
+
+  <event name="jdk.CodeCacheConfiguration">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheStatistics">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.CodeCacheFull">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+  </event>
+
+  <event name="jdk.OSInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.VirtualizationInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ContainerConfiguration">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ContainerCPUUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerCPUThrottling">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerMemoryUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.ContainerIOUsage">
+    <setting name="enabled">true</setting>
+    <setting name="period">30 s</setting>
+  </event>
+
+  <event name="jdk.CPUInformation">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.ThreadContextSwitchRate">
+    <setting name="enabled" control="compiler-enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ThreadCPULoad">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.CPUTimeStampCounter">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.SystemProcess">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.ProcessStart">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.NetworkUtilization">
+    <setting name="enabled">true</setting>
+    <setting name="period">5 s</setting>
+  </event>
+
+  <event name="jdk.CompilerQueueUtilization">
+    <setting name="enabled">true</setting>
+    <setting name="period">10 s</setting>
+  </event>
+
+  <event name="jdk.InitialEnvironmentVariable">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.PhysicalMemory">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.SwapSpace">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationInNewTLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationOutsideTLAB">
+    <setting name="enabled" control="gc-enabled-high">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ObjectAllocationSample">
+    <setting name="enabled" control="object-allocation-enabled">true</setting>
+    <setting name="throttle" control="allocation-profiling">150/s</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.NativeLibrary">
+    <setting name="enabled">true</setting>
+    <setting name="period">everyChunk</setting>
+  </event>
+
+  <event name="jdk.NativeLibraryLoad">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.NativeLibraryUnload">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ModuleRequire">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.ModuleExport">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.FileForce">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">20 ms</setting>
+  </event>
+
+  <event name="jdk.FileRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+    <setting name="throttle">100/s</setting>
+  </event>
+
+  <event name="jdk.FileWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+    <setting name="throttle">100/s</setting>
+  </event>
+
+  <event name="jdk.SocketRead">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+    <setting name="throttle">100/s</setting>
+  </event>
+
+  <event name="jdk.SocketWrite">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+    <setting name="throttle">100/s</setting>
+  </event>
+
+  <event name="jdk.Deserialization">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.SerializationMisdeclaration">
+    <setting name="enabled">false</setting>
+  </event>
+
+  <event name="jdk.InitialSecurityProperty">
+    <setting name="enabled">true</setting>
+    <setting name="period">beginChunk</setting>
+  </event>
+
+  <event name="jdk.SecurityPropertyModification">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.SecurityProviderService">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.TLSHandshake">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.X509Validation">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.X509Certificate">
+    <setting name="enabled">false</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.JavaExceptionThrow">
+    <setting name="enabled" control="enable-exceptions">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="throttle" control="exceptions-throttle-rate">off</setting>
+  </event>
+
+  <event name="jdk.JavaErrorThrow">
+    <setting name="enabled" control="enable-errors">true</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.ExceptionStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">1000 ms</setting>
+  </event>
+
+  <event name="jdk.ActiveRecording">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ActiveSetting">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.Flush">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ns</setting>
+  </event>
+
+  <event name="jdk.DataLoss">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.DumpReason">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="jdk.ZAllocationStall">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZPageAllocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">1 ms</setting>
+  </event>
+
+  <event name="jdk.ZRelocationSet">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZRelocationSetGroup">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsCounter">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZStatisticsSampler">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZThreadPhase">
+    <setting name="enabled">false</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZUncommit">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZYoungGarbageCollection">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.ZOldGarbageCollection">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ms</setting>
+  </event>
+
+  <event name="jdk.Deoptimization">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">false</setting>
+  </event>
+
+  <event name="jdk.HeapDump">
+    <setting name="enabled">true</setting>
+    <setting name="threshold">0 ns</setting>
+    <setting name="stackTrace">true</setting>
+  </event>
+
+  <event name="jdk.DirectBufferStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">5 s</setting>
+  </event>
+
+  <event name="jdk.FinalizerStatistics">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.JavaAgent">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.NativeAgent">
+    <setting name="enabled">true</setting>
+    <setting name="period">endChunk</setting>
+  </event>
+
+  <event name="jdk.DeprecatedInvocation">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="level">forRemoval</setting>
+  </event>
+
+  <event name="org.mozilla.javascript.ClassCompileEvent">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="org.mozilla.javascript.InterpreterCompileEvent">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="org.mozilla.javascript.ParseEvent">
+    <setting name="enabled">true</setting>
+  </event>
+
+  <event name="org.mozilla.javascript.ObjectsInitEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  
+  <event name="org.mozilla.javascript.SafeObjectsInitEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  
+  <event name="org.mozilla.javascript.ScriptExecEvent">
+    <setting name="enabled">true</setting>
+  </event>
+  
+  <!--
+  Contents of the control element is not read by the JVM, it's used
+  by JDK Mission Control and the 'jfr'-tool to change settings that
+  carry the control attribute.
+
+  -->
+  <control>
+
+    <selection default="normal" name="gc" label="Garbage Collector">
+      <option name="off" label="Off">off</option>
+      <option name="normal" label="Normal">normal</option>
+      <option name="detailed" label="Detailed">detailed</option>
+      <option name="high" label="High, incl. TLABs/PLABs (may cause many events)">high</option>
+      <option name="all" label="All, incl. Heap Statistics (may cause long GCs)">all</option>
+    </selection>
+
+    <condition name="gc-enabled-normal" true="true" false="false">
+      <or>
+        <test name="gc" value="normal" operator="equal"/>
+        <test name="gc" value="detailed" operator="equal"/>
+        <test name="gc" value="high" operator="equal"/>
+        <test name="gc" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-detailed" true="true" false="false">
+      <or>
+        <test name="gc" value="detailed" operator="equal"/>
+        <test name="gc" value="high" operator="equal"/>
+        <test name="gc" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-high" true="true" false="false">
+      <or>
+        <test name="gc" value="high" operator="equal"/>
+        <test name="gc" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="gc-enabled-all" true="true" false="false">
+      <test name="gc" value="all" operator="equal"/>
+    </condition>
+
+    <selection default="low" name="allocation-profiling" label="Allocation Profiling">
+      <option name="off" label="Off">0/s</option>
+      <option name="low" label="Low">150/s</option>
+      <option name="medium" label="Medium">300/s</option>
+      <option name="high" label="High">1000/s</option>
+      <option name="maximum" label="Maximum">1000000000/s</option>
+    </selection>
+
+    <condition name="object-allocation-enabled" true="true" false="false">
+      <not>
+        <test name="allocation-profiling" value="off" operator="equal"/>
+      </not>
+    </condition>
+
+    <selection default="normal" name="compiler" label="Compiler">
+      <option name="off" label="Off">off</option>
+      <option name="normal" label="Normal">normal</option>
+      <option name="detailed" label="Detailed">detailed</option>
+      <option name="all" label="All">all</option>
+    </selection>
+
+    <condition name="compiler-enabled" true="false" false="true">
+      <test name="compiler" value="off" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-enabled-failure" true="true" false="false">
+      <or>
+        <test name="compiler" value="detailed" operator="equal"/>
+        <test name="compiler" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="compiler-sweeper-threshold" true="0 ms" false="100 ms">
+      <test name="compiler" value="all" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="1000 ms">
+      <test name="compiler" value="normal" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="100 ms">
+      <test name="compiler" value="detailed" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-compilation-threshold" true="0 ms">
+      <test name="compiler" value="all" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="60 s">
+      <test name="compiler" value="normal" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="10 s">
+      <test name="compiler" value="detailed" operator="equal"/>
+    </condition>
+
+    <condition name="compiler-phase-threshold" true="0 s">
+      <test name="compiler" value="all" operator="equal"/>
+    </condition>
+
+    <selection default="normal" name="method-profiling" label="Method Profiling">
+      <option name="off" label="Off">off</option>
+      <option name="normal" label="Normal">normal</option>
+      <option name="high" label="High">high</option>
+      <option name="max" label="Maximum (High Overhead)">max</option>
+    </selection>
+
+    <condition name="method-sampling-java-interval" true="999 d">
+      <test name="method-profiling" value="off" operator="equal"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="20 ms">
+      <test name="method-profiling" value="normal" operator="equal"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="10 ms">
+      <test name="method-profiling" value="high" operator="equal"/>
+    </condition>
+
+    <condition name="method-sampling-java-interval" true="1 ms">
+      <test name="method-profiling" value="max" operator="equal"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="999 d">
+      <test name="method-profiling" value="off" operator="equal"/>
+    </condition>
+
+    <condition name="method-sampling-native-interval" true="20 ms">
+      <or>
+        <test name="method-profiling" value="normal" operator="equal"/>
+        <test name="method-profiling" value="high" operator="equal"/>
+        <test name="method-profiling" value="max" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="method-sampling-enabled" true="false" false="true">
+      <test name="method-profiling" value="off" operator="equal"/>
+    </condition>
+
+    <selection default="once" name="thread-dump" label="Thread Dump">
+      <option name="off" label="Off">999 d</option>
+      <option name="once" label="At least Once">everyChunk</option>
+      <option name="60s" label="Every 60 s">60 s</option>
+      <option name="10s" label="Every 10 s">10 s</option>
+      <option name="1s" label="Every 1 s">1 s</option>
+    </selection>
+
+    <condition name="thread-dump-enabled" true="false" false="true">
+      <test name="thread-dump" value="999 d" operator="equal"/>
+    </condition>
+
+    <selection default="all" name="exceptions" label="Exceptions">
+      <option name="off" label="Off">off</option>
+      <option name="throttled" label="Errors and 100 Exceptions Per Second">throttled</option>
+      <option name="all" label="Errors and All Exceptions">all</option>
+    </selection>
+
+    <condition name="enable-errors" true="true" false="false">
+      <or>
+        <test name="exceptions" value="throttled" operator="equal"/>
+        <test name="exceptions" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="enable-exceptions" true="true" false="false">
+      <or>
+        <test name="exceptions" value="throttled" operator="equal"/>
+        <test name="exceptions" value="all" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="exceptions-throttle-rate" true="off" false="100/s">
+      <test name="exceptions" value="all" operator="equal"/>
+    </condition>
+
+    <selection default="types" name="memory-leaks" label="Memory Leak Detection">
+      <option name="off" label="Off">off</option>
+      <option name="types" label="Object Types">types</option>
+      <option name="stack-traces" label="Object Types + Allocation Stack Traces">stack-traces</option>
+      <option name="gc-roots" label="Object Types + Allocation Stack Traces + Path to GC Root">gc-roots</option>
+    </selection>
+
+    <condition name="old-objects-enabled" true="false" false="true">
+      <test name="memory-leaks" value="off" operator="equal"/>
+    </condition>
+
+    <condition name="old-objects-stack-trace" true="true" false="false">
+      <or>
+        <test name="memory-leaks" value="stack-traces" operator="equal"/>
+        <test name="memory-leaks" value="gc-roots" operator="equal"/>
+      </or>
+    </condition>
+
+    <condition name="old-objects-cutoff" true="1 h" false="0 ns">
+      <test name="memory-leaks" value="gc-roots" operator="equal"/>
+    </condition>
+
+    <text name="locking-threshold" label="Locking Threshold" contentType="timespan" minimum="0 s">1 ms</text>
+
+    <text name="method-timing" description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon." label="Method Timing Filter" contentType="method-filter"/>
+
+    <text name="method-trace" description="A filter can be an annotation (@jakarta.ws.rs.GET), a full qualified class name (com.example.Foo), a fully qualified method reference (java.lang.HashMap::resize) or a class initializer (::&lt;clinit&gt;). Use &lt;init&gt; for constructors. Separate multiple filters with semicolon." label="Method Trace Filter" contentType="method-filter"/>
+
+    <flag name="class-loading" label="Class Loading">false</flag>
+
+  </control>
+
+</configuration>


### PR DESCRIPTION
Add JFR events for internal Rhino processes and an option to emit JFR events from tests.

This adapts a pattern we have used internally to avoid unnecessary creation of J FR event objects, and instead uses the technique to make the event objects opaque. This technique will scale fine for small set of event types, but will need some rework to be really performant if the number grows.

I included the `TEST_EVENT` as a useful way to temporarily instrument areas of the code.

I have also added support for emitting standard junit events.